### PR TITLE
feat(tests): add local plugin smoke-test sandbox setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 # Claude Code
 .claude/worktrees/
 CLAUDE.local.md
+
+# Local plugin testing
+tests/sandbox/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,7 @@ Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direc
 
 ## Testing locally
 
-```bash
-# In a disposable project or Claude Code test session:
-/plugin marketplace add /absolute/path/to/acss-plugins
-/plugin install acss-app-builder@<local-marketplace-name>
-```
+Run `tests/setup.sh` from the repo root to scaffold a disposable Vite+React+TS sandbox at `tests/sandbox/` (gitignored), then `cd tests/sandbox && claude` and paste the recipe the script printed. See [`tests/README.md`](./tests/README.md) for the full workflow, including the `--reset` flag.
 
 Full validation: manual SKILL.md review → local install → smoke-test slash commands → run Python scripts against a sample project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,19 @@ Bump the version in `plugin.json` when shipping changes — `/plugin update` use
 
 ## Testing locally
 
-```bash
-# In a disposable project or a Claude Code test session:
-/plugin marketplace add /absolute/path/to/acss-plugins
-/plugin install acss-app-builder@<local-marketplace-name>
+Run `tests/setup.sh` from the repo root to scaffold a disposable Vite + React + TypeScript sandbox at `tests/sandbox/` (gitignored). The script prints a copy-pasteable Claude Code recipe that adds the local marketplace and installs all four plugins.
+
+```sh
+tests/setup.sh
+cd tests/sandbox && claude
 ```
+
+See [`tests/README.md`](./tests/README.md) for the full workflow:
+
+- Per-plugin smoke flows with what to verify after each command
+- A verification checklist (including `npm run build` in the sandbox)
+- Reset and custom-recipe guidance
+- Troubleshooting
 
 Local-path marketplaces work the same as git-hosted ones. When satisfied, push to GitHub and let users install from `shawn-sandy/acss-plugins`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ See [GUIDE.md](./GUIDE.md) for the full end-user guide — install, choose a plu
 /plugin install acss-kit-builder@shawn-sandy-acss-plugins
 ```
 
+## Testing locally
+
+Contributors can smoke-test plugin changes against a disposable sandbox without leaking artifacts into the repo:
+
+```sh
+tests/setup.sh
+cd tests/sandbox && claude
+```
+
+The sandbox is gitignored. See [`tests/README.md`](./tests/README.md) for the full workflow, the `--reset` flag, and troubleshooting.
+
 ## Relationship to the main fpkit repo
 
 Plugin development references the live fpkit source at [`shawn-sandy/acss`](https://github.com/shawn-sandy/acss). Contributors should keep both repos available side-by-side — see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the workflow.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,206 @@
+# Local plugin testing
+
+Smoke-test the plugins in this marketplace by installing them into a disposable Vite + React + TypeScript sandbox.
+
+The sandbox lives at `tests/sandbox/` and is **gitignored** — it never lands in commits or PRs. Only the scaffolding (`setup.sh`, this file) is committed, so any contributor can recreate the same starting point with one command.
+
+## Contents
+
+1. [Prerequisites](#prerequisites)
+2. [One-shot setup](#one-shot-setup)
+3. [Running the recipe](#running-the-recipe)
+4. [Per-plugin smoke flows](#per-plugin-smoke-flows)
+5. [Verification checklist](#verification-checklist)
+6. [Reset](#reset)
+7. [Custom recipes](#custom-recipes)
+8. [What this does NOT cover](#what-this-does-not-cover)
+9. [Troubleshooting](#troubleshooting)
+
+## Prerequisites
+
+- **Node 20+** and **npm** on `PATH`
+- **Claude Code CLI** (`claude`) on `PATH` — `claude --version` should print >= 1.0.33
+
+## One-shot setup
+
+From the repo root:
+
+```sh
+tests/setup.sh
+```
+
+The script:
+
+1. Verifies `node`, `npm`, and that you're inside the acss-plugins repo (looks for `.claude-plugin/marketplace.json`).
+2. Scaffolds a fresh Vite + React + TypeScript project at `tests/sandbox/`.
+3. Installs `sass` (every plugin that writes SCSS depends on it).
+4. Initializes a git repo inside the sandbox and makes one bootstrap commit, so plugin "dirty-tree" guards have a clean anchor for the developer's first run.
+5. Writes `tests/sandbox/RECIPE.md` and prints the same recipe to stdout.
+
+Re-running without `--reset` errors out with a hint — see [Reset](#reset).
+
+## Running the recipe
+
+```sh
+cd tests/sandbox
+claude
+```
+
+Inside the Claude Code session, paste the block from `RECIPE.md` (or the script's stdout). It registers the local marketplace and installs all four plugins:
+
+```
+/plugin marketplace add <absolute path printed by the script>
+/plugin install acss-app-builder@acss-plugins
+/plugin install acss-kit-builder@acss-plugins
+/plugin install acss-theme-builder@acss-plugins
+/plugin install acss-component-specs@acss-plugins
+```
+
+The marketplace name suffix is `acss-plugins` (the `name` field in `marketplace.json`) — different from the GitHub-source form (`shawn-sandy-acss-plugins`) shown in the root [README.md](../README.md).
+
+Then exercise plugins per the flows below.
+
+## Per-plugin smoke flows
+
+These are the minimum runs that prove a plugin's core paths work after a code change. Run them in the order shown — `/app-init` bootstraps the structure that the other plugins write into.
+
+### acss-app-builder
+
+```
+/app-init
+/app-page dashboard
+/app-layout sidebar
+/app-form contact
+/app-pattern data-table
+```
+
+What to verify:
+
+- `/app-init` creates `src/app/`, `src/pages/`, `src/styles/theme/`, and updates `src/main.tsx` with theme imports.
+- `/app-page dashboard` writes `src/pages/Dashboard.tsx`.
+- `/app-layout sidebar` writes `src/app/AppShell.tsx` + `AppShell.scss` and updates the entry file.
+- `/app-form contact` writes `src/forms/ContactForm.tsx` (or similar — check argument hint).
+- `/app-pattern data-table` writes `src/patterns/DataTable.tsx`.
+
+Read [`plugins/acss-app-builder/README.md`](../plugins/acss-app-builder/README.md) for the full command reference.
+
+### acss-kit-builder
+
+```
+/kit-list
+/kit-add badge
+/kit-add button card
+```
+
+What to verify:
+
+- `/kit-list` is read-only — prints the component catalog with no file changes.
+- `/kit-add badge` creates `src/components/fpkit/badge/badge.tsx` + `badge.scss`, plus `src/components/fpkit/ui.tsx` (re-exports) on first run, plus `.acss-target.json` config.
+- `/kit-add button card` adds two components in one invocation.
+
+### acss-theme-builder
+
+```
+/theme-create "#4f46e5"
+/theme-update src/styles/theme/light.css --color-primary="#2563eb"
+/theme-brand forest --from="#0f766e"
+```
+
+What to verify:
+
+- `/theme-create "#4f46e5"` creates both `src/styles/theme/light.css` and `dark.css` with WCAG-AA contrast for all 10 semantic role pairs. Watch for the validation summary in the response.
+- `/theme-update` edits an existing theme file in place and re-validates contrast — if a change drops below AA, it reverts and reports.
+- `/theme-brand forest` creates `src/styles/theme/brand-forest.css` with light/dark overrides scoped to `[data-brand="forest"]`.
+
+### acss-component-specs
+
+```
+/spec-list
+/spec-validate
+/spec-render button --target=react
+```
+
+What to verify:
+
+- `/spec-list` prints the spec catalog (Button, Card, Dialog, Alert, Stack, Nav).
+- `/spec-validate` runs schema + stale-stamp validation against all specs and exits with a JSON summary.
+- `/spec-render button --target=react` writes a React + SCSS rendering of the Button spec into the project (path depends on plugin config).
+
+## Verification checklist
+
+After running a smoke flow, check:
+
+- [ ] No errors in the Claude Code session output.
+- [ ] The expected files appear under `src/` (per the per-plugin flows above).
+- [ ] `npm run build` in the sandbox succeeds (catches type errors and broken SCSS imports). This is the most reliable sanity check after generated-code changes.
+- [ ] `git status` inside the sandbox shows only the new files you'd expect — nothing modified outside the plugin's documented surface.
+- [ ] `git diff src/main.tsx` (or `src/index.tsx`) shows clean import additions when a plugin updates the entry file (no duplicate or orphan imports).
+
+If any check fails, capture the Claude Code response and the file diff in the issue or PR description.
+
+## Reset
+
+```sh
+tests/setup.sh --reset
+```
+
+Wipes and recreates `tests/sandbox/`. Use this:
+
+- Between unrelated test sessions to avoid cross-contamination.
+- When a plugin run leaves the sandbox in a state you can't easily reverse.
+- After pulling new plugin changes that affect bootstrap behavior (e.g. `/app-init` adds a new entry-file import).
+
+`--reset` is the only cleanup mechanism — there is no separate `clean.sh`. The sandbox is fully self-contained and removable without affecting anything else in the repo.
+
+## Custom recipes
+
+The default `RECIPE.md` lives inside the sandbox and is gitignored (transitively, via the `tests/sandbox/` rule). You can:
+
+- **Edit it freely.** It's regenerated on `--reset`, so don't store anything you can't reproduce.
+- **Save curated flows** as additional files alongside it (e.g. `tests/sandbox/recipe-theme-only.md`) — also gitignored.
+- **Pin a recipe across resets** by keeping it as a personal note in `CLAUDE.local.md` (committed-ignore) or in your shell history.
+
+For sharing a recipe with other contributors, propose adding it as a **Next Steps** item in a PR description, or open an issue. The repo intentionally avoids a `tests/recipes/` directory until there's a proven need for multiple curated flows.
+
+## What this does NOT cover
+
+- **Python script tests** — for the validation/detection scripts under `plugins/*/scripts/`, use the [`/review-script`](../plugins/) and `/review-scripts` skills (defined globally in your Claude Code setup).
+- **Static plugin validation** — for manifest, SKILL.md, and structural checks, use `/validate-plugin <plugin>` or `/verify-plugins` (sweeps all plugins).
+- **Automated assertions on slash command output** — review side effects manually inside the sandbox. There is no headless command harness; running the plugins requires a live Claude Code session.
+- **Cross-plugin integration tests** — the smoke flows above hit one plugin at a time. The shared sandbox enables ad-hoc multi-plugin sequences (e.g. `/app-init` → `/kit-add badge` → `/app-pattern data-table`), but those are exercised by the developer, not by an automated runner.
+
+## Troubleshooting
+
+**`Run this script from inside the acss-plugins repo`**
+The script is invoked from a path where it can't find `.claude-plugin/marketplace.json`. `cd` to the repo root and re-run.
+
+**`Sandbox already exists at: <path>. Re-run with --reset to wipe and recreate it.`**
+Expected behavior on second run. Pass `--reset` if you want a clean rebuild; otherwise keep working in the existing sandbox.
+
+**`/plugin marketplace add` fails with "could not load"**
+The recipe uses an absolute path. If you copied `RECIPE.md` from another machine or moved the repo, run `tests/setup.sh --reset` to regenerate `RECIPE.md` with the correct path.
+
+**`/plugin install acss-app-builder@acss-plugins` says "not found"**
+When the marketplace is added from a local path, Claude Code uses the `name` field from `marketplace.json` as the suffix. Confirm with `/plugin marketplace list` — if the suffix differs (some Claude Code versions normalize differently), use what's listed there.
+
+**Plugin command refuses with "dirty tree"**
+The bootstrap commit should prevent this on first run. If you've already executed commands and re-run a plugin that checks the tree, commit your work-in-progress first:
+```sh
+cd tests/sandbox && git add -A && git commit -m "wip"
+```
+Or pass `--force` if the command supports it.
+
+**`npm create vite@latest` hangs at "Ok to proceed?"**
+The script sets `NPM_CONFIG_YES=true` to skip this prompt. If you've shadowed it in your shell or your npm version handles env vars differently, run:
+```sh
+echo "yes" | tests/setup.sh
+```
+
+**`sass` fails to install**
+`tests/sandbox/` runs its own `npm install`. If your machine has a registry-blocking firewall or a stale npm cache, clear it:
+```sh
+cd tests/sandbox && npm cache clean --force && npm install
+```
+
+**Stray nested directory created at `<repo>/Users/...`**
+A symptom of an older `create-vite` mishandling absolute paths. The current `setup.sh` works around this by `cd`-ing to `tests/` and passing a bare directory name. If you see this, you're running an outdated copy of the script — `git pull` and re-run.

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,8 +95,8 @@ Read [`plugins/acss-app-builder/README.md`](../plugins/acss-app-builder/README.m
 What to verify:
 
 - `/kit-list` is read-only — prints the component catalog with no file changes.
-- `/kit-add badge` creates `src/components/fpkit/badge/badge.tsx` + `badge.scss`, plus `src/components/fpkit/ui.tsx` (re-exports) on first run, plus `.acss-target.json` config.
-- `/kit-add button card` adds two components in one invocation.
+- `/kit-add badge` creates `<componentsDir>/badge/badge.tsx` + `badge.scss`, plus `<componentsDir>/ui.tsx` (re-exports) and a top-level `.acss-target.json` recording the chosen path on first run. `<componentsDir>` defaults to `src/components/fpkit/` and is configurable on first run.
+- `/kit-add button card` adds two components in one invocation under the same `<componentsDir>`.
 
 ### acss-theme-builder
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Scaffold a disposable Vite + React + TypeScript sandbox at tests/sandbox/
+# for smoke-testing the acss-plugins marketplace locally.
+#
+# Usage:
+#   tests/setup.sh           # first-time setup (errors if sandbox exists)
+#   tests/setup.sh --reset   # wipe and recreate the sandbox
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SANDBOX="$REPO_ROOT/tests/sandbox"
+RESET=0
+
+if [[ "${1:-}" == "--reset" ]]; then
+  RESET=1
+elif [[ -n "${1:-}" ]]; then
+  echo "Unknown argument: $1" >&2
+  echo "Usage: tests/setup.sh [--reset]" >&2
+  exit 1
+fi
+
+# --- Preflight -----------------------------------------------------------
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: 'node' not found on PATH." >&2
+  echo "Install Node 20+ from https://nodejs.org or via your version manager." >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: 'npm' not found on PATH." >&2
+  exit 1
+fi
+
+if [[ ! -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
+  echo "Error: marketplace.json not found at $REPO_ROOT/.claude-plugin/" >&2
+  echo "Run this script from inside the acss-plugins repo." >&2
+  exit 1
+fi
+
+if [[ -d "$SANDBOX" && "$RESET" -eq 0 ]]; then
+  echo "Sandbox already exists at: $SANDBOX"
+  echo "Re-run with --reset to wipe and recreate it."
+  exit 1
+fi
+
+# --- Scaffold ------------------------------------------------------------
+
+if [[ -d "$SANDBOX" ]]; then
+  echo "Removing existing sandbox..."
+  rm -rf "$SANDBOX"
+fi
+
+mkdir -p "$REPO_ROOT/tests"
+
+echo "Scaffolding Vite + React + TypeScript at $SANDBOX..."
+# create-vite mishandles absolute paths in some versions (it treats them as relative
+# to cwd, producing a nested duplicate). Workaround: cd to the parent and pass a
+# bare directory name. NPM_CONFIG_YES skips the "Ok to proceed?" exec prompt.
+cd "$REPO_ROOT/tests"
+NPM_CONFIG_YES=true npm create vite@latest sandbox -- --template react-ts
+
+cd "$SANDBOX"
+
+echo "Installing dependencies..."
+npm install --silent
+
+echo "Adding sass (required by every acss plugin that writes SCSS)..."
+npm install --silent --save-dev sass
+
+# --- Bootstrap commit ----------------------------------------------------
+# Some plugin commands refuse to run on a dirty tree. Initializing a git repo
+# with one commit gives those guards a clean anchor for the developer's first run.
+
+echo "Initializing git and committing the bootstrap state..."
+git init -q
+git add -A
+git commit -q -m "initial sandbox"
+
+# --- Recipe --------------------------------------------------------------
+
+cat > "$SANDBOX/RECIPE.md" <<EOF
+# Local plugin testing recipe
+
+This sandbox is a disposable Vite + React + TypeScript project. From here:
+
+\`\`\`
+claude
+\`\`\`
+
+Inside the Claude Code session, paste these commands:
+
+\`\`\`
+/plugin marketplace add $REPO_ROOT
+/plugin install acss-app-builder@acss-plugins
+/plugin install acss-kit-builder@acss-plugins
+/plugin install acss-theme-builder@acss-plugins
+/plugin install acss-component-specs@acss-plugins
+\`\`\`
+
+Then exercise the plugins. Suggested smoke flow:
+
+\`\`\`
+/app-init
+/app-page dashboard
+/theme-create "#4f46e5"
+/kit-add badge
+\`\`\`
+
+Verify file changes appear under \`src/\` (\`app/\`, \`pages/\`, \`styles/theme/\`, \`components/fpkit/\`).
+
+Reset this sandbox with:
+\`\`\`
+$REPO_ROOT/tests/setup.sh --reset
+\`\`\`
+EOF
+
+echo ""
+echo "================================================================"
+cat "$SANDBOX/RECIPE.md"
+echo "================================================================"
+echo ""
+echo "Sandbox ready. cd tests/sandbox && claude"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -12,13 +12,19 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SANDBOX="$REPO_ROOT/tests/sandbox"
 RESET=0
 
-if [[ "${1:-}" == "--reset" ]]; then
-  RESET=1
-elif [[ -n "${1:-}" ]]; then
-  echo "Unknown argument: $1" >&2
+if [[ $# -gt 1 ]]; then
+  echo "Too many arguments: $*" >&2
   echo "Usage: tests/setup.sh [--reset]" >&2
   exit 1
 fi
+
+case "${1:-}" in
+  --reset) RESET=1 ;;
+  "")      ;;
+  *)       echo "Unknown argument: $1" >&2
+           echo "Usage: tests/setup.sh [--reset]" >&2
+           exit 1 ;;
+esac
 
 # --- Preflight -----------------------------------------------------------
 
@@ -30,6 +36,12 @@ fi
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "Error: 'npm' not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: 'git' not found on PATH." >&2
+  echo "git is required for the bootstrap commit inside the sandbox." >&2
   exit 1
 fi
 
@@ -96,10 +108,10 @@ This sandbox is a disposable Vite + React + TypeScript project. From here:
 claude
 \`\`\`
 
-Inside the Claude Code session, paste these commands:
+Inside the Claude Code session, paste these commands (the path is quoted so it works even if your repo lives under a directory with spaces):
 
 \`\`\`
-/plugin marketplace add $REPO_ROOT
+/plugin marketplace add "$REPO_ROOT"
 /plugin install acss-app-builder@acss-plugins
 /plugin install acss-kit-builder@acss-plugins
 /plugin install acss-theme-builder@acss-plugins
@@ -115,11 +127,11 @@ Then exercise the plugins. Suggested smoke flow:
 /kit-add badge
 \`\`\`
 
-Verify file changes appear under \`src/\` (\`app/\`, \`pages/\`, \`styles/theme/\`, \`components/fpkit/\`).
+Verify file changes appear under \`src/\`: \`app/\`, \`pages/\`, \`styles/theme/\`, plus your kit components directory (default: \`components/fpkit/\`, configurable on first \`/kit-add\` run via \`.acss-target.json\`).
 
 Reset this sandbox with:
 \`\`\`
-$REPO_ROOT/tests/setup.sh --reset
+"$REPO_ROOT/tests/setup.sh" --reset
 \`\`\`
 EOF
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -81,23 +81,11 @@ npm install --silent
 echo "Adding sass (required by every acss plugin that writes SCSS)..."
 npm install --silent --save-dev sass
 
-# --- Bootstrap commit ----------------------------------------------------
-# Some plugin commands refuse to run on a dirty tree. Initializing a git repo
-# with one commit gives those guards a clean anchor for the developer's first run.
-
-echo "Initializing git and committing the bootstrap state..."
-git init -q
-git add -A
-# Pass a synthetic identity scoped to this one commit so the script works on
-# fresh machines with no global user.name/user.email configured. The contributor's
-# normal git config still applies to any subsequent commits they make in the
-# sandbox (the -c flags only affect this single git invocation). The .invalid
-# TLD is reserved by RFC 2606 to signal a non-real address.
-git -c user.name="acss-plugins sandbox" \
-    -c user.email="sandbox@acss-plugins.invalid" \
-    commit -q -m "initial sandbox"
-
-# --- Recipe --------------------------------------------------------------
+# --- Recipe (written before commit so it's part of the bootstrap) --------
+# Generated first, ahead of the bootstrap commit, so RECIPE.md is included in
+# the initial commit. If we wrote it after, the sandbox would have an untracked
+# file from the start — defeating the "clean anchor" the bootstrap commit is
+# meant to provide for plugin dirty-tree guards.
 
 cat > "$SANDBOX/RECIPE.md" <<EOF
 # Local plugin testing recipe
@@ -127,13 +115,37 @@ Then exercise the plugins. Suggested smoke flow:
 /kit-add badge
 \`\`\`
 
-Verify file changes appear under \`src/\`: \`app/\`, \`pages/\`, \`styles/theme/\`, plus your kit components directory (default: \`components/fpkit/\`, configurable on first \`/kit-add\` run via \`.acss-target.json\`).
+Verify file changes appear under \`src/\`: \`app/\`, \`pages/\`, \`styles/theme/\`, plus your kit components directory (default: \`src/components/fpkit/\`, configurable on first \`/kit-add\` run via \`.acss-target.json\`).
 
 Reset this sandbox with:
 \`\`\`
 "$REPO_ROOT/tests/setup.sh" --reset
 \`\`\`
 EOF
+
+# --- Bootstrap commit ----------------------------------------------------
+# Some plugin commands refuse to run on a dirty tree. Initializing a git repo
+# with one commit (including RECIPE.md, written above) gives those guards a
+# clean anchor for the developer's first run.
+
+echo "Initializing git and committing the bootstrap state..."
+git init -q
+git add -A
+# Per-invocation -c flags cover three failure modes contributors hit on real
+# machines without polluting their global config:
+#   - synthetic identity: works on fresh machines with no user.name/user.email
+#   - commit.gpgsign=false: signing a synthetic identity would be misleading,
+#     and contributors who enforce signing globally would otherwise hard-fail
+#   - --no-verify: the bootstrap commit predates any project hooks the dev
+#     might add later; running pre-commit or commit-msg hooks against vite
+#     scaffolding output is not meaningful
+# The .invalid TLD is reserved by RFC 2606 to signal a non-real address.
+# Subsequent commits the contributor makes inside tests/sandbox/ use their
+# normal git config — the overrides only affect this one invocation.
+git -c user.name="acss-plugins sandbox" \
+    -c user.email="sandbox@acss-plugins.invalid" \
+    -c commit.gpgsign=false \
+    commit --no-verify -q -m "initial sandbox"
 
 echo ""
 echo "================================================================"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -76,7 +76,14 @@ npm install --silent --save-dev sass
 echo "Initializing git and committing the bootstrap state..."
 git init -q
 git add -A
-git commit -q -m "initial sandbox"
+# Pass a synthetic identity scoped to this one commit so the script works on
+# fresh machines with no global user.name/user.email configured. The contributor's
+# normal git config still applies to any subsequent commits they make in the
+# sandbox (the -c flags only affect this single git invocation). The .invalid
+# TLD is reserved by RFC 2606 to signal a non-real address.
+git -c user.name="acss-plugins sandbox" \
+    -c user.email="sandbox@acss-plugins.invalid" \
+    commit -q -m "initial sandbox"
 
 # --- Recipe --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `tests/setup.sh` (executable) and `tests/README.md` so any contributor can scaffold a disposable Vite + React + TS sandbox at `tests/sandbox/` in one command, install the local marketplace, and exercise plugin slash commands. Sandbox stays gitignored; only the scaffolding is committed.
- Consolidates the testing workflow into a single source of truth — `README.md`, `CLAUDE.md`, and `CONTRIBUTING.md` now point at `tests/README.md` instead of duplicating the install snippet.
- Per-plugin smoke flows documented for all four plugins (`acss-app-builder`, `acss-kit-builder`, `acss-theme-builder`, `acss-component-specs`) with explicit "what to verify" lists and an `npm run build` checkpoint.

## What's in `tests/`

| File | Purpose | Committed? |
|---|---|---|
| `tests/setup.sh` | bash script: preflight, scaffold Vite, install sass, bootstrap commit, print recipe | yes (executable) |
| `tests/README.md` | runbook + per-plugin smoke flows + verification checklist + troubleshooting | yes |
| `tests/sandbox/` | the disposable Vite project (created by the script) | gitignored |
| `tests/sandbox/RECIPE.md` | written by `setup.sh`; same recipe as stdout | gitignored (transitively) |

## Notable bug worked around

`create-vite` (current versions) interprets the absolute-path positional argument as relative to cwd, producing a nested duplicate (e.g. `<repo>/Users/.../tests/sandbox/`). `setup.sh` works around this by `cd`-ing to `tests/` and passing a bare `sandbox` directory name. Caught during end-to-end verification — comment in the script explains it.

## What this does NOT cover (intentional, deferred)

- Python script unit tests for `plugins/*/scripts/`
- CI smoke runner (Claude Code can't run in CI)
- Per-plugin assertion fixtures / snapshot diffs
- A curated `tests/recipes/` directory

These are listed as Next Steps in the plan file at `~/.claude/plans/i-want-to-create-indexed-seahorse.md`.

## Test plan

- [ ] `tests/setup.sh` from the repo root: scaffolding completes, `tests/sandbox/` exists with `package.json`, `node_modules/`, `src/`, `RECIPE.md`.
- [ ] `git status` shows zero new tracked files inside `tests/sandbox/` (the directory is ignored).
- [ ] `tests/setup.sh` re-run without `--reset` errors with a hint pointing at `--reset`.
- [ ] `tests/setup.sh --reset` rebuilds the sandbox cleanly.
- [ ] `tests/setup.sh --bogus` rejects unknown args with a usage line.
- [ ] `cd tests/sandbox && claude`, paste the recipe, confirm `/plugin marketplace add <REPO_ROOT>` succeeds and `/plugin install acss-app-builder@acss-plugins` resolves. (Verifies the local-marketplace install suffix.)
- [ ] Run `/app-init` in the sandbox; confirm `src/app/`, `src/styles/theme/`, etc. appear.
- [ ] Run `npm run build` inside `tests/sandbox/` after a smoke flow — expect a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)