### PR TITLE
docs: flag fpkit-developer deprecation, add changelogs, fill install gaps

### DIFF
--- a/plugins/acss-app-builder/.claude-plugin/plugin.json
+++ b/plugins/acss-app-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-app-builder",
   "description": "Scaffold apps with the @fpkit/acss design system: layouts, pages, themes, forms, patterns. Works with the @fpkit/acss npm package OR generated acss-kit-builder source. Supersedes the deprecated fpkit-developer plugin.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-app-builder/CHANGELOG.md
+++ b/plugins/acss-app-builder/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the `acss-app-builder` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the plugin adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.2] - 2026-04-22
+
+### Added
+
+- `CHANGELOG.md` (this file).
+- `scripts/README.md` — index of the four Python helper scripts (Vite detection, component-source detection, CSS variable validation, theme contrast validation) with I/O contracts and exit codes.
+- `## Installation` section in README with marketplace + manual install instructions.
+
+### Fixed
+
+- Typo in README migration snippet — the `/plugin uninstall` example now uses the correct marketplace name `shawn-sandy-acss-plugins`.
+
+## [0.1.1]
+
+Extracted from `shawn-sandy/acss` into the `acss-plugins` marketplace. Supersedes the deprecated `fpkit-developer` plugin. See `git log -- plugins/acss-app-builder` for the full development history of the seven `/app-*` commands, reference docs, and assets.

--- a/plugins/acss-app-builder/README.md
+++ b/plugins/acss-app-builder/README.md
@@ -14,7 +14,7 @@ Prefers generated source when both are present.
 This plugin **replaces** the deprecated `fpkit-developer` plugin. If you installed the old one via marketplace, uninstall it first to avoid duplicate skills loading:
 
 ```
-/plugin uninstall fpkit-developer@shawn-sandy-acss
+/plugin uninstall fpkit-developer@shawn-sandy-acss-plugins
 ```
 
 All composition / extension / a11y workflows from `fpkit-developer` are preserved as sections of the `/app-compose` command in this plugin.
@@ -24,6 +24,25 @@ All composition / extension / a11y workflows from `fpkit-developer` are preserve
 - Vite + React + TypeScript project
 - `sass` or `sass-embedded` in `devDependencies`
 - Claude Code >= v1.0.33
+
+## Installation
+
+### Marketplace install (recommended)
+
+```shell
+/plugin marketplace add shawn-sandy/acss-plugins
+/plugin install acss-app-builder@shawn-sandy-acss-plugins
+```
+
+### Manual install via GitHub clone
+
+```bash
+git clone https://github.com/shawn-sandy/acss-plugins.git
+mkdir -p ~/.claude/plugins/
+cp -r acss-plugins/plugins/acss-app-builder ~/.claude/plugins/
+```
+
+For project-level install, substitute `~/.claude/plugins/` with `.claude/plugins/` inside your project.
 
 ## Commands
 

--- a/plugins/acss-app-builder/scripts/README.md
+++ b/plugins/acss-app-builder/scripts/README.md
@@ -1,0 +1,55 @@
+# acss-app-builder scripts
+
+Python helpers invoked by the plugin's slash commands. All scripts follow the repo-wide contract documented in [`../../../CLAUDE.md`](../../../CLAUDE.md):
+
+- Python 3 stdlib only — no external dependencies
+- Output JSON to stdout
+- Exit `0` on success, non-zero on failure
+- Include a `"reasons"` array for human-readable error messages
+
+Each script carries a full usage docstring at the top of the file. This README indexes them so you can pick the right one without opening all four.
+
+## Index
+
+| Script | Purpose | Primary input | Exit codes |
+|---|---|---|---|
+| [`detect_vite_project.py`](./detect_vite_project.py) | Detect a Vite + React + TypeScript project and locate its entry file | `[project_root]` (defaults to cwd) | `0` = detected, `1` = not detected |
+| [`detect_component_source.py`](./detect_component_source.py) | Decide whether to import fpkit components from generated source, the `@fpkit/acss` npm package, or neither | `[project_root]` (defaults to cwd) | `0` = resolved, `1` = unresolved |
+| [`validate_css_vars.py`](./validate_css_vars.py) | Validate CSS custom properties in SCSS files against fpkit naming conventions (`--{component}-{property}`, rem units, approved abbreviations) | `file_or_directory` | `0` = all valid, non-zero on violations |
+| [`validate_theme.py`](./validate_theme.py) | Validate a theme CSS file (`light.css`, `dark.css`, `brand-*.css`) for WCAG AA contrast on semantic role pairs | `<file-or-dir>` | `0` = no failures, `1` = contrast pair below threshold, `2` = usage / IO error |
+
+## Output shape
+
+All scripts print a single JSON object to stdout. Representative fields:
+
+```jsonc
+// detect_vite_project.py
+{
+  "isVite": true,
+  "isReact": true,
+  "isTypeScript": true,
+  "projectRoot": "/abs/path",
+  "entry": "src/main.tsx",
+  "viteConfig": "vite.config.ts",
+  "reasons": ["..."]
+}
+
+// detect_component_source.py
+{
+  "source": "generated" | "npm" | "none",
+  "projectRoot": "/abs/path",
+  "componentsDir": "src/components/fpkit",
+  "reasons": ["..."]
+}
+```
+
+For validator scripts (`validate_css_vars.py`, `validate_theme.py`), the JSON includes a per-file or per-pair breakdown with pass/fail entries plus a `reasons` array.
+
+## Running a script directly
+
+```bash
+python3 plugins/acss-app-builder/scripts/detect_vite_project.py /path/to/project
+python3 plugins/acss-app-builder/scripts/validate_theme.py src/styles/light.css
+```
+
+Inside Claude Code, these are invoked automatically by the plugin's skills — you generally don't need to run them by hand.

--- a/plugins/acss-kit-builder/.claude-plugin/plugin.json
+++ b/plugins/acss-kit-builder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit-builder",
   "description": "Generate fpkit-style React components without installing @fpkit/acss. Reference-guided generation with CSS custom properties. Requires only React + sass.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-kit-builder/CHANGELOG.md
+++ b/plugins/acss-kit-builder/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the `acss-kit-builder` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the plugin adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.2] - 2026-04-22
+
+### Added
+
+- `CHANGELOG.md` (this file).
+
+## [0.1.1]
+
+Extracted from `shawn-sandy/acss` into the `acss-plugins` marketplace. See `git log -- plugins/acss-kit-builder` for the full development history of `/kit-add`, `/kit-list`, and the reference catalog.

--- a/plugins/fpkit-developer/.claude-plugin/plugin.json
+++ b/plugins/fpkit-developer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fpkit-developer",
-  "description": "Guides development of applications built with @fpkit/acss React components. Provides component composition workflows, CSS variable validation, and WCAG accessibility guidance.",
-  "version": "0.1.7",
+  "description": "[DEPRECATED] Superseded by acss-app-builder (/app-compose command). Guides development of applications built with @fpkit/acss React components. Kept for one release cycle for migration.",
+  "version": "0.1.8",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/fpkit-developer/CHANGELOG.md
+++ b/plugins/fpkit-developer/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the `fpkit-developer` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the plugin adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.8] - 2026-04-22
+
+### Changed
+
+- `plugin.json` description now prefixed with `[DEPRECATED]` and points users to the successor command `/app-compose` in `acss-app-builder`. This surfaces the deprecation in `/plugin list` output.
+
+### Added
+
+- `CHANGELOG.md` (this file).
+
+### Deprecation status
+
+This plugin remains deprecated and will be removed after one more release cycle. Migrate to `acss-app-builder` — see the README for the migration path.
+
+## [0.1.7] and earlier
+
+Pre-deprecation development of the guided fpkit composition workflow. See `git log -- plugins/fpkit-developer` for detail.


### PR DESCRIPTION
## Summary

Targeted documentation pass across all three plugins in the marketplace.

- **Surfaces the fpkit-developer deprecation** where users actually see it. The plugin's README already had a deprecation banner, but `plugin.json` — the authoritative source Claude Code reads for `/plugin list` and `/plugin update` — still described the plugin as active. Now prefixed with `[DEPRECATED]` and points to the successor command `/app-compose` in `acss-app-builder`.
- **Fills an install-docs gap in acss-app-builder.** The flagship plugin's README had no Installation section (the other two plugins do). Added a marketplace + manual-clone install block mirroring the structure used in `acss-kit-builder/README.md`.
- **Fixes a silent copy-paste failure** in `acss-app-builder/README.md:17` where the uninstall snippet used `@shawn-sandy-acss` instead of `@shawn-sandy-acss-plugins` — a user following the migration steps would see a confusing no-op.
- **Adds a per-plugin `CHANGELOG.md`** (Keep a Changelog format) to each of the three plugins so release history has a stable home.
- **Adds `plugins/acss-app-builder/scripts/README.md`** — an index of the four Python helpers with I/O contracts and exit codes. Individual script docstrings were good but non-browsable.
- **Bumps plugin versions** per the repo's pre-submit checklist in `CLAUDE.md`:
  - `acss-app-builder`: `0.1.1` → `0.1.2`
  - `acss-kit-builder`: `0.1.1` → `0.1.2`
  - `fpkit-developer`: `0.1.7` → `0.1.8`

## Files

**Modified (4):**
- `plugins/fpkit-developer/.claude-plugin/plugin.json` — description + version
- `plugins/acss-app-builder/README.md` — Installation section + typo fix
- `plugins/acss-app-builder/.claude-plugin/plugin.json` — version
- `plugins/acss-kit-builder/.claude-plugin/plugin.json` — version

**Created (4):**
- `plugins/fpkit-developer/CHANGELOG.md`
- `plugins/acss-app-builder/CHANGELOG.md`
- `plugins/acss-kit-builder/CHANGELOG.md`
- `plugins/acss-app-builder/scripts/README.md`

## Reviewer notes

- No changes to any existing README body (other than acss-app-builder), SKILL.md, or reference docs. Scope was intentionally kept narrow.
- No change to `marketplace.json` — its `fpkit-developer` entry already carried a "Deprecated —" description prefix, so no drift introduced. Per `CLAUDE.md` the marketplace manifest also intentionally omits per-plugin `version` fields (plugin.json wins silently), and that pattern is preserved.
- `/app-compose` cross-reference resolves — `plugins/acss-app-builder/commands/app-compose.md` exists on disk.

## Test plan

- [ ] Local install: `/plugin marketplace add /path/to/worktree` then `/plugin list` — fpkit-developer description should show the `[DEPRECATED]` marker
- [ ] Copy-paste the new `acss-app-builder` install snippet from the updated README into Claude Code and confirm it resolves
- [ ] Markdown preview check on each new `CHANGELOG.md` and `scripts/README.md` (tables and links render)
- [ ] Confirm no dirty-git-tree issues — repo is clean post-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)