### PR TITLE
docs(acss-kit-builder): add first-component tutorial

### DIFF
--- a/plugins/acss-kit-builder/docs/README.md
+++ b/plugins/acss-kit-builder/docs/README.md
@@ -8,6 +8,7 @@ Developers using the plugin to generate fpkit-style components into their own pr
 
 | Guide | What it covers |
 |-------|---------------|
+| [tutorial.md](tutorial.md) | A guided walkthrough: generate, import, and customize your first component |
 | [concepts.md](concepts.md) | The mental model: UI base component, data-\* variants, CSS-var fallbacks, aria-disabled, generation flow, and cross-plugin coordination |
 | [commands.md](commands.md) | Full reference for `/kit-add` and `/kit-list` |
 | [recipes.md](recipes.md) | Step-by-step walkthroughs for the most common tasks |

--- a/plugins/acss-kit-builder/docs/tutorial.md
+++ b/plugins/acss-kit-builder/docs/tutorial.md
@@ -13,7 +13,6 @@ Prerequisites:
 - React + TypeScript project with a `package.json`
 - `sass` or `sass-embedded` in `devDependencies`
 - `acss-kit-builder` installed via `/plugin install acss-kit-builder@shawn-sandy-acss-plugins`
-- Clean git working tree (commands refuse a dirty tree unless you pass `--force`)
 
 If sass is not installed:
 
@@ -21,7 +20,7 @@ If sass is not installed:
 npm install -D sass
 ```
 
-This walkthrough uses **Button**. It is a single-file component with no fpkit dependencies, so the only first-run extra is the shared `ui.tsx` foundation — perfect for seeing the setup flow in one command.
+This walkthrough uses **Button**. It has no component dependencies — only the shared `ui.tsx` foundation is copied on first run — so you see the full setup flow in a single command.
 
 ---
 
@@ -35,10 +34,10 @@ Open Claude Code in your project directory and run:
 
 Output groups every available component into four categories:
 
-- **Simple** — leaf components with no dependencies (Badge, Tag, Heading, Text, Link, Icon)
-- **Interactive** — Button, Form controls, focus-managed elements
-- **Layout** — Card, layout primitives
-- **Complex** — Dialog, Nav and other components that depend on simpler ones
+- **Simple** — leaf components with no dependencies (Badge, Tag, Heading, Text)
+- **Interactive** — components built on the `useDisabledState` pattern (Button, Link)
+- **Layout** — structural and compound components (Card, Nav)
+- **Complex** — components that depend on multiple simpler components (Alert, Dialog, Form)
 
 Why look first? You don't write what you can generate. The catalog tells you exactly what's available before you commit to writing anything yourself.
 
@@ -50,14 +49,14 @@ Why look first? You don't write what you can generate. The catalog tells you exa
 /kit-list button
 ```
 
-This prints Button's full Generation Contract without writing any files:
+This prints Button's Generation Contract without writing any files. Highlights the output covers:
 
-- **Dependencies:** none — Button only imports the `UI` foundation from `../ui`
-- **Props:** `type` (required), `children`, `disabled`, `size`, `variant`, `color`, `block`, plus standard event handlers
-- **CSS variables:** `--btn-bg`, `--btn-color`, `--btn-radius`, `--btn-padding-inline`, `--btn-primary-bg`, `--btn-primary-hover-bg`, size tokens (`--btn-size-xs` through `--btn-size-xl`), and state tokens (`--btn-focus-outline`, `--btn-disabled-opacity`)
+- **Dependencies:** Button has none — it only imports the `UI` foundation from `../ui`
+- **Props:** including `type` (required), `children`, `disabled`, `size`, `variant`, `color`, `block`, plus the standard event handlers
+- **CSS variables:** including base tokens (`--btn-bg`, `--btn-color`, `--btn-radius`, `--btn-padding-inline`), size tokens, color variants (`--btn-primary-bg` and friends), and state tokens (`--btn-focus-outline`, `--btn-disabled-opacity`)
 - **Usage snippet** — a JSX example you can copy
 
-Reading this first means no surprises in the next step.
+Treat the `/kit-list button` output itself as the authoritative list — these bullets are highlights so you know what shape to expect before running `/kit-add`.
 
 ---
 

--- a/plugins/acss-kit-builder/docs/tutorial.md
+++ b/plugins/acss-kit-builder/docs/tutorial.md
@@ -1,0 +1,177 @@
+# acss-kit-builder — Tutorial: your first component
+
+Generate, import, and customize a Button in under five minutes. By the end you will have a working, themeable Button component you own outright — no `@fpkit/acss` npm dependency, no boilerplate.
+
+If you want the mental model first, read [concepts.md](concepts.md). Otherwise, start here.
+
+---
+
+## Before you start
+
+Prerequisites:
+
+- React + TypeScript project with a `package.json`
+- `sass` or `sass-embedded` in `devDependencies`
+- `acss-kit-builder` installed via `/plugin install acss-kit-builder@shawn-sandy-acss-plugins`
+- Clean git working tree (commands refuse a dirty tree unless you pass `--force`)
+
+If sass is not installed:
+
+```bash
+npm install -D sass
+```
+
+This walkthrough uses **Button**. It is a single-file component with no fpkit dependencies, so the only first-run extra is the shared `ui.tsx` foundation — perfect for seeing the setup flow in one command.
+
+---
+
+## Step 1 — Browse the catalog
+
+Open Claude Code in your project directory and run:
+
+```
+/kit-list
+```
+
+Output groups every available component into four categories:
+
+- **Simple** — leaf components with no dependencies (Badge, Tag, Heading, Text, Link, Icon)
+- **Interactive** — Button, Form controls, focus-managed elements
+- **Layout** — Card, layout primitives
+- **Complex** — Dialog, Nav and other components that depend on simpler ones
+
+Why look first? You don't write what you can generate. The catalog tells you exactly what's available before you commit to writing anything yourself.
+
+---
+
+## Step 2 — Inspect Button before generating
+
+```
+/kit-list button
+```
+
+This prints Button's full Generation Contract without writing any files:
+
+- **Dependencies:** none — Button only imports the `UI` foundation from `../ui`
+- **Props:** `type` (required), `children`, `disabled`, `size`, `variant`, `color`, `block`, plus standard event handlers
+- **CSS variables:** `--btn-bg`, `--btn-color`, `--btn-radius`, `--btn-padding-inline`, `--btn-primary-bg`, `--btn-primary-hover-bg`, size tokens (`--btn-size-xs` through `--btn-size-xl`), and state tokens (`--btn-focus-outline`, `--btn-disabled-opacity`)
+- **Usage snippet** — a JSX example you can copy
+
+Reading this first means no surprises in the next step.
+
+---
+
+## Step 3 — Generate the component
+
+```
+/kit-add button
+```
+
+The plugin will:
+
+1. Verify sass is present. If not, it aborts here with a message.
+2. Ask "Where should components be generated? (default: `src/components/fpkit/`)" — press Enter to accept the default or type a custom path.
+3. Write `.acss-target.json` at the project root with the chosen directory.
+4. Copy `ui.tsx` (the polymorphic foundation component) to `<target>/ui.tsx`.
+5. Generate `button/button.tsx` and `button/button.scss`.
+
+Commit `.acss-target.json` to git. It is shared with `acss-app-builder` — both plugins read from it.
+
+After the run, your tree looks like:
+
+```
+src/components/fpkit/
+  ui.tsx              # polymorphic foundation (one per project)
+  button/
+    button.tsx        # Button + inlined useDisabledState hook
+    button.scss       # styles with hardcoded fallbacks for every CSS var
+```
+
+The SCSS uses hardcoded fallbacks (e.g. `var(--btn-bg, transparent)`) so the component renders correctly even before you set any custom variables. This is what makes the next step purely additive.
+
+---
+
+## Step 4 — Import and use it
+
+In `src/App.tsx` (or any page file):
+
+```tsx
+import Button from './components/fpkit/button/button'
+import './components/fpkit/button/button.scss'
+
+export default function App() {
+  return (
+    <Button type="button" color="primary" onClick={() => alert('hi')}>
+      Click me
+    </Button>
+  )
+}
+```
+
+Two things to notice:
+
+- **`type` is required.** Button rejects implicit submit semantics — you always declare intent (`button`, `submit`, or `reset`). If TypeScript flags a missing `type`, that's the safety net firing.
+- **The SCSS import lives next to the TSX import.** Generated components don't bundle styles, so each component file expects its sibling SCSS to be imported once per app.
+
+---
+
+## Step 5 — Customize via CSS variables
+
+Generated files are yours to edit, but you rarely need to — variants and theming are CSS-variable-first. Override at any scope:
+
+```scss
+/* Global — applies everywhere */
+:root {
+  --btn-primary-bg: #7c3aed;
+  --btn-radius: 999px;
+}
+
+/* Scoped to a theme class */
+.dark-theme {
+  --btn-primary-bg: #4c1d95;
+  --btn-primary-hover-bg: #6d28d9;
+}
+
+/* Context-specific */
+.hero-section .btn {
+  --btn-padding-inline: 2.5rem;
+  --btn-fs: 1.125rem;
+}
+```
+
+Why prefer overrides over editing `button.scss` directly? The skip-existing rule in `/kit-add` means re-running the command never touches your generated files — but if you ever delete and regenerate (see [recipes.md — Regenerate a component](recipes.md#regenerate-a-component-after-upstream-changes)), customizations stored in `:root` or theme classes survive because they live outside the component file.
+
+The full naming convention and per-component variable sets are in [`references/css-variables.md`](../skills/acss-kit-builder/references/css-variables.md).
+
+---
+
+## Verify
+
+```bash
+npx tsc --noEmit
+npm run dev
+```
+
+You should see:
+
+- TypeScript exits `0`. Button's props are fully typed; the required `type` prop is enforced.
+- The dev server renders a button styled by the CSS variables you set in Step 5 (or the built-in fallbacks if you skipped it).
+- Clicking it fires the `onClick` handler.
+- Tabbing onto the button shows a visible focus ring (`--btn-focus-outline` defaults to `2px solid currentColor`).
+- `disabled` buttons stay in tab order and signal state via `aria-disabled` rather than the native `disabled` attribute (WCAG 2.1.1).
+
+If the button renders unstyled, the `import './components/fpkit/button/button.scss'` line is missing.
+
+---
+
+## Where to next
+
+You have generated, imported, and customized one component. From here:
+
+- [recipes.md](recipes.md) — variations: multiple components in one pass, components with dependencies (Dialog pulls in Button), regenerate after an upstream change, change the target directory.
+- [concepts.md](concepts.md) — the mental model: the `UI` polymorphic base, `data-*` attribute variants, why `aria-disabled` instead of the native attribute.
+- [commands.md](commands.md) — full `/kit-list` and `/kit-add` reference.
+- [Button reference](../skills/acss-kit-builder/references/components/button.md) — every prop, every CSS variable, and the full implementation source.
+- [troubleshooting.md](troubleshooting.md) — when things don't work.
+
+Ready to compose components into pages or generate themes? Install [`acss-app-builder`](../../acss-app-builder/README.md) — it reads the same `.acss-target.json` and uses your generated source automatically.


### PR DESCRIPTION
## Summary

- New `plugins/acss-kit-builder/docs/tutorial.md` — a focused walkthrough that takes a reader with an existing Vite + React + TS + sass project from `/kit-list` to a customized, working Button in nine steps.
- Indexed at the top of the `docs/README.md` "For consumers" table so newcomers land on it before reference material.
- Style mirrors `recipes.md` (noun-phrase headings, `---` separators, fenced blocks, no emoji); prereq wording and the "The plugin will:" numbered list are lifted verbatim from `recipes.md` for cross-doc consistency.

## Why

The plugin's existing developer guide is weighted toward reference material — `concepts.md`, `commands.md`, `recipes.md`, `troubleshooting.md`, `architecture.md`. The root `GUIDE.md` Section 7 has a full new-project walkthrough, but its scope (Vite scaffold + theme + layout + page + verification) is too broad for a developer who just wants to learn the component-creation loop. This tutorial fills that gap with a single, beginner-oriented happy path scoped to one component (`Button`) chosen because it triggers the first-run `ui.tsx` foundation copy.

## Reviewer notes

- **No `plugin.json` bump.** Docs-only addition inside the plugin's `docs/` folder. Consistent with how the existing concepts/commands/recipes/troubleshooting/architecture guides were added (commit 6b064aa).
- **No `marketplace.json` change.** The plugin description hasn't changed.
- **Component choice rationale.** The walkthrough uses `Button` rather than `Badge` because Button has zero fpkit dependencies (`useDisabledState` is inlined) but does trigger the one-time `ui.tsx` foundation copy, so the reader sees the full first-run setup behavior in a single command.

## Test plan

- [x] All seven relative links in `tutorial.md` resolve (verified locally with `test -f`)
- [x] `recipes.md#regenerate-a-component-after-upstream-changes` anchor matches a real `## ` heading in `recipes.md`
- [ ] In a scratch Vite + React + TS + sass project with `acss-kit-builder` installed, follow the tutorial verbatim and confirm: `/kit-list` lists categories; `/kit-list button` shows the Generation Contract; `/kit-add button` writes `ui.tsx` + `button/button.tsx` + `button/button.scss` + `.acss-target.json`; the import snippet renders without TS errors; the CSS variable override visibly changes the button color; `npx tsc --noEmit` exits 0
- [ ] Cross-doc consistency check: `tutorial.md` does not contradict `concepts.md`, `recipes.md`, or `commands.md` on components dir default, first-run behavior, skip-existing rule, or CSS variable override pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)