### PR TITLE
docs: address review findings from #1 (second typo, script I/O contracts)

### DIFF
--- a/plugins/acss-app-builder/CHANGELOG.md
+++ b/plugins/acss-app-builder/CHANGELOG.md
@@ -7,12 +7,12 @@ All notable changes to the `acss-app-builder` plugin are documented here. Format
 ### Added
 
 - `CHANGELOG.md` (this file).
-- `scripts/README.md` — index of the four Python helper scripts (Vite detection, component-source detection, CSS variable validation, theme contrast validation) with I/O contracts and exit codes.
+- `scripts/README.md` — index of the four Python helpers. Documents the split between detection scripts (JSON on stdout) and validator scripts (plain text + exit-code semantics), including correct field names on each output path.
 - `## Installation` section in README with marketplace + manual install instructions.
 
 ### Fixed
 
-- Typo in README migration snippet — the `/plugin uninstall` example now uses the correct marketplace name `shawn-sandy-acss-plugins`.
+- Typo in the `/plugin uninstall` migration snippet — now uses the correct marketplace name `shawn-sandy-acss-plugins`. Corrected in two places: `README.md` (line 17) and `commands/app-compose.md` (line 14). Copy-pasting either snippet will now actually uninstall the deprecated plugin instead of silently no-opping.
 
 ## [0.1.1]
 

--- a/plugins/acss-app-builder/commands/app-compose.md
+++ b/plugins/acss-app-builder/commands/app-compose.md
@@ -11,7 +11,7 @@ Follow the `/app-compose` section of `.claude/plugins/acss-app-builder/skills/ac
 **This command replaces** the deprecated `/fpkit-developer:fpkit-dev` from the `fpkit-developer` plugin. If that plugin is still installed, uninstall it to avoid duplicate skill activation:
 
 ```
-/plugin uninstall fpkit-developer@shawn-sandy-acss
+/plugin uninstall fpkit-developer@shawn-sandy-acss-plugins
 ```
 
 **Decision tree:**

--- a/plugins/acss-app-builder/scripts/README.md
+++ b/plugins/acss-app-builder/scripts/README.md
@@ -1,26 +1,26 @@
 # acss-app-builder scripts
 
-Python helpers invoked by the plugin's slash commands. All scripts follow the repo-wide contract documented in [`../../../CLAUDE.md`](../../../CLAUDE.md):
+Python helpers invoked by the plugin's slash commands. All scripts are Python 3 stdlib only — no external dependencies.
 
-- Python 3 stdlib only — no external dependencies
-- Output JSON to stdout
-- Exit `0` on success, non-zero on failure
-- Include a `"reasons"` array for human-readable error messages
+The four scripts split into two groups with different output contracts:
+
+- **Detection scripts** (`detect_vite_project.py`, `detect_component_source.py`) — print a single JSON object on stdout.
+- **Validator scripts** (`validate_css_vars.py`, `validate_theme.py`) — print human-readable plain text on stdout; signal result via exit code.
 
 Each script carries a full usage docstring at the top of the file. This README indexes them so you can pick the right one without opening all four.
 
 ## Index
 
-| Script | Purpose | Primary input | Exit codes |
-|---|---|---|---|
-| [`detect_vite_project.py`](./detect_vite_project.py) | Detect a Vite + React + TypeScript project and locate its entry file | `[project_root]` (defaults to cwd) | `0` = detected, `1` = not detected |
-| [`detect_component_source.py`](./detect_component_source.py) | Decide whether to import fpkit components from generated source, the `@fpkit/acss` npm package, or neither | `[project_root]` (defaults to cwd) | `0` = resolved, `1` = unresolved |
-| [`validate_css_vars.py`](./validate_css_vars.py) | Validate CSS custom properties in SCSS files against fpkit naming conventions (`--{component}-{property}`, rem units, approved abbreviations) | `file_or_directory` | `0` = all valid, non-zero on violations |
-| [`validate_theme.py`](./validate_theme.py) | Validate a theme CSS file (`light.css`, `dark.css`, `brand-*.css`) for WCAG AA contrast on semantic role pairs | `<file-or-dir>` | `0` = no failures, `1` = contrast pair below threshold, `2` = usage / IO error |
+| Script | Purpose | Primary input | Stdout | Exit codes |
+|---|---|---|---|---|
+| [`detect_vite_project.py`](./detect_vite_project.py) | Detect a Vite + React project and locate its entry file. TypeScript is reported as metadata but is not required for detection. | `[project_root]` (defaults to cwd) | JSON object | `0` = Vite + React detected, `1` = not detected |
+| [`detect_component_source.py`](./detect_component_source.py) | Decide whether to import fpkit components from generated source, the `@fpkit/acss` npm package, or neither | `[project_root]` (defaults to cwd) | JSON object | `0` = `generated` or `npm` resolved, `1` = no project root found or `source=none` |
+| [`validate_css_vars.py`](./validate_css_vars.py) | Validate CSS custom properties in SCSS files against fpkit naming conventions (`--{component}-{property}`, rem units, approved abbreviations) | `[file_or_directory]` (defaults to cwd) | Plain text summary + per-file error listing | `0` = all valid (or no SCSS files found), `1` = at least one violation |
+| [`validate_theme.py`](./validate_theme.py) | Validate a theme CSS file (`light.css`, `dark.css`, `brand-*.css`) for WCAG AA contrast on semantic role pairs | `<file-or-dir>` | Plain text summary + per-failure listing | `0` = no failures, `1` = contrast pair below threshold, `2` = usage / IO error |
 
-## Output shape
+## Detection script output
 
-All scripts print a single JSON object to stdout. Representative fields:
+Both detection scripts print a single JSON object to stdout.
 
 ```jsonc
 // detect_vite_project.py
@@ -31,19 +31,53 @@ All scripts print a single JSON object to stdout. Representative fields:
   "projectRoot": "/abs/path",
   "entry": "src/main.tsx",
   "viteConfig": "vite.config.ts",
-  "reasons": ["..."]
+  "reasons": ["..."]          // populated on failure paths; may be empty on success
 }
 
-// detect_component_source.py
+// detect_component_source.py — success path
 {
-  "source": "generated" | "npm" | "none",
+  "source": "generated",      // or "npm" or "none"
   "projectRoot": "/abs/path",
   "componentsDir": "src/components/fpkit",
-  "reasons": ["..."]
+  "importMapHint": "import Button from '../src/components/fpkit/button/button'"
+}
+
+// detect_component_source.py — no-project-found error path (exit 1)
+{
+  "source": "none",
+  "projectRoot": null,
+  "componentsDir": "src/components/fpkit",
+  "importMapHint": "",
+  "reasons": ["No project root containing react was found."]
 }
 ```
 
-For validator scripts (`validate_css_vars.py`, `validate_theme.py`), the JSON includes a per-file or per-pair breakdown with pass/fail entries plus a `reasons` array.
+Note: `detect_component_source.py` emits `importMapHint` on the success path and `reasons` only on the no-project-found error path. Consumers should branch on the `source` field.
+
+## Validator script output
+
+Validators print plain text designed for a human reader, not JSON. Downstream consumers should treat the **exit code** as the authoritative signal and the stdout as diagnostic detail.
+
+```
+# validate_css_vars.py (success)
+Validating 12 file(s)...
+
+✓ All CSS variables are valid!
+
+# validate_css_vars.py (failure)
+✗ Found 3 validation error(s):
+
+styles/button.scss:
+  Line 14: --btn-background-color
+    Use approved abbreviation 'bg' instead of 'background-color'
+
+# validate_theme.py (success)
+validate_theme: OK (2 palette file(s) checked)
+
+# validate_theme.py (failure)
+Contrast failures:
+  light.css: color-text on color-bg = 3.12:1 (required 4.5:1) [resolved fg=#888, bg=#fff]
+```
 
 ## Running a script directly
 


### PR DESCRIPTION
## Summary

Fast-follow PR addressing two remote-review findings from [#1](https://github.com/shawn-sandy/acss-plugins/pull/1) that landed after the squash-merge, so they never made it into main.

### 1. Second instance of the `@shawn-sandy-acss` typo

PR #1 fixed this marketplace-name typo in `plugins/acss-app-builder/README.md:17` but missed the identical snippet in `plugins/acss-app-builder/commands/app-compose.md:14` — which is actually the more critical location, since `/app-compose` is advertised as the migration path off the deprecated `fpkit-developer` plugin. A user copy-pasting the uninstall snippet from the command's own doc would hit a marketplace-not-found no-op, leaving the deprecated plugin installed and causing the duplicate-skills-loading problem the deprecation workflow is meant to prevent.

One-character fix: append `-plugins`.

### 2. `scripts/README.md` misdocumented the I/O contracts

Three issues in the scripts index, all reconciled by reading the actual script implementations:

- **Validator scripts emit plain text, not JSON.** The README claimed all four scripts output JSON on stdout. But `validate_css_vars.py` and `validate_theme.py` print human-readable text (`✓ All CSS variables are valid!`, `Contrast failures:`, per-file error listings) and never import `json`. Split the doc into a detection-scripts section (JSON on stdout) and a validator-scripts section (plain text + exit-code semantics).
- **`detect_component_source.py` success-path example was wrong.** Showed a `reasons` key that only exists on the no-project-found error path, and omitted `importMapHint` — the one field that is always emitted on success and carries the script's primary consumer-facing output (the `import Button from ...` suggestion). Replaced with the correct success-path object and added a separate error-path example so both paths are documented.
- **`detect_vite_project.py` description overstated the requirements.** The index row said "Vite + React + TypeScript" but the actual detection gate at `detect_vite_project.py:103` is `is_vite and is_react`; `isTypeScript` is reported as metadata only and doesn't affect the exit code. Clarified the row.

## Files changed

- `plugins/acss-app-builder/commands/app-compose.md` — marketplace-name typo fix
- `plugins/acss-app-builder/scripts/README.md` — rewritten to accurately document the two script-output contracts
- `plugins/acss-app-builder/CHANGELOG.md` — expanded the `0.1.2` entry to cover both fixes (0.1.2 was released to main via PR #1; this PR is a patch on that same version's documentation)

## Reviewer notes

- No plugin.json version bump. These are corrections to docs that shipped in 0.1.2 via PR #1. Bumping to 0.1.3 for a same-day doc correction felt like churn — happy to add the bump if the project prefers it.
- No changes to any script — the scripts were correct, the README was wrong. Fix is entirely in the docs.
- Memory note saved to avoid repeating: when fixing a typo in a copy-paste snippet, grep the whole repo for the old string, not just the file where it was first noticed.

## Test plan

- [ ] Copy-paste the `/plugin uninstall` snippet from both `README.md:17` and `commands/app-compose.md:14` — both should now reference `@shawn-sandy-acss-plugins`
- [ ] Run `validate_theme.py src/styles/` and confirm plain-text output matches the README's validator-scripts example
- [ ] Run `detect_component_source.py` against a project with generated components and confirm the output has an `importMapHint` key (not `reasons`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)