### PR TITLE
docs: add developer guides for acss-kit-builder and acss-component-specs

### DIFF
--- a/plugins/acss-component-specs/README.md
+++ b/plugins/acss-component-specs/README.md
@@ -81,6 +81,17 @@ Scripts in `scripts/` follow the repo contract: stdlib only, JSON to stdout, exi
 | `verify_contract_subset.py` | Confirm kit-builder Generation Contracts covered by spec shape |
 | `fetch_fpkit_source.py` | Fetch and cache fpkit source from GitHub |
 
+## Developer Guide
+
+Detailed guides are in [`docs/`](docs/):
+
+- [concepts.md](docs/concepts.md) — mental model: specs as source of truth, 7-kind `maps_to`, a11y block, 3-step render flow, atomic failure, version stamps
+- [commands.md](docs/commands.md) — full reference for all six `/spec-*` commands
+- [spec-authoring.md](docs/spec-authoring.md) — how to author a new component spec end-to-end
+- [recipes.md](docs/recipes.md) — step-by-step walkthroughs for common tasks
+- [troubleshooting.md](docs/troubleshooting.md) — concrete failure modes and fixes
+- [architecture.md](docs/architecture.md) — contributor guide: scripts reference, compound parts, render pipeline, cross-plugin wiring
+
 ## v0.1 Limitations
 
 - `format_version: 1` is experimental — breaking schema changes are possible until v1.0.0.

--- a/plugins/acss-component-specs/docs/README.md
+++ b/plugins/acss-component-specs/docs/README.md
@@ -1,0 +1,37 @@
+# acss-component-specs — Developer Guide
+
+This directory contains the developer guide for the `acss-component-specs` Claude Code plugin. For installation and a command overview, see the [plugin README](../README.md).
+
+## For consumers
+
+Developers using the plugin to author specs and render framework-specific component files.
+
+| Guide | What it covers |
+|-------|---------------|
+| [concepts.md](concepts.md) | The mental model: specs as source of truth, the 7-kind `maps_to` discriminator, the a11y block, the 3-step render flow, atomic failure, version stamps, and cross-plugin coordination |
+| [commands.md](commands.md) | Full reference for `/spec-add`, `/spec-render`, `/spec-diff`, `/spec-promote`, `/spec-validate`, `/spec-list` |
+| [spec-authoring.md](spec-authoring.md) | How to author a new component spec end-to-end |
+| [recipes.md](recipes.md) | Step-by-step walkthroughs for common tasks |
+| [troubleshooting.md](troubleshooting.md) | Concrete failure modes and how to resolve them |
+
+## For contributors
+
+Developers maintaining the plugin itself (SKILL.md, specs, references, Python scripts, cross-plugin scripts).
+
+| Guide | What it covers |
+|-------|---------------|
+| [architecture.md](architecture.md) | Plugin internals: scripts contract and reference, compound-part handling, render pipeline, cross-plugin wiring, v0.2 roadmap |
+
+## Reference material (canonical sources)
+
+| File | Purpose |
+|------|---------|
+| [`../skills/acss-component-specs/SKILL.md`](../skills/acss-component-specs/SKILL.md) | Full runbook for all six commands; coordination with kit-builder and app-builder |
+| [`../skills/acss-component-specs/references/spec-format.md`](../skills/acss-component-specs/references/spec-format.md) | Authoritative spec schema: required fields, 7-kind `maps_to` table, a11y block, stamps, `format_version` bump policy |
+| [`../skills/acss-component-specs/references/authoring-guide.md`](../skills/acss-component-specs/references/authoring-guide.md) | 10-step walkthrough for contributors adding a new spec |
+| [`../skills/acss-component-specs/references/compound-components.md`](../skills/acss-component-specs/references/compound-components.md) | Compound component sub-spec pattern, React/HTML/Astro per-target conventions |
+| [`../skills/acss-component-specs/references/state-and-events.md`](../skills/acss-component-specs/references/state-and-events.md) | Stateful component patterns: Dialog, Alert, interactive Card, aria-disabled, Nav active state |
+| [`../skills/acss-component-specs/references/frameworks/react.md`](../skills/acss-component-specs/references/frameworks/react.md) | React+SCSS renderer rulebook |
+| [`../skills/acss-component-specs/references/frameworks/html.md`](../skills/acss-component-specs/references/frameworks/html.md) | HTML+CSS renderer rulebook, native element catalog |
+| [`../skills/acss-component-specs/references/frameworks/astro.md`](../skills/acss-component-specs/references/frameworks/astro.md) | Astro+SCSS renderer rulebook |
+| [`../skills/acss-component-specs/specs/`](../skills/acss-component-specs/specs/) | Bundled reference specs (button, card, dialog, alert, stack, nav) |

--- a/plugins/acss-component-specs/docs/architecture.md
+++ b/plugins/acss-component-specs/docs/architecture.md
@@ -1,0 +1,133 @@
+# acss-component-specs — Architecture (Contributor Guide)
+
+This page is for maintainers editing the plugin: adding new renderers, modifying scripts, updating specs, or extending cross-plugin coordination.
+
+## Plugin layout
+
+```
+plugins/acss-component-specs/
+  .claude-plugin/
+    plugin.json                     # Authoritative version source
+  assets/
+    foundation/
+      ui.tsx                        # Polymorphic UI base for React renderer; copied into user projects
+      ui-html.css                   # CSS baseline for HTML renderer
+    fpkit-cache/
+      .gitkeep                      # Cache populated at runtime by fetch_fpkit_source.py; gitignored
+  commands/
+    spec-add.md                     # /spec-add command definition
+    spec-render.md                  # /spec-render command definition
+    spec-diff.md                    # /spec-diff command definition
+    spec-promote.md                 # /spec-promote command definition
+    spec-validate.md                # /spec-validate command definition
+    spec-list.md                    # /spec-list command definition
+  scripts/
+    fetch_fpkit_source.py
+    parse_spec.py
+    validate_spec.py
+    plan_render.py
+    check_kitbuilder_parity.py
+    verify_contract_subset.py
+  skills/
+    acss-component-specs/
+      SKILL.md                      # Full runbook for all six commands
+      specs/                        # Bundled reference specs
+        button.md
+        card.md + card-title.md + card-content.md + card-footer.md
+        dialog.md
+        alert.md
+        stack.md
+        nav.md + nav-link.md
+      references/
+        spec-format.md              # Authoritative schema
+        authoring-guide.md          # 10-step contributor walkthrough
+        compound-components.md      # Sub-spec pattern across all 3 renderers
+        state-and-events.md         # Stateful component patterns
+        frameworks/
+          react.md                  # React+SCSS renderer rulebook
+          html.md                   # HTML+CSS renderer rulebook, native element catalog
+          astro.md                  # Astro+SCSS renderer rulebook
+```
+
+## Command → SKILL delegation
+
+Each command file in `commands/` is thin: it declares the signature, tools, and a one-line body that ends with "Follow SKILL.md § /<command>". The logic lives entirely in the corresponding section of `SKILL.md`. Do not duplicate the workflow inside the command file.
+
+## scripts/ contract
+
+All Python scripts must satisfy four rules (from the repo-level `CLAUDE.md`):
+
+1. **Python 3 stdlib only** — no third-party packages (`pip install` is not available in plugin context).
+2. **Output JSON to stdout** — one JSON object, complete and valid.
+3. **Exit 0 on success, 1 on failure**.
+4. **Include a `"reasons"` array** in JSON output for human-readable error messages.
+
+### Script reference
+
+| Script | Input | JSON output shape | Notes |
+|--------|-------|-------------------|-------|
+| `parse_spec.py` | `<spec-file>` | `{ ok, data: { frontmatter, sections, theme_dependencies }, reasons }` | Hand-rolled minimal YAML parser; rejects anchors/aliases; auto-derives `theme_dependencies` from `var(--color-*, …)` patterns |
+| `validate_spec.py` | `[spec-file ...] [--stale]` | `{ ok, data: { validated, errors: { path: [msg] }, stale: [...] }, reasons }` | Imports `parse_spec` via `sys.path.insert`; `--stale` scans project files for `// generated from <spec>.md@<ver>` stamps |
+| `plan_render.py` | `<spec-file> [--target=react\|html\|astro\|all]` | `{ ok, data: { component, targets, dependency_order, manifest, staging_base, is_compound_part }, reasons }` | Hard-codes `DEPENDENCY_GRAPH` and `COMPOUND_PARTS` set; compound parts return empty manifests |
+| `check_kitbuilder_parity.py` | `<component> [<component2> …]` | `{ ok, data: { results: { <comp>: { ok, reasons } } }, reasons }` | Compares `.acss-staging/react/<c>/<c>.scss` against kit-builder `## SCSS Pattern` block; "no kit-builder counterpart" is a pass |
+| `verify_contract_subset.py` | (none) | `{ ok, data: { ref_files_checked, contract_fields_seen, missing }, reasons }` | Walks kit-builder `references/components/*.md`; confirms every Generation Contract field maps to a spec frontmatter field |
+| `fetch_fpkit_source.py` | `<component> [--refresh]` | `{ ok, data: { component, sha, cache_path, source_url, fetched, [bytes] }, reasons }` | Only script with filesystem side effects (writes cache); uses `urllib.request` (stdlib); 7-day TTL; SHA-resolve failure falls back to `'main'` as version label |
+
+## How compound parts are handled
+
+`plan_render.py` maintains a `COMPOUND_PARTS` set (e.g., `{'card-title', 'card-content', 'card-footer', 'nav-link'}`). When a component name is in this set, `plan_render.py` returns an empty `manifest` — the sub-part's output is emitted *inside* the parent component file, not in a dedicated file.
+
+The `is_compound_part` flag in the output tells the SKILL that the parent spec should be the render target. For Astro, compound parts are emitted as separate files (because Astro does not use `Object.assign` on components) — `plan_render.py` handles this per-target.
+
+When adding a new compound parent, update `DEPENDENCY_GRAPH` and add the sub-part names to `COMPOUND_PARTS`.
+
+## How the render pipeline slots together
+
+```
+/spec-render button --target=react
+  → plan_render.py          (dependency order + file manifest)
+  → SKILL.md §R3            (lazy-load references/frameworks/react.md + spec file)
+  → SKILL.md §R4            (emit files to .acss-staging/react/, stamp each file)
+  → SKILL.md §R5            (theme check: scan project for :root { --color-* })
+  → SKILL.md §R6            (gitignore check: prompt to add .acss-staging/)
+```
+
+Each `references/frameworks/*.md` is loaded **lazily** — only the relevant renderer doc is read during a given render invocation. This keeps the LLM's context lean when rendering a single framework.
+
+## Cross-plugin coordination
+
+### With acss-kit-builder
+
+- **Spec wins:** When kit-builder is installed, Step B0 of kit-builder's SKILL probes for the spec before using its bundled reference doc. No configuration required; the probe is passive.
+- **`check_kitbuilder_parity.py`:** Pre-commit hook (fires when `specs/*.md` changes). Compares staged SCSS against kit-builder's bundled SCSS pattern. Keeps the two sources in sync during the transition window before kit-builder's bundled references are deprecated.
+- **`verify_contract_subset.py`:** Used by `/release-check`. Confirms that every field in kit-builder's Generation Contract blocks has a corresponding spec frontmatter field. Ensures the interop shape stays intact.
+
+### With acss-app-builder
+
+- **`.acss-target.json.framework`:** Component-specs extends the shared config with an optional `framework` field. App-builder reads `componentsDir`; component-specs reads both `componentsDir` and `framework`. Both plugins commit to the same file — do not remove fields the other plugin writes.
+
+### With acss-theme-builder
+
+- **CSS cascade, no imports:** Every SCSS file uses `var(--component-prop, var(--color-token, #hardcoded))`. Theme values propagate via the natural CSS cascade when theme-builder output is present. The SKILL warns (step R5) if no `:root { --color-* }` block is found, but the component is functional either way.
+
+## Adding a new renderer (framework)
+
+1. Add a new `references/frameworks/<name>.md` following the structure of `react.md`, `html.md`, or `astro.md`. Include: file-output naming rules, per-`maps_to` kind mappings, asset copy prompts (e.g., `ui.tsx` equivalent), and state/event handling patterns.
+2. Update `plan_render.py` to accept the new `--target=<name>` value and add the file manifest logic for the new framework.
+3. Update the `SKILL.md` sections for `/spec-render` and `/spec-promote` to reference the new target.
+4. Update all six command files if their argument-hint or description changes.
+5. Bump `plugin.json` version.
+
+## v0.2 roadmap (from CHANGELOG)
+
+Known deferrals so contributors know what's in-flight and should not re-implement:
+
+- Web component HTML renderer (`<fpk-button>` with shadow DOM) — deferred from v0.1.
+- Astro inline `<style>` blocks option — deferred from v0.1.
+- `/spec-migrate` tooling for `format_version` upgrades — deferred from v0.1.
+- Second-wave components: Form, Badge, Tag, Heading, Text, Link, Icon — deferred from v0.1.
+- Bidirectional drift detection in `/spec-diff` (currently staging → project only) — deferred to v0.3.
+
+## format_version policy
+
+`format_version: 1` is the current schema version. It is bumped **only** when the schema breaks backward compatibility (removing a required field, changing a field's type, renaming a `maps_to` kind). Do not bump it for additive changes (new optional fields). The bump requires a migration path for existing specs — document it in the CHANGELOG and consider shipping `/spec-migrate` tooling before bumping.

--- a/plugins/acss-component-specs/docs/commands.md
+++ b/plugins/acss-component-specs/docs/commands.md
@@ -1,0 +1,207 @@
+# acss-component-specs — Command Reference
+
+All six commands delegate to the corresponding section in [`SKILL.md`](../skills/acss-component-specs/SKILL.md). This file is the human-readable reference; the SKILL.md is the authoritative Claude workflow.
+
+---
+
+## /spec-add
+
+Scaffold a new component spec by fetching the fpkit component source from GitHub.
+
+**Signature**
+
+```
+/spec-add <component> [--refresh]
+```
+
+**Tools used:** `WebFetch, Write, Read, Bash`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<component>` | Yes | Component name (e.g., `button`, `stack`). Used to look up the fpkit source path and name the output spec file. |
+| `--refresh` | No | Force a re-fetch from GitHub, bypassing the 7-day cache in `assets/fpkit-cache/`. Use when the upstream fpkit source has changed. |
+
+### What happens
+
+1. Runs `scripts/fetch_fpkit_source.py <component> [--refresh]`. Hits the GitHub API to resolve the current `main` SHA, then fetches the component source from `https://raw.githubusercontent.com/shawn-sandy/acss/main/packages/fpkit/src/components/...`. Caches the result under `assets/fpkit-cache/<sha>/`.
+2. Reads the cached source. Extracts props, events, CSS variables, and state patterns.
+3. Reads [`references/spec-format.md`](../skills/acss-component-specs/references/spec-format.md) to confirm the frontmatter schema.
+4. Writes `specs/<component>.md` with `format_version: 1`, the resolved SHA in `fpkit_version`, and the extracted data structured into the spec frontmatter + Markdown body.
+5. Runs `scripts/validate_spec.py specs/<component>.md` to confirm the new spec passes schema validation.
+
+### Example
+
+```
+/spec-add stack                # Fetch stack.tsx, scaffold specs/stack.md, validate
+/spec-add button --refresh     # Re-fetch button source, update specs/button.md
+```
+
+---
+
+## /spec-render
+
+Render a component spec into framework-specific files in the staging directory.
+
+**Signature**
+
+```
+/spec-render <component> [--target=react|html|astro|all]
+```
+
+**Tools used:** `Read, Write, Edit, Bash, Glob`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<component>` | Yes | Spec name to render. A `specs/<component>.md` file must exist. |
+| `--target` | No | Framework to render for. Defaults to the `framework` field in `.acss-target.json`; if absent, renders all three. |
+
+### What happens (steps R1–R6)
+
+1. **R1 — Target resolution:** `--target` wins over `.acss-target.json.framework`, which wins over the default (all).
+2. **R2 — Plan:** Runs `scripts/plan_render.py specs/<component>.md --target=<target>`. Returns the dependency order and the file manifest (which `.tsx`/`.scss` or `.html`/`.css` or `.astro`/`.scss` files to write).
+3. **R3 — Reference load:** Reads the appropriate `references/frameworks/<target>.md` lazily. Reads the spec file.
+4. **R4 — Emit:** Writes each file to `.acss-staging/<framework>/`. Every generated file is stamped `// generated from <component>.md@<version>` on the first line. Atomic: if any file fails, all staged output is rolled back.
+5. **R5 — Theme check:** Scans project SCSS/CSS for `:root { --color-primary: …`. If missing and the spec declares `theme_dependencies`, prepends a warning comment to the SCSS and logs a console warning.
+6. **R6 — Gitignore prompt:** On first render, checks the project `.gitignore` for `.acss-staging/`. If absent, prompts to add it.
+
+### Example
+
+```
+/spec-render button                    # Render to all targets (or the .acss-target.json default)
+/spec-render dialog --target=react     # React+SCSS only
+/spec-render card --target=astro       # Astro+SCSS only
+```
+
+---
+
+## /spec-diff
+
+Preview the diff between staged render output and existing project files. Never writes.
+
+**Signature**
+
+```
+/spec-diff <component> [--target=react|html|astro]
+```
+
+**Tools used:** `Bash, Read`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<component>` | Yes | Component name. Staged files must exist in `.acss-staging/<framework>/`. |
+| `--target` | No | Which staged target to diff. Defaults to the same resolution as `/spec-render`. |
+
+### What happens
+
+Locates files under `.acss-staging/<framework>/<component>/`, compares each against the corresponding file under `componentsDir`, and prints a unified diff block per file pair. If a project file does not yet exist, the diff shows the full new file as a diff against nothing.
+
+Run this before every `/spec-promote`. It is your last chance to review before staged files overwrite project files.
+
+### Example
+
+```
+/spec-diff button
+/spec-diff dialog --target=react
+```
+
+---
+
+## /spec-promote
+
+Move staged render output into project component directories.
+
+**Signature**
+
+```
+/spec-promote <component> [--target=react|html|astro|all]
+```
+
+**Tools used:** `Bash, Read, Write, Edit`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<component>` | Yes | Component name. Staged files must exist. |
+| `--target` | No | Which staged target to promote. |
+
+### What happens
+
+Reads `componentsDir` from `.acss-target.json`. **Moves** (not copies) each staging file to its final destination under `componentsDir`, overwriting the existing file and reporting the outcome. The staging directory for that component is left empty after a successful promotion.
+
+Always run `/spec-diff` first.
+
+### Example
+
+```
+/spec-promote button
+/spec-promote card --target=react
+```
+
+---
+
+## /spec-validate
+
+Validate component specs against the schema. Optionally flag stale project stamps.
+
+**Signature**
+
+```
+/spec-validate [<component>] [--stale]
+```
+
+**Tools used:** `Bash, Read`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[<component>]` | No | Spec to validate. Without an argument, validates all `specs/*.md`. |
+| `--stale` | No | After schema validation, scan project files for `// generated from <spec>.md@<ver>` stamps and flag any whose version is behind the current spec. |
+
+### What happens
+
+Runs `scripts/validate_spec.py` with the appropriate arguments. Exit 0 = clean. Exit 1 = errors or stale files found.
+
+Checks include: required frontmatter fields, `format_version == 1`, `a11y.wcag` non-empty (unless `a11y.layout_only: true`), WCAG 2.2 SC identifiers, props have `name` + `maps_to`, `maps_to` is one of the 7 valid kinds, `fpkit_source` starts with `https://`.
+
+### Example
+
+```
+/spec-validate                 # Validate all specs
+/spec-validate button          # Validate only button.md
+/spec-validate --stale         # Validate all + find outdated generated files
+```
+
+---
+
+## /spec-list
+
+List all available component specs and their status, or dump full details for one spec.
+
+**Signature**
+
+```
+/spec-list [<component>]
+```
+
+**Tools used:** `Read, Bash, Glob`
+
+### What happens
+
+**Without an argument:** Globs `specs/*.md`, runs `scripts/parse_spec.py` on each, and prints a table of `name`, `format_version`, and `fpkit_version`. If no specs exist, prompts to run `/spec-add`.
+
+**With a component name:** Reads `specs/<component>.md` and prints a full summary: frontmatter fields, props table, events, CSS vars, a11y block, framework notes.
+
+### Example
+
+```
+/spec-list                     # Table of all available specs
+/spec-list button              # Full details for button.md
+```

--- a/plugins/acss-component-specs/docs/concepts.md
+++ b/plugins/acss-component-specs/docs/concepts.md
@@ -1,0 +1,97 @@
+# acss-component-specs — Core Concepts
+
+This page covers the mental model you need before working with `acss-component-specs`. Understanding these ideas helps you reason about what specs are, how rendering works, and where things can go wrong.
+
+## The problem this plugin solves
+
+`acss-kit-builder` generates React-only output using bundled reference docs. Teams working with HTML-first or Astro-based projects had no authoritative source of truth. This plugin adds a layer above kit-builder: a single YAML+Markdown spec per component that produces valid React+SCSS, HTML+CSS, *or* Astro+SCSS output — authored once.
+
+Do not use this plugin for pure React-only projects that are already satisfied with kit-builder's output. The extra abstraction is warranted only when you need multi-framework output or want a formal schema that survives framework migrations.
+
+## Specs as source of truth
+
+A spec is a single `.md` file with two parts:
+
+- **YAML frontmatter** — the machine-readable contract. Declares props, events, accessibility requirements, CSS variables, and framework-specific notes. The Python scripts and the LLM renderer both consume this.
+- **Markdown body** — the LLM's knowledge base. Contains the complete SCSS pattern, usage examples, and any prose notes that don't fit a structured field.
+
+Generated files are stamped `// generated from button.md@0.1.0`. The spec version is the authority; generated files are derivatives.
+
+## The 7-kind maps_to discriminator
+
+Every prop in the spec frontmatter declares how it maps to the rendered output via a `maps_to` field. There are exactly 7 kinds:
+
+| Kind | What it produces in the output |
+|------|-------------------------------|
+| `prop` | A React prop or HTML attribute passed through directly |
+| `aria` | An ARIA attribute (`aria-label`, `aria-disabled`, etc.) |
+| `data-attr` | A `data-*` attribute on the root element |
+| `data-attr-token` | A space-separated token inside a `data-*` attribute (for `[attr~="value"]` selectors) |
+| `element` | Determines which HTML element to render |
+| `class` | Adds a class to the element |
+| `css-var` | A CSS custom property that controls a visual aspect |
+
+This table is the discriminator for all three renderers. The React renderer maps `aria` → `aria-*` React prop; the HTML renderer maps `aria` → the same attribute on the element; the Astro renderer maps it to a prop.
+
+See [`references/spec-format.md`](../skills/acss-component-specs/references/spec-format.md) for the full schema including the `framework_notes` shape, `fpkit_source` / `fpkit_version` pinning, and the `format_version` strict-bump policy.
+
+## The a11y block
+
+Every spec must include an `a11y` block declaring the WCAG 2.2 success criteria the component addresses. The `validate_spec.py` script checks that all listed SCs are valid WCAG 2.2 identifiers and that the list is non-empty — unless `a11y.layout_only: true` is set, which exempts layout primitives like Stack.
+
+The a11y block also carries per-target notes (e.g., which ARIA roles to use in HTML vs React) and the `wcag` list of applicable SCs.
+
+## The 3-step render flow
+
+Rendering is always a staged, explicit three-step process:
+
+```
+/spec-render <component> [--target=react|html|astro|all]
+/spec-diff <component>
+/spec-promote <component>
+```
+
+`/spec-render` writes to `.acss-staging/<framework>/`. It never touches your project files. `/spec-diff` shows a unified diff between staging and your project. `/spec-promote` moves staged files to their final destination under `componentsDir`.
+
+**Promotion is never automatic.** The `/spec-diff` step is intentional: you review before committing changes to your project. Always run `/spec-diff` before `/spec-promote`.
+
+## Atomic failure
+
+If a render fails partway through (e.g., a dependency spec is missing or a script exits 1), all staged output for that invocation is rolled back. Staging is all-or-nothing — a partial staging directory is never left behind.
+
+## Version stamps
+
+Every generated file carries a version stamp on the first line:
+
+```tsx
+// generated from button.md@0.1.0
+```
+
+Run `/spec-validate --stale` to find project files whose stamps are behind the current spec version. This is the mechanism for tracking which project files need to be re-rendered after a spec update.
+
+## Spec wins over kit-builder
+
+When both `acss-component-specs` and `acss-kit-builder` are installed, kit-builder probes for a spec file before falling back to its bundled reference doc. If a spec exists, it takes precedence. No configuration is required — this is a passive upgrade. Kit-builder's bundled reference docs carry a "Legacy reference" banner to signal this relationship.
+
+## Passive theme integration
+
+Generated SCSS uses CSS custom properties with multi-level fallbacks:
+
+```scss
+background: var(--btn-primary-bg, var(--color-primary, #0066cc));
+```
+
+When `acss-theme-builder` output is present in your project (a `:root { --color-primary: … }` block), theme values propagate via the CSS cascade — no `@import` is needed. When no theme is found, hardcoded fallbacks apply and `/spec-render` warns you. The warning is informational; components are functional either way.
+
+## .acss-target.json — project config
+
+This file (written to the project root on first `/kit-add` or `/spec-render`) is the shared configuration between `acss-component-specs`, `acss-kit-builder`, and `acss-app-builder`:
+
+```json
+{
+  "componentsDir": "src/components/fpkit",
+  "framework": "react"
+}
+```
+
+The optional `framework` field sets the default render target for `/spec-render` — without it, all three targets are rendered. Override per-invocation with `--target`. Commit this file to git.

--- a/plugins/acss-component-specs/docs/recipes.md
+++ b/plugins/acss-component-specs/docs/recipes.md
@@ -1,0 +1,153 @@
+# acss-component-specs — Recipes
+
+Common tasks, step by step. Each recipe assumes the plugin is installed and you are inside a Claude Code session in your project directory.
+
+---
+
+## Render a component to a single framework
+
+```
+/spec-render button --target=react
+/spec-diff button
+/spec-promote button
+```
+
+1. `/spec-render` writes `button/button.tsx` and `button/button.scss` to `.acss-staging/react/`.
+2. `/spec-diff` shows a unified diff between staging and your current project files (or shows the new files in full if they don't exist yet).
+3. `/spec-promote` moves the staged files to `<componentsDir>/button/`.
+
+---
+
+## Render to all three frameworks
+
+```
+/spec-render button --target=all
+```
+
+Or, if `.acss-target.json` has no `framework` field, render all is the default:
+
+```
+/spec-render button
+```
+
+This writes output to three staging subdirectories:
+
+```
+.acss-staging/
+  react/button/button.tsx + button.scss
+  html/button/button.html + button.css
+  astro/button/Button.astro + button.scss
+```
+
+Promote each independently:
+
+```
+/spec-promote button --target=react
+/spec-promote button --target=html
+/spec-promote button --target=astro
+```
+
+---
+
+## Configure a per-project default framework
+
+Edit `.acss-target.json`:
+
+```json
+{
+  "componentsDir": "src/components",
+  "framework": "astro"
+}
+```
+
+Now `/spec-render <component>` defaults to Astro. Override any time with `--target`.
+
+---
+
+## Handle a compound component (Card)
+
+Card has sub-parts (Title, Content, Footer) defined as separate sub-specs. When you render Card, all sub-parts are included automatically:
+
+```
+/spec-render card --target=react
+```
+
+`plan_render.py` knows about the compound parts and emits them inside the parent component file (using `Object.assign(Card, { Title, Content, Footer })`). No separate files are created for the sub-parts — they live in `card/card.tsx`.
+
+For Astro, sub-parts are emitted as separate files (`card/CardTitle.astro`, etc.) because Astro does not use static properties on components.
+
+See [`references/compound-components.md`](../skills/acss-component-specs/references/compound-components.md) for the full compound pattern.
+
+---
+
+## Handle a stateful component (Dialog)
+
+Dialog requires Button as a dependency. `plan_render.py` resolves this:
+
+```
+/spec-render dialog --target=react
+```
+
+Preview output:
+
+```
+New:
+  ui.tsx          (if not present)
+  button/button.tsx
+  button/button.scss
+  dialog/dialog.tsx
+  dialog/dialog.scss
+```
+
+The Dialog spec uses a native `<dialog>` element for built-in focus management. The React renderer emits `useRef<HTMLDialogElement>` + `dialogRef.current?.showModal()`. No focus-trap library is needed.
+
+See [`references/state-and-events.md`](../skills/acss-component-specs/references/state-and-events.md) for how Dialog, Alert, and interactive Card are handled per framework.
+
+---
+
+## Update a spec and find stale project files
+
+After editing a spec (or after running `/spec-add <component> --refresh` to pull upstream changes), bump the spec's patch version in its frontmatter:
+
+```yaml
+# specs/button.md
+format_version: 1
+name: button
+fpkit_version: "newsha1"   # updated by /spec-add --refresh
+```
+
+Then find project files that are behind:
+
+```
+/spec-validate --stale
+```
+
+`validate_spec.py` scans project files for `// generated from button.md@<old-version>` stamps and reports which files need re-rendering.
+
+For each stale file:
+
+```
+/spec-render button --target=react
+/spec-diff button
+/spec-promote button
+```
+
+---
+
+## Validate all specs at once
+
+```
+/spec-validate
+```
+
+Validates every `specs/*.md` against the schema. Useful before committing a batch of new or edited specs, or as part of a pre-PR check.
+
+---
+
+## Check what components are available
+
+```
+/spec-list
+```
+
+Prints a table of all specs with `name`, `format_version`, and `fpkit_version`. Use `/spec-list <component>` to dump full details for one spec (props, events, CSS vars, a11y block).

--- a/plugins/acss-component-specs/docs/spec-authoring.md
+++ b/plugins/acss-component-specs/docs/spec-authoring.md
@@ -1,0 +1,172 @@
+# acss-component-specs — Authoring a Spec
+
+This page walks through the full flow of creating a new component spec. For the authoritative schema reference, see [`references/spec-format.md`](../skills/acss-component-specs/references/spec-format.md). For the 10-step contributor walkthrough, see [`references/authoring-guide.md`](../skills/acss-component-specs/references/authoring-guide.md).
+
+## Overview
+
+Authoring a spec is a three-step process:
+
+```
+/spec-add <component>     # fetch source, scaffold spec
+/spec-validate <component> # confirm schema is valid
+/spec-render <component>  # render to staging to verify output
+```
+
+## Step 1: Scaffold with /spec-add
+
+```
+/spec-add stack
+```
+
+`/spec-add` runs `scripts/fetch_fpkit_source.py stack` to:
+
+1. Resolve the current `main` SHA via the GitHub API.
+2. Fetch the component source from `https://raw.githubusercontent.com/shawn-sandy/acss/main/packages/fpkit/src/components/stack/stack.tsx` (falling back to `<comp>s/<comp>.tsx` or `<comp>/<comp>.tsx` if the primary path fails).
+3. Cache the source under `assets/fpkit-cache/<sha>/stack.tsx` (valid 7 days; `--refresh` forces re-fetch).
+
+Claude reads the cached source, extracts the component structure, and writes `specs/stack.md` with the full frontmatter populated.
+
+## Step 2: Understand the frontmatter schema
+
+A spec file (`specs/<component>.md`) opens with YAML frontmatter followed by a Markdown body.
+
+**Required frontmatter fields:**
+
+```yaml
+format_version: 1
+name: stack
+display_name: Stack
+description: "A layout primitive that stacks children with consistent spacing."
+fpkit_source: "https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/components/stack/stack.tsx"
+fpkit_version: "abc1234"   # resolved short SHA from fetch_fpkit_source.py
+a11y:
+  layout_only: true        # omit wcag list for layout-only primitives
+  wcag: []
+```
+
+**Props array:**
+
+```yaml
+props:
+  - name: gap
+    type: string
+    default: "1rem"
+    description: "Spacing between children"
+    maps_to: css-var
+    css_var: "--stack-gap"
+  - name: as
+    type: string
+    default: "div"
+    description: "HTML element to render"
+    maps_to: element
+```
+
+## The 7-kind maps_to reference
+
+Every prop must declare `maps_to`. Use this table to choose the right kind:
+
+| Kind | When to use | Example |
+|------|-------------|---------|
+| `prop` | A React prop or HTML attribute passed straight through | `className`, `id`, `onClick` |
+| `aria` | An ARIA attribute on the root element | `aria-label`, `aria-expanded` |
+| `data-attr` | A `data-*` attribute used for styling variants | `data-color="primary"` |
+| `data-attr-token` | A space-separated token inside a `data-*` attribute | `data-btn="lg"` (combines with `data-btn="block"`) |
+| `element` | Determines which HTML element to render (the `as` prop) | `<UI as="nav">` |
+| `class` | Adds a CSS class to the root element | `class="btn"` |
+| `css-var` | A CSS custom property controlling a visual aspect | `--stack-gap` |
+
+When a prop maps to `css-var`, include a `css_var` field naming the variable. When it maps to `data-attr` or `data-attr-token`, include a `data_attr` field naming the attribute.
+
+## Step 3: Fill in the Markdown body
+
+The Markdown body is the LLM renderer's knowledge base. It is not parsed structurally — write it for a developer reader. The body should include at minimum:
+
+- The full SCSS pattern (the complete block that will be emitted, including all variants)
+- A usage example for React (and HTML/Astro if they differ meaningfully)
+- Any generation notes (e.g., "This component has no SCSS; it is a layout wrapper")
+
+```markdown
+## SCSS Pattern
+
+```scss
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, 1rem);
+}
+```
+
+## Usage
+
+```tsx
+<Stack gap="2rem">
+  <Card>...</Card>
+  <Card>...</Card>
+</Stack>
+```
+```
+
+## Compound components
+
+For components with sub-parts (Card + Card.Title + Card.Content + Card.Footer), author a parent spec and separate sub-specs:
+
+```
+specs/card.md          # parent spec; props for the Card wrapper
+specs/card-title.md    # sub-spec with parent: card + maps_to_parent: compound-part
+specs/card-content.md
+specs/card-footer.md
+```
+
+The sub-specs use two additional frontmatter fields:
+
+```yaml
+parent: card
+maps_to_parent: compound-part
+```
+
+`plan_render.py` knows about the `COMPOUND_PARTS` set and treats compound parts as output that lives *inside* the parent component file rather than in their own files. See [`references/compound-components.md`](../skills/acss-component-specs/references/compound-components.md) for the full pattern including React `Object.assign`, HTML semantic nesting, and Astro slot conventions.
+
+## Stateful components
+
+For components with interactive state (Dialog, Alert, interactive Card), the body should document the state management approach for each renderer. Key patterns are in [`references/state-and-events.md`](../skills/acss-component-specs/references/state-and-events.md).
+
+The `a11y` block should list all applicable WCAG 2.2 SCs. For Dialog:
+
+```yaml
+a11y:
+  wcag: ["2.1.1", "4.1.2", "2.4.3", "2.4.7", "1.3.1"]
+  notes: "Use native <dialog> + showModal() for built-in focus trap and Escape key handling."
+```
+
+## Step 4: Validate
+
+```
+/spec-validate stack
+```
+
+`validate_spec.py` checks:
+
+- Required fields are present.
+- `format_version == 1`.
+- `a11y.wcag` is non-empty (unless `a11y.layout_only: true`).
+- All WCAG SCs are valid WCAG 2.2 identifiers.
+- Every prop has `name` + `maps_to`.
+- `maps_to` is one of the 7 valid kinds.
+- `fpkit_source` starts with `https://`.
+
+Exit 0 = clean. Fix any reported errors before proceeding.
+
+## Step 5: Render to confirm output
+
+```
+/spec-render stack --target=react
+/spec-diff stack
+```
+
+Review the diff. If the emitted output looks correct, you can promote or discard staging — the goal here is to confirm the spec produces sensible code before committing it.
+
+## Versioning your spec
+
+The `fpkit_version` field is a short SHA resolved by `fetch_fpkit_source.py`. It pins the spec to the exact fpkit commit it was authored from. When upstream fpkit changes, run `/spec-add <component> --refresh` to update the spec and re-pin to the new SHA.
+
+`format_version` tracks the spec schema version, not the component version. It starts at `1` and bumps only when the schema itself breaks backward compatibility (a rare event managed by the plugin maintainer, not individual spec authors).

--- a/plugins/acss-component-specs/docs/troubleshooting.md
+++ b/plugins/acss-component-specs/docs/troubleshooting.md
@@ -1,0 +1,115 @@
+# acss-component-specs — Troubleshooting
+
+---
+
+## Stale stamps: "/spec-validate --stale" reports outdated files
+
+**Symptom:** Running `/spec-validate --stale` lists project files with stamps older than the current spec version (e.g., `// generated from button.md@0.0.9` but current spec is `0.1.0`).
+
+**Fix:**
+
+```
+/spec-render button --target=react
+/spec-diff button
+/spec-promote button
+```
+
+Re-render the component from the updated spec, review the diff, and promote. Repeat for each stale file or framework target.
+
+If you updated the spec without bumping its version field, the stamp check won't flag it. Always bump the spec's patch version in frontmatter when you make meaningful changes to the spec body.
+
+---
+
+## Kit-builder parity drift: pre-commit hook fails
+
+**Symptom:** You edited `specs/button.md` and ran `git commit`. The pre-commit hook ran `check_kitbuilder_parity.py` and exited 1 with a message like "SCSS parity drift for 'button': staged SCSS differs from kit-builder reference."
+
+**Cause:** The SCSS block in your spec (written to `.acss-staging/react/button/button.scss`) no longer matches the `## SCSS Pattern` block in `acss-kit-builder/skills/acss-kit-builder/references/components/button.md`.
+
+**Fix:** You need to reconcile the two. Either:
+
+1. Update the SCSS pattern in `specs/button.md`'s Markdown body to match the kit-builder reference, or
+2. Update the kit-builder reference doc's `## SCSS Pattern` block to match the spec (and bump kit-builder's version).
+
+Option 2 is the right call when the spec is intentionally ahead of the bundled reference — the spec is the source of truth. Option 1 is right when you made an unintentional change to the spec body.
+
+After reconciling, re-run `/spec-render button --target=react` to update the staged SCSS, then retry the commit.
+
+---
+
+## fpkit cache miss / network failure in /spec-add
+
+**Symptom:** `/spec-add <component>` aborts or produces a spec with `fpkit_version: "main"` (instead of a real short SHA).
+
+**Cause:** `fetch_fpkit_source.py` could not reach the GitHub API or the raw file URL.
+
+**Check:**
+
+```bash
+python3 plugins/acss-component-specs/scripts/fetch_fpkit_source.py button
+```
+
+The JSON output includes a `reasons` array explaining the failure. Common reasons:
+
+- Network unavailable.
+- GitHub API rate limit hit (returns HTTP 403). Wait or set `GITHUB_TOKEN` in your environment.
+- Component path not in the known path map. The script tries `<comp>s/<comp>.tsx` and `<comp>/<comp>.tsx` as fallbacks. If neither exists, it fails.
+
+When the SHA resolve fails but the source fetch succeeds, the version is recorded as `"main"`. The spec is still functional, but the version is not pinned. Re-run with `--refresh` when network access is restored to pin it properly.
+
+---
+
+## Atomic rollback: render fails mid-way
+
+**Symptom:** `/spec-render <component>` reports a failure and `.acss-staging/` is empty (or does not contain the expected files).
+
+**Cause:** The atomic-failure rule in the SKILL rolls back all staged output if any step fails. The staging directory is never left in a partial state.
+
+**Fix:** Read the error message. Common causes:
+- `specs/<component>.md` does not exist → run `/spec-add <component>` first.
+- A dependency spec is missing (e.g., Dialog needs Button, but `specs/button.md` doesn't exist) → run `/spec-add button`, then retry.
+- `validate_spec.py` found a schema error → fix the spec frontmatter, then retry.
+
+---
+
+## Missing theme: "/spec-render" warns about CSS variables
+
+**Symptom:** After running `/spec-render`, you see a warning: "No `:root { --color-primary: … }` found in project CSS/SCSS. Theme values will fall back to hardcoded defaults."
+
+**Cause:** The spec's `theme_dependencies` field declares that the component uses one or more `--color-*` tokens (e.g., `--color-primary`, `--color-text-inverse`). The renderer scanned the project and found no `:root` block defining these tokens.
+
+**This is informational, not an error.** Hardcoded fallbacks are present on every CSS variable, so the component renders correctly without a theme file.
+
+**Fix (optional):** Install `acss-theme-builder` and generate a theme with `/app-theme`. The generated `:root { … }` block will supply the tokens and suppress the warning.
+
+---
+
+## ".acss-staging/ not in .gitignore"
+
+**Symptom:** On first render, you see a prompt: "`.acss-staging/` is not in your project's `.gitignore`. Add it? [Enter/Ctrl+C]"
+
+**Fix:** Press Enter. The staging directory is a transient build artifact — it should not be committed. The prompt is step R6 of the render flow; it fires once per project.
+
+If you dismissed the prompt and accidentally committed `.acss-staging/` contents, remove them:
+
+```bash
+echo '.acss-staging/' >> .gitignore
+git rm -r --cached .acss-staging/
+git commit -m "chore: remove staging directory from tracking"
+```
+
+---
+
+## framework in .acss-target.json is overriding --target
+
+**Symptom:** You ran `/spec-render button --target=html` expecting HTML output, but React output appeared instead.
+
+**Cause:** The `--target` flag overrides `.acss-target.json.framework`. If React output appeared despite `--target=html`, check that the `--target` argument was actually passed and that the spec renders correctly to HTML (some specs have incomplete HTML framework notes — check the spec body's HTML section).
+
+**Resolution order (highest priority first):**
+
+1. `--target` flag passed to the command.
+2. `framework` field in `.acss-target.json`.
+3. Default: render all three.
+
+If `framework` in `.acss-target.json` is set to `react` and you want a one-off HTML render, always pass `--target=html` explicitly.

--- a/plugins/acss-kit-builder/README.md
+++ b/plugins/acss-kit-builder/README.md
@@ -251,6 +251,16 @@ All generated components build on top of `UI`. It is copied to your target direc
 | **Bundle size** | Entire package ships | Only generated components ship |
 | **Updates** | npm version bumps | Re-run `/kit-add` or edit directly |
 
+## Developer Guide
+
+Detailed guides are in [`docs/`](docs/):
+
+- [concepts.md](docs/concepts.md) — mental model: UI base, data-\* variants, CSS-var fallbacks, aria-disabled, generation flow
+- [commands.md](docs/commands.md) — full `/kit-add` and `/kit-list` reference
+- [recipes.md](docs/recipes.md) — step-by-step walkthroughs for common tasks
+- [troubleshooting.md](docs/troubleshooting.md) — concrete failure modes and fixes
+- [architecture.md](docs/architecture.md) — contributor guide: adding components, cross-plugin wiring, version-bump checklist
+
 ## License
 
 MIT

--- a/plugins/acss-kit-builder/docs/README.md
+++ b/plugins/acss-kit-builder/docs/README.md
@@ -1,0 +1,35 @@
+# acss-kit-builder — Developer Guide
+
+This directory contains the developer guide for the `acss-kit-builder` Claude Code plugin. For installation and a command overview, see the [plugin README](../README.md).
+
+## For consumers
+
+Developers using the plugin to generate fpkit-style components into their own projects.
+
+| Guide | What it covers |
+|-------|---------------|
+| [concepts.md](concepts.md) | The mental model: UI base component, data-\* variants, CSS-var fallbacks, aria-disabled, generation flow, and cross-plugin coordination |
+| [commands.md](commands.md) | Full reference for `/kit-add` and `/kit-list` |
+| [recipes.md](recipes.md) | Step-by-step walkthroughs for the most common tasks |
+| [troubleshooting.md](troubleshooting.md) | Concrete failure modes and how to resolve them |
+
+## For contributors
+
+Developers maintaining or extending the plugin itself (SKILL.md, reference docs, component catalog).
+
+| Guide | What it covers |
+|-------|---------------|
+| [architecture.md](architecture.md) | Plugin internals: SKILL.md structure, how to add a component reference, cross-plugin wiring, version-bump checklist |
+
+## Reference material (canonical sources)
+
+These files are the authoritative source of truth. The guides in this folder summarize and link into them rather than duplicate them.
+
+| File | Purpose |
+|------|---------|
+| [`../skills/acss-kit-builder/SKILL.md`](../skills/acss-kit-builder/SKILL.md) | Full generation workflow (Steps A–F) invoked by Claude on every `/kit-add` call |
+| [`../skills/acss-kit-builder/references/architecture.md`](../skills/acss-kit-builder/references/architecture.md) | UI polymorphic types, `classes` vs `className`, compound component pattern, data-attribute selectors |
+| [`../skills/acss-kit-builder/references/accessibility.md`](../skills/acss-kit-builder/references/accessibility.md) | WCAG rationale, full `useDisabledState` hook source, WCAG checklist per component category |
+| [`../skills/acss-kit-builder/references/composition.md`](../skills/acss-kit-builder/references/composition.md) | Component categories, generation decision tree, inline-types pattern |
+| [`../skills/acss-kit-builder/references/css-variables.md`](../skills/acss-kit-builder/references/css-variables.md) | Naming convention, approved abbreviations, logical properties, rem conversion |
+| [`../skills/acss-kit-builder/references/components/`](../skills/acss-kit-builder/references/components/) | Per-component Generation Contracts, props, CSS vars, usage snippets |

--- a/plugins/acss-kit-builder/docs/architecture.md
+++ b/plugins/acss-kit-builder/docs/architecture.md
@@ -1,0 +1,128 @@
+# acss-kit-builder — Architecture (Contributor Guide)
+
+This page is for maintainers editing the plugin: adding component references, updating the SKILL workflow, or extending cross-plugin coordination.
+
+## Plugin layout
+
+```
+plugins/acss-kit-builder/
+  .claude-plugin/
+    plugin.json                # Authoritative version source; read by Claude Code + /plugin update
+  assets/
+    foundation/
+      ui.tsx                   # Polymorphic UI base — copied verbatim into user projects
+  commands/
+    kit-add.md                 # /kit-add definition; delegates to SKILL.md
+    kit-list.md                # /kit-list definition; delegates to SKILL.md
+  skills/
+    acss-kit-builder/
+      SKILL.md                 # The full generation workflow (Steps A–F)
+      references/
+        architecture.md        # UI polymorphic chain, compound pattern, data-attr selectors
+        accessibility.md       # WCAG rationale, useDisabledState source, WCAG checklist
+        composition.md         # Component categories, decision tree, inline-types pattern
+        css-variables.md       # Naming convention, fallbacks, rem conversion
+        components/
+          alert.md             # Generation Contract + full reference
+          button.md
+          card.md
+          catalog.md           # Badge, Tag, Heading, Text, Link, List, Details, Progress, Icon
+          dialog.md
+          form.md
+          nav.md
+```
+
+## Command → SKILL delegation
+
+Command files are intentionally thin. Each one:
+
+1. Documents the command signature and a brief description (for the Claude Code command palette).
+2. Points at the relevant SKILL.md section for the actual workflow.
+
+The logic lives entirely in `SKILL.md`. Do not duplicate generation logic inside a command file — changes would need to be maintained in two places and would drift.
+
+## How to add a new component reference
+
+1. **Create `references/components/<name>.md`** (or add the component to `catalog.md` for simple leaf components).
+
+   The file must start with a "Legacy reference" banner so users know an `acss-component-specs` spec supersedes it when installed:
+
+   ```markdown
+   > **Legacy reference.** When `acss-component-specs` is installed, `/kit-add <name>` prefers
+   > the spec at `specs/<name>.md` over this file. Use `/spec-add <name>` + `/spec-render <name>`
+   > for the spec-based flow.
+   ```
+
+2. **Add a Generation Contract block:**
+
+   ```markdown
+   ## Generation Contract
+
+   \`\`\`
+   export_name:  ComponentName
+   file:         component-name/component-name.tsx
+   scss:         component-name/component-name.scss
+   imports:      [../ui]
+   dependencies: [other-component-name]
+   \`\`\`
+   ```
+
+   The five fields are the stable interop shape between this plugin and `acss-component-specs`. Every field is required. `dependencies` is an array of component names (lowercase, matching their reference doc names). An empty array `[]` means a leaf component.
+
+3. **Add the props interface, CSS variables, and a usage snippet** following the pattern in existing reference docs (see `references/components/button.md` for the most complete example).
+
+4. **Cross-link the relevant shared references** within the doc body:
+   - Polymorphic `UI` type chain → `references/architecture.md`
+   - `useDisabledState` hook → `references/accessibility.md`
+   - Compound component pattern → `references/composition.md`
+   - CSS variable naming / fallback strategy → `references/css-variables.md`
+
+5. **Update `catalog.md` if the component is a simple leaf.** Simple components (no state, no deps, one `.tsx` + one `.scss`) belong in `catalog.md` rather than a dedicated file, to keep the file count manageable.
+
+6. **All fpkit source references must use full GitHub URLs** — never repo-relative paths. For example:
+   ```
+   https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/components/button/btn.tsx
+   ```
+   This is a project-level rule from `CLAUDE.md`.
+
+## The spec-bridge probe (Step B0)
+
+When the SKILL runs `/kit-add`, Step B0 probes for an `acss-component-specs` spec before falling back to the bundled reference. It checks two paths:
+
+```
+$CLAUDE_PLUGIN_ROOT/../acss-component-specs/skills/acss-component-specs/specs/<component>.md
+~/.claude/plugins/cache/acss-component-specs/skills/acss-component-specs/specs/<component>.md
+```
+
+The first path works when both plugins are in the same marketplace directory. The second is the fallback for cache-installed plugins. If neither resolves, the bundled reference doc is used with no warning.
+
+When adding a new component reference, the "Legacy reference" banner is what signals to users that a spec takes precedence. If no spec exists yet, the banner still belongs — it signals intent and tells users they can author one via `/spec-add`.
+
+## .acss-target.json — shared contract
+
+`.acss-target.json` at the project root is written by `acss-kit-builder` and also read by `acss-app-builder`. It contains at minimum:
+
+```json
+{
+  "componentsDir": "src/components/fpkit"
+}
+```
+
+`acss-component-specs` extends this with an optional `framework` field (see the component-specs architecture doc). The SKILL reads the file during Step A3 and writes it if absent. Never assume a fixed path — always resolve from this file.
+
+## Version bump checklist
+
+Before committing any plugin change, per the repo-level pre-submit checklist:
+
+1. Bump the version in `.claude-plugin/plugin.json` using `/release-plugin acss-kit-builder` (or manually).
+2. Confirm that all new `references/` file links to fpkit source use full GitHub URLs.
+3. Update `marketplace.json` description if the change is user-facing. Do not add a `version` key to the `marketplace.json` entry — `plugin.json` is the authoritative version source.
+4. Update `README.md` if commands or behavior changed.
+
+Docs-only additions (new `docs/*.md` files) do not require a version bump, as they do not change command behavior or generated output.
+
+## assets/foundation/ui.tsx
+
+This file is copied verbatim into user projects. Changes to it are rare and high-impact: every project that has already run `/kit-add` keeps the old copy (skip-existing rule). Treat changes to `ui.tsx` like a breaking change — note them prominently in the CHANGELOG and consider bumping the minor version.
+
+If you modify the polymorphic type chain (the `PolymorphicRef<C>` → `UIProps<C>` ladder), verify that the generated component `.tsx` files in the reference docs still type-check against the new types. The reference docs contain inline TSX examples that must be kept consistent with `ui.tsx`.

--- a/plugins/acss-kit-builder/docs/commands.md
+++ b/plugins/acss-kit-builder/docs/commands.md
@@ -1,0 +1,118 @@
+# acss-kit-builder — Command Reference
+
+## /kit-add
+
+Generate one or more fpkit-style components into your project.
+
+**Signature**
+
+```
+/kit-add <component> [component2 ...]
+```
+
+**Tools used:** `Read, Glob, Grep, Write, Edit, AskUserQuestion`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<component>` | Yes | Name of the component to generate (e.g., `button`, `dialog`, `badge`). Case-insensitive. Pass multiple names to generate several in one invocation. |
+
+No flags. Component names map directly to the reference catalog — run `/kit-list` to see available names.
+
+### What happens step by step
+
+These steps correspond to Steps A–F in [`SKILL.md`](../skills/acss-kit-builder/SKILL.md).
+
+**Step A — First-run init (runs once per project)**
+
+1. Reads `package.json` to confirm this is a React + TypeScript project.
+2. Checks `devDependencies` for `sass` or `sass-embedded`. Aborts with an install hint if neither is found.
+3. Reads `.acss-target.json` from the project root. If the file does not exist, asks: "Where should components be generated? (default: `src/components/fpkit/`)" and writes the file.
+4. Copies `assets/foundation/ui.tsx` to `<target>/ui.tsx` if that file does not already exist.
+
+**Step B — Generation workflow**
+
+1. **B0 — Spec bridge:** Probes for an `acss-component-specs` spec at two locations (see [concepts.md](concepts.md#the-acss-component-specs-bridge)). Uses the spec if found; silently falls back to the bundled reference doc.
+2. **B1 — Reference lookup:** Reads the component's reference doc from `references/components/`.
+3. **B2 — Dependency resolution:** Reads the Generation Contract (`export_name`, `file`, `scss`, `imports`, `dependencies`). Walks the dependency tree recursively until all leaf components are identified.
+4. **B3–B4 — Preview + confirmation:** Displays the full file tree that will be created or skipped. Waits for confirmation before writing anything.
+5. **B5 — Bottom-up generation:** Generates leaf dependencies first. Skips any file that already exists and uses the existing file's import path instead.
+
+**Steps C–E — Code generation**
+
+Claude applies the constraints from [`references/`](../skills/acss-kit-builder/references/) when writing the output:
+
+- TypeScript: all types inlined, local imports only, `useDisabledState` inlined for interactive components.
+- SCSS: CSS-var fallbacks on every property, rem units only, `data-*` attribute selectors for variants.
+- Accessibility: `aria-disabled` over native `disabled`, `:focus-visible` indicators.
+
+**Step F — Summary**
+
+Prints created and skipped files, plus an import and JSX usage snippet.
+
+### Examples
+
+```
+/kit-add badge                 # Single leaf component, no deps
+/kit-add button                # Interactive; inlines useDisabledState
+/kit-add dialog                # Complex; resolves and generates button first
+/kit-add badge button card     # Multiple components in one pass
+```
+
+### Available components
+
+Run `/kit-list` for the full categorized listing. The shortlist:
+
+| Category | Components |
+|----------|-----------|
+| Simple | badge, tag, heading, text, link, list, details, progress, icon |
+| Interactive | button |
+| Layout | card, nav |
+| Complex | alert, dialog, form |
+
+---
+
+## /kit-list
+
+List available components or inspect a specific one.
+
+**Signature**
+
+```
+/kit-list [component]
+```
+
+**Tools used:** `Read` only — this command never writes files.
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `[component]` | No | Name of a specific component to inspect. Omit to list all. |
+
+### What happens step by step
+
+**Without an argument**
+
+Reads [`references/components/catalog.md`](../skills/acss-kit-builder/references/components/catalog.md) and prints all components grouped by category (Simple / Interactive / Layout / Complex) with a one-line description of each.
+
+**With a component name**
+
+Reads that component's reference doc (either from `catalog.md` or from a dedicated `references/components/{name}.md`) and prints:
+
+- Generation Contract (`export_name`, `file`, `scss`, `imports`, `dependencies`)
+- Props interface
+- CSS variables with their fallback values
+- A usage snippet
+
+Nothing is written to disk.
+
+### Examples
+
+```
+/kit-list                      # Print all available components by category
+/kit-list badge                # Show Badge's Generation Contract, props, CSS vars, and usage
+/kit-list dialog               # Show Dialog's full dependency tree (button)
+/kit-list form                 # Show which sub-controls form.tsx contains
+```

--- a/plugins/acss-kit-builder/docs/concepts.md
+++ b/plugins/acss-kit-builder/docs/concepts.md
@@ -1,0 +1,108 @@
+# acss-kit-builder — Core Concepts
+
+This page covers the mental model you need before running `/kit-add`. Understanding these ideas will help you reason about what gets generated, why the generated code looks the way it does, and what to do when something unexpected happens.
+
+## Why generated code instead of an npm package
+
+`@fpkit/acss` is a real npm package. This plugin deliberately does not install it. Instead, Claude reads fpkit component patterns from bundled reference documents and writes self-contained TypeScript + SCSS files directly into your project. You own the output — you can edit it freely, and there is nothing to update via npm. The trade-off is that updates require re-running `/kit-add` (which respects existing files; see [skip-existing](#bottom-up-generation-and-skip-existing) below).
+
+## The UI foundation component
+
+Every generated component imports a single shared file: `ui.tsx`. This is the only file the plugin copies verbatim from the fpkit source rather than generating from a reference doc. It is a **polymorphic React component** that:
+
+- Renders as any HTML element via the `as` prop (`<UI as="button">`, `<UI as="nav">`)
+- Forwards all props (including ARIA attributes) to the rendered element
+- Provides type-safe refs that match the rendered element type
+- Supports a `classes` alias for `className` — when both are provided, `classes` wins
+
+`ui.tsx` is copied to your target directory on the first `/kit-add` run. All generated components import it with a local relative path (`import UI from '../ui'`). Never import it from an npm package.
+
+See [`references/architecture.md`](../skills/acss-kit-builder/references/architecture.md) for the full polymorphic type chain.
+
+## data-\* attribute variants (not BEM)
+
+Generated components use `data-*` attribute selectors for styling variants instead of BEM modifier classes. For example, a button's size and color:
+
+```tsx
+<Button data-btn="lg" data-color="primary">Submit</Button>
+```
+
+```scss
+.btn {
+  &[data-btn~="lg"] { font-size: var(--btn-lg-fs, 1.125rem); }
+  &[data-color="primary"] { background: var(--btn-primary-bg, var(--color-primary, #0066cc)); }
+}
+```
+
+The `~=` selector matches a space-separated word, which lets you compose multiple variants: `data-btn="lg block"` activates both `lg` and `block` rules simultaneously.
+
+## CSS custom properties with mandatory fallbacks
+
+Every CSS variable in generated SCSS **must** include a hardcoded fallback value. This makes components work in isolation without a global tokens file:
+
+```scss
+font-size: var(--btn-fs, 0.9375rem);           /* correct */
+font-size: var(--btn-fs);                       /* wrong — breaks without a token file */
+```
+
+Variable naming follows the pattern `--{component}-{element?}-{variant?}-{property}`. For example: `--btn-primary-bg`, `--card-title-fs`, `--dialog-backdrop-bg`.
+
+All sizes use **rem** (never px). Conversion: `px / 16 = rem`.
+
+See [`references/css-variables.md`](../skills/acss-kit-builder/references/css-variables.md) for the full naming convention, approved abbreviations, and logical-property rules.
+
+## aria-disabled and useDisabledState
+
+Interactive components (Button, any component with a clickable surface) use `aria-disabled="true"` instead of the native `disabled` attribute. The reason: native `disabled` removes an element from the keyboard tab order, which fails WCAG 2.1.1 (Non-text Contrast) and breaks the expected experience for keyboard and screen-reader users.
+
+The plugin inlines a condensed `useDisabledState<T>` hook (~50 lines) directly into each interactive component file. It is never a shared import — each component that needs it carries its own copy. This keeps generated files self-contained.
+
+See [`references/accessibility.md`](../skills/acss-kit-builder/references/accessibility.md) for the full hook source, the `resolveDisabledState` one-liner, focus management guidelines, and the WCAG checklist per component category.
+
+## Types inline, imports local-only
+
+Generated `.tsx` files have two hard rules:
+
+- **All TypeScript types are inlined** — no cross-component type imports. Each file defines its own `ButtonProps`, `CardProps`, and so on.
+- **All imports use local relative paths** — never `@fpkit/acss`. The only imports in a generated file are `import React from 'react'` and `import UI from '../ui'` (plus sibling component imports for compounds like `import Button from '../button/button'`).
+
+## The Generation Contract
+
+Every component in the reference catalog has a **Generation Contract** block. It is the stable interface between the component reference docs and the generation workflow:
+
+```
+export_name:  Button
+file:         button/button.tsx
+scss:         button/button.scss
+imports:      [../ui]
+dependencies: []
+```
+
+Five fields. `dependencies` is the key one: it lists the component names that must exist before this component can be generated. The plugin resolves this recursively to build a full dependency tree before writing any files.
+
+## Bottom-up generation and skip-existing
+
+When you run `/kit-add dialog`, the plugin resolves that Dialog depends on Button (and Button has no dependencies). It then generates in **bottom-up order**: Button first, Dialog second. If `button/button.tsx` already exists, it is **skipped** — the existing file is used as-is and the Dialog import path resolves to it without modification.
+
+This means you can safely re-run `/kit-add dialog` after editing `button/button.tsx`; your edits are preserved.
+
+## The acss-component-specs bridge
+
+If the `acss-component-specs` plugin is also installed, `acss-kit-builder` checks for a spec file before falling back to its bundled reference doc. The probe runs in Step B0 of the SKILL.md workflow and checks two locations:
+
+1. `$CLAUDE_PLUGIN_ROOT/../acss-component-specs/skills/acss-component-specs/specs/<component>.md`
+2. `~/.claude/plugins/cache/acss-component-specs/skills/acss-component-specs/specs/<component>.md`
+
+When a spec is found, it takes precedence. If no spec exists, the fallback to the bundled reference is silent. Every bundled component reference doc (except `catalog.md` and `form.md`) carries a "Legacy reference" banner pointing to the spec-based alternative.
+
+## .acss-target.json — shared project config
+
+On the first `/kit-add` run in a project, the plugin writes a `.acss-target.json` file at the project root:
+
+```json
+{
+  "componentsDir": "src/components/fpkit"
+}
+```
+
+This file is the shared coordination point with the `acss-app-builder` plugin. Both plugins resolve the component output directory from it. Commit this file to git. If you need to change the target directory, edit the file directly or delete it and re-run `/kit-add` (you will be prompted again).

--- a/plugins/acss-kit-builder/docs/recipes.md
+++ b/plugins/acss-kit-builder/docs/recipes.md
@@ -1,0 +1,187 @@
+# acss-kit-builder — Recipes
+
+Common tasks, step by step. Each recipe assumes the plugin is installed and you are inside a Claude Code session in your project directory.
+
+---
+
+## First run: initializing a project
+
+The first `/kit-add` run in any project triggers a one-time setup sequence.
+
+**Prerequisites:**
+
+- React + TypeScript project with a `package.json`
+- `sass` or `sass-embedded` in `devDependencies`
+
+If sass is not installed:
+
+```bash
+npm install -D sass
+```
+
+**Run:**
+
+```
+/kit-add badge
+```
+
+The plugin will:
+
+1. Verify sass is present. If not, it aborts here with a message.
+2. Ask "Where should components be generated? (default: `src/components/fpkit/`)" — press Enter to accept the default or type a custom path.
+3. Write `.acss-target.json` at the project root with the chosen directory.
+4. Copy `ui.tsx` (the polymorphic foundation component) to `<target>/ui.tsx`.
+5. Generate the Badge component.
+
+Commit `.acss-target.json` to git. It is shared with `acss-app-builder` — both plugins read from it.
+
+---
+
+## Generate a single leaf component
+
+```
+/kit-add badge
+```
+
+Badge has no dependencies. The plugin reads `catalog.md`, shows a preview (`badge/badge.tsx + badge/badge.scss`), waits for confirmation, then writes both files.
+
+Import in your project:
+
+```tsx
+import Badge from './components/fpkit/badge/badge'
+```
+
+---
+
+## Generate a component with dependencies
+
+```
+/kit-add dialog
+```
+
+Dialog depends on Button. The plugin resolves the full tree and generates bottom-up:
+
+```
+Preview:
+  ui.tsx                  (already exists — skipped)
+  button/button.tsx       (new)
+  button/button.scss      (new)
+  dialog/dialog.tsx       (new)
+  dialog/dialog.scss      (new)
+```
+
+Confirm, and all files are written in the correct order. If `button/button.tsx` already exists, it is skipped and Dialog still imports from the existing path.
+
+---
+
+## Regenerate a component after upstream changes
+
+To update a component to the latest reference without losing your edits to other components:
+
+1. Delete only the files you want to regenerate:
+   ```bash
+   rm src/components/fpkit/badge/badge.tsx src/components/fpkit/badge/badge.scss
+   ```
+2. Re-run:
+   ```
+   /kit-add badge
+   ```
+
+Files that still exist are skipped. Deleted files are regenerated from the current reference.
+
+If `acss-component-specs` is installed and a spec exists for the component, run `/spec-render badge --target=react` + `/spec-diff badge` + `/spec-promote badge` instead — that flow gives you a diff preview before overwriting.
+
+---
+
+## Generate multiple components in one pass
+
+```
+/kit-add badge button alert
+```
+
+Dependencies are resolved across all requested components. Shared deps (Button for Alert, etc.) are deduplicated — Button is generated once even if multiple requested components need it.
+
+---
+
+## Customize a generated component
+
+Generated files are yours. Edit them freely:
+
+```tsx
+// button/button.tsx — add a custom isLoading prop
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, isLoading, ...props }, ref) => {
+    ...
+    return (
+      <UI as="button" data-btn={isLoading ? 'loading' : undefined} ...>
+        {isLoading ? <Spinner /> : children}
+      </UI>
+    )
+  }
+)
+```
+
+The skip-existing rule means re-running `/kit-add button` will not overwrite your edits. To get a fresh copy, delete the file first (see "Regenerate" above).
+
+---
+
+## Override a CSS variable
+
+Components use CSS custom properties with hardcoded fallbacks. Override at any scope without touching the generated file:
+
+```css
+/* Global — applies everywhere */
+:root {
+  --btn-primary-bg: #7c3aed;
+  --btn-radius: 2rem;
+}
+
+/* Scoped to a theme class */
+.dark-theme {
+  --card-bg: #2d2d2d;
+  --card-border: 1px solid #404040;
+}
+
+/* Context-specific */
+.hero-section .btn {
+  --btn-padding-inline: 2.5rem;
+}
+```
+
+See [`references/css-variables.md`](../skills/acss-kit-builder/references/css-variables.md) for the full naming convention and the per-component variable sets.
+
+---
+
+## Change the target directory
+
+Edit `.acss-target.json` at the project root:
+
+```json
+{
+  "componentsDir": "src/ui/fpkit"
+}
+```
+
+All future `/kit-add` runs will generate files into the new directory. Existing generated files in the old directory are not moved — do that manually if needed, and update your imports.
+
+---
+
+## Inspect a component before generating
+
+Use `/kit-list` to see props, CSS variables, dependencies, and a usage snippet without writing any files:
+
+```
+/kit-list dialog
+```
+
+Output includes the Generation Contract (dependency tree), the props interface, all CSS variables with their fallback values, and a basic JSX usage snippet. Useful for planning before running `/kit-add`.
+
+---
+
+## List all available components
+
+```
+/kit-list
+```
+
+Prints all components organized by category (Simple / Interactive / Layout / Complex) with a one-line description of each.

--- a/plugins/acss-kit-builder/docs/troubleshooting.md
+++ b/plugins/acss-kit-builder/docs/troubleshooting.md
@@ -1,0 +1,110 @@
+# acss-kit-builder — Troubleshooting
+
+---
+
+## "sass or sass-embedded not found in devDependencies"
+
+**Symptom:** `/kit-add` aborts immediately with a message about missing sass.
+
+**Fix:**
+
+```bash
+npm install -D sass
+```
+
+Then re-run `/kit-add`. The plugin reads `package.json`'s `devDependencies` key — make sure the install completed and the key is present before retrying.
+
+If your project uses `sass-embedded` instead:
+
+```bash
+npm install -D sass-embedded
+```
+
+Either package satisfies the check.
+
+---
+
+## "Components are generating into the wrong directory"
+
+**Symptom:** Files appear in a different folder than expected.
+
+**Cause:** `.acss-target.json` at the project root contains a `componentsDir` value from a previous `/kit-add` run or from `acss-app-builder`.
+
+**Fix:** Open `.acss-target.json` and update `componentsDir` to the path you want:
+
+```json
+{
+  "componentsDir": "src/components/fpkit"
+}
+```
+
+Future `/kit-add` runs will use the new path. Existing generated files in the old directory are not moved — rename the directory manually and update your imports if you change the path after files have already been generated.
+
+---
+
+## Component name not recognized
+
+**Symptom:** `/kit-add frobniz` fails or produces an empty preview.
+
+**Fix:** Run `/kit-list` to see the full list of available component names. Names are lowercase and exact — `dialog`, not `Dialog` or `modal`. The available components are: badge, tag, heading, text, link, list, details, progress, icon, button, alert, card, nav, dialog, form.
+
+If you need a component that is not listed, it does not yet have a bundled reference doc. Use `/kit-list` to check for aliases, or author a spec via `acss-component-specs` and `/spec-add`.
+
+---
+
+## "acss-component-specs is installed but the spec isn't being used"
+
+**Symptom:** `/kit-add button` generates from the bundled reference doc even though you installed `acss-component-specs`.
+
+**Cause:** The B0 spec-bridge probe checks two paths. If neither resolves to an actual file, it silently falls back to the bundled reference.
+
+**Check the two probe paths:**
+
+1. `$CLAUDE_PLUGIN_ROOT/../acss-component-specs/skills/acss-component-specs/specs/<component>.md`
+2. `~/.claude/plugins/cache/acss-component-specs/skills/acss-component-specs/specs/<component>.md`
+
+If the spec file exists but the first path is wrong (e.g., the plugins are in different directories), the probe silently skips it. Confirm that `acss-component-specs` is installed at the expected sibling path relative to `acss-kit-builder`.
+
+If the spec file does not exist yet, run `/spec-add <component>` first.
+
+---
+
+## "ui.tsx already exists but looks different from what the plugin expects"
+
+**Symptom:** After running `/kit-add`, you notice that the `ui.tsx` in your project does not match the `assets/foundation/ui.tsx` in the plugin. Your generated components import from it, but something behaves unexpectedly.
+
+**Cause:** The skip-existing rule means `/kit-add` never overwrites `ui.tsx` once it exists. If you or another plugin wrote a different `ui.tsx` first, the generated components will import from that file.
+
+**Fix:** Compare your `ui.tsx` against [`assets/foundation/ui.tsx`](../assets/foundation/ui.tsx). If they have diverged, copy the plugin's version and reconcile any local modifications. The `UI` component's polymorphic type chain (`PolymorphicRef<C>` → `UIProps<C>` → `UIComponent`) must be intact for generated components to type-check correctly.
+
+---
+
+## "Bottom-up generation order is surprising"
+
+**Symptom:** You expected `alert` to be generated before `button`, but they were generated in the opposite order.
+
+**Explanation:** The plugin generates leaf dependencies first. If Alert depends on Button, Button is generated first (it is closer to the leaf). This is intentional — it guarantees that every dependency exists on disk before the component that imports it is written.
+
+If you are surprised by which component depends on which, run `/kit-list <component>` to see the full dependency list before running `/kit-add`.
+
+---
+
+## "My edited component was overwritten"
+
+**Symptom:** You edited a generated file, then re-ran `/kit-add` and your changes were gone.
+
+**This should not happen.** The skip-existing rule means `/kit-add` does not write to a file that already exists. If your edits were lost, check:
+
+1. Did you delete and recreate the file before running `/kit-add`?
+2. Was the file in the correct `componentsDir` at the time of the second run? (Check `.acss-target.json`.)
+3. Did you run `/spec-promote` instead of `/kit-add`? The `spec-promote` command does overwrite — that is its documented behavior.
+
+---
+
+## Import paths resolve incorrectly after renaming a component file
+
+**Symptom:** After renaming `button/button.tsx` to `button/btn.tsx`, the Dialog component breaks because it imports from `../button/button`.
+
+**Cause:** Import paths in generated files are resolved at generation time from the component's `file` field in its Generation Contract. Renaming files after generation requires updating imports manually.
+
+**Fix:** Update all `import` statements that reference the old filename. There is no automated re-import for post-generation renames.


### PR DESCRIPTION
## Summary
- Add `docs/` folder to `acss-kit-builder` with 6 guide files: README (index), concepts, commands, recipes, troubleshooting, and architecture
- Add `docs/` folder to `acss-component-specs` with 7 guide files: README (index), concepts, commands, spec-authoring, recipes, troubleshooting, and architecture
- Update both plugin READMEs with a Developer Guide section linking into `docs/`

## Changes
Covers two audiences: consumers (concepts → commands → recipes → troubleshooting) and contributors (architecture). Content links into the canonical `SKILL.md` and `references/` tree rather than duplicating it, to prevent drift. Includes the `acss-component-specs`-specific spec authoring walkthrough, the 7-kind `maps_to` quick-reference table, Python scripts reference, cross-plugin coordination details, and the v0.2 roadmap from the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)