### PR TITLE
feat: add AGENTS.md and .agents/ skills for Codex compatibility

### DIFF
--- a/.agents/skills/add-command/SKILL.md
+++ b/.agents/skills/add-command/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: add-command
+description: Scaffold a new slash command for a plugin — creates the command .md with front-matter and adds a stub section to SKILL.md.
+disable-model-invocation: false
+---
+
+# /add-command
+
+Usage: `/add-command <plugin-name> <command-name>`
+
+Example: `/add-command acss-app-builder app-export`
+
+## Steps
+
+1. **Validate inputs** — confirm `<plugin-name>` is one of the existing plugin directories. If `<command-name>` already exists in `commands/`, stop and warn.
+
+2. **Ask the user** (via AskUserQuestion):
+   - One-line description of what the command does
+   - Argument hint (e.g., `<name> [--force]`) — leave empty if none
+   - Which tools the command needs (default: `Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion`)
+
+3. **Create `<plugin>/commands/<command-name>.md`**:
+
+```markdown
+---
+description: <user's description>
+argument-hint: <argument-hint>
+allowed-tools: <tools>
+---
+
+<One sentence summary of what this command does.>
+
+Follow the `/<command-name>` workflow in the plugin's master SKILL.md:
+`.Codex/plugins/<plugin>/skills/<plugin>/SKILL.md`
+
+**Quick checklist:**
+
+1. TODO — fill in steps
+2. ...
+
+**Safety:** refuse on dirty git tree and on any existing non-empty target file unless `--force`.
+```
+
+4. **Add a stub section to `<plugin>/skills/<plugin>/SKILL.md`** at the end of the file:
+
+```markdown
+## /<command-name>
+
+> TODO: implement this workflow
+
+### Steps
+
+1. ...
+```
+
+5. **Print a summary**:
+   - Files created/modified
+   - Reminder: "Fill in the SKILL.md stub and the command checklist before testing."
+
+Do not implement the command logic. The user fills in the SKILL.md stub.

--- a/.agents/skills/release-check/SKILL.md
+++ b/.agents/skills/release-check/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: release-check
+description: Audit release paperwork for a plugin before opening a PR — confirms version bump, CHANGELOG, and README are all touched when they should be.
+argument-hint: <plugin-name>
+disable-model-invocation: false
+---
+
+# /release-check
+
+Usage: `/release-check <plugin-name>`
+
+Example: `/release-check acss-app-builder`
+
+This skill audits whether the release paperwork is complete on the current branch. It does **not** perform the version bump — use `/release-plugin <name> <version>` for that. Run this after `/release-plugin` and before opening a PR.
+
+## Steps
+
+### 1. Confirm plugin exists
+
+Verify `$ARGUMENTS` matches a directory under `plugins/`. If not, list available plugins and stop.
+
+### 2. Diff main...HEAD for the plugin
+
+```bash
+git diff main...HEAD --name-only -- plugins/<plugin>/
+```
+
+Collect the list of changed files scoped to `plugins/<plugin>/`.
+
+### 3. Check version bump
+
+- Attempt to read `plugins/<plugin>/.Codex-plugin/plugin.json` from `main` via `git show main:plugins/<plugin>/.Codex-plugin/plugin.json`.
+- If the command exits non-zero (file does not exist on `main`): PASS with note "New plugin — initial version establishes the baseline." Skip the version-diff check.
+- Otherwise read the same file from `HEAD` and compare `version` fields.
+- PASS if the `version` field differs between `main` and `HEAD`.
+- FAIL if version is unchanged: "plugin.json version not bumped — run `/release-plugin <name> <new-version>` first."
+
+### 4. Check CHANGELOG touched
+
+- PASS if `plugins/<plugin>/CHANGELOG.md` appears in the diff from step 2.
+- FAIL if absent: "CHANGELOG.md not updated — add an entry for this release."
+
+### 5. Check README updated when commands or SKILL changed
+
+If any of these paths are in the diff:
+
+- `plugins/<plugin>/commands/*.md`
+- `plugins/<plugin>/skills/<plugin>/SKILL.md`
+
+Then `plugins/<plugin>/README.md` must also be in the diff.
+
+- PASS if README is touched or none of the trigger paths changed.
+- FAIL if trigger paths changed but README did not: "commands/ or SKILL.md changed — update README.md to reflect new behavior."
+
+### 6. Check marketplace.json description (informational)
+
+The root marketplace.json lives at `.Codex-plugin/marketplace.json` — not inside the plugin directory — so it never appears in the scoped diff from step 2. Run a separate unscoped diff:
+
+```bash
+git diff main...HEAD --name-only
+```
+
+If `.Codex-plugin/marketplace.json` appears in this diff, note it as touched. If not touched, remind: "Consider updating `.Codex-plugin/marketplace.json` description if this change is user-facing."
+
+## Output
+
+Print a checklist:
+
+```
+Release checklist for acss-app-builder (main...HEAD)
+
+  [PASS] plugin.json version bumped (0.2.1 → 0.3.0)
+  [FAIL] CHANGELOG.md not updated
+  [PASS] README.md updated alongside command changes
+  [INFO] marketplace.json not touched — update description if change is user-facing
+
+1 item needs attention before opening a PR.
+```
+
+If all required checks pass: "Release paperwork complete. Ready to open a PR."
+
+Do not commit, push, or open the PR — leave that to the user or `/ship`.

--- a/.agents/skills/release-plugin/SKILL.md
+++ b/.agents/skills/release-plugin/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: release-plugin
+description: Bump a plugin's version in plugin.json and update marketplace.json description if needed. Run before committing a publishable change.
+disable-model-invocation: false
+---
+
+# /release-plugin
+
+Usage: `/release-plugin <plugin-name> <new-version>`
+
+Example: `/release-plugin acss-app-builder 0.1.2`
+
+## Steps
+
+1. **Confirm the plugin exists** — verify `$ARGUMENTS` matches one of: `acss-app-builder`, `acss-kit-builder`, `fpkit-developer`. If not, list available plugins and stop.
+
+2. **Read current version** from `<plugin>/.Codex-plugin/plugin.json`.
+
+3. **Validate the new version** — must be a valid semver string (`MAJOR.MINOR.PATCH`). Refuse if not.
+
+4. **Bump `plugin.json`** — update the `"version"` field in `<plugin>/.Codex-plugin/plugin.json`.
+
+5. **Check marketplace.json** — read `.Codex-plugin/marketplace.json`. If the matching plugin entry contains a `"version"` key, **remove it** and warn the user ("marketplace.json should not have a version field — the plugin.json always wins").
+
+6. **Ask the user** if the marketplace.json `description` for this plugin needs updating to reflect the change. If yes, update it.
+
+7. **Print a pre-commit summary**:
+   - Plugin bumped: `<plugin>` `<old>` → `<new>`
+   - Files modified: list them
+   - Reminder: "Run the pre-submit checklist in AGENTS.md before committing."
+
+Do not commit. Do not push. Leave that to the user.

--- a/.agents/skills/validate-plugin/SKILL.md
+++ b/.agents/skills/validate-plugin/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: validate-plugin
+description: Check a plugin's structure for completeness and correctness before publishing. Catches common issues like missing files, repo-relative fpkit links, or malformed JSON.
+disable-model-invocation: false
+---
+
+# /validate-plugin
+
+Usage: `/validate-plugin <plugin-name>`
+
+Example: `/validate-plugin acss-kit-builder`
+
+## Checks
+
+Run each check in order. Report all failures at the end, not one at a time.
+
+### 1. Manifest
+- `<plugin>/.Codex-plugin/plugin.json` exists and is valid JSON
+- Required fields present: `name`, `description`, `version`, `author`, `license`
+- `version` is a valid semver string
+- `claudeCodeMinVersion` is present (warn if missing, don't fail)
+
+### 2. Marketplace entry
+- `.Codex-plugin/marketplace.json` has an entry matching the plugin name
+- The entry does **not** have a `"version"` field (this causes silent conflicts)
+- `description` is non-empty
+
+### 3. Required files
+- `README.md` exists
+- `commands/` directory exists and contains at least one `.md` file
+- `skills/<plugin>/SKILL.md` exists
+
+### 4. Command files
+For each `commands/*.md`:
+- Has valid YAML front-matter with `description` and `allowed-tools` fields
+- Body references `SKILL.md` (not re-implements logic inline)
+- Does not contain repo-relative paths to fpkit source (e.g., `../../acss/`)
+
+### 5. SKILL.md references
+- No repo-relative fpkit source links — all fpkit references must be full GitHub URLs (`https://github.com/shawn-sandy/acss/...`)
+- Each command mentioned in the SKILL.md has a corresponding `commands/*.md` file
+
+### 6. Python scripts (if present)
+- Run `python3 -m py_compile <script>` on each `.py` file in `scripts/` or `<plugin>/scripts/`
+- Report any syntax errors
+
+### 7. Assets
+- If `assets/` exists, verify no `.tmpl` files contain un-substituted `{{PLACEHOLDER}}` tokens that look like they were accidentally left from a copy-paste (i.e., tokens that don't follow the `{{ALL_CAPS}}` convention)
+
+## Output
+
+Print a summary table:
+```
+PASS  Manifest fields
+PASS  Marketplace entry
+FAIL  Command files — app-init.md missing allowed-tools front-matter
+PASS  SKILL.md references
+...
+```
+
+Exit with a count of failures. If zero failures: "Plugin <name> is ready to publish."

--- a/.agents/skills/verify-plugins/SKILL.md
+++ b/.agents/skills/verify-plugins/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: verify-plugins
+description: Run structural validation across all plugins in the repo. Reports pass/fail per plugin without requiring a plugin name argument.
+disable-model-invocation: false
+---
+
+# /verify-plugins
+
+Usage: `/verify-plugins`
+
+Scans every directory under `plugins/` and reports pass/fail for each. No argument needed — this is a repo-wide sweep, not a single-plugin check.
+
+## What this skill does vs. /validate-plugin
+
+`/validate-plugin <name>` does deep per-plugin validation (semver strings, command bodies, fpkit URL checks, Python syntax). Use it before publishing a specific plugin.
+
+`/verify-plugins` is a fast structural sweep — catches missing manifests, forbidden `version` keys, and absent required files across all plugins at once. Run it after branching or merging to confirm nothing regressed.
+
+## Checks (per plugin)
+
+Run these in order for each `plugins/*/` directory.
+
+### 1. Manifest exists and has required fields
+
+```bash
+jq -e '(.name | type == "string" and length > 0) and (.version | type == "string" and length > 0) and (.description | type == "string" and length > 0)' plugins/<plugin>/.Codex-plugin/plugin.json
+```
+
+- PASS if file exists and all three fields are non-null/non-empty strings.
+- FAIL if file is missing or any field is absent or empty.
+
+### 2. Marketplace entry has no `version` key
+
+Read `.Codex-plugin/marketplace.json`. Run two checks in sequence.
+
+First, verify the entry exists:
+
+```bash
+jq -e --arg p "<plugin>" '.plugins | map(.name) | index($p) != null' .Codex-plugin/marketplace.json
+```
+
+- FAIL if entry is absent: "marketplace.json has no entry for <plugin> — add one."
+- If absent, skip the next check for this plugin.
+
+Then, verify no `version` key:
+
+```bash
+jq -e '.plugins[] | select(.name == "<plugin>") | has("version") | not' .Codex-plugin/marketplace.json
+```
+
+- PASS if no `version` key present.
+- FAIL with message: "marketplace.json entry for <plugin> carries a `version` key — remove it (plugin.json always wins)."
+
+### 3. Required files present
+
+Check that each of these paths exists:
+
+- `plugins/<plugin>/README.md`
+- `plugins/<plugin>/skills/<plugin>/SKILL.md`
+- `plugins/<plugin>/commands/` directory containing at least one `.md` file
+
+Report each missing path as a separate FAIL line.
+
+### 4. Delegate deep checks (optional)
+
+After the structural sweep, offer: "Run `/validate-plugin <name>` for a full pre-publish check on any plugin above."
+
+Do not re-implement the logic from `validate-plugin` — keep this skill fast and structural only.
+
+## Output format
+
+```
+plugins/acss-app-builder
+  PASS  Manifest fields (name, version, description)
+  PASS  Marketplace entry has no version key
+  PASS  README.md present
+  PASS  skills/acss-app-builder/SKILL.md present
+  PASS  commands/ has .md files
+
+plugins/acss-kit-builder
+  PASS  Manifest fields (name, version, description)
+  FAIL  Marketplace entry has a version key — remove it
+  PASS  README.md present
+  ...
+
+Summary: 2 plugins checked, 1 failure total.
+```
+
+If all pass: "All plugins passed structural checks."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## What this repo is
+
+A Codex **plugin marketplace** — not a Node.js or Python package. There are no build scripts, no `npm install`, and no CI pipeline.
+
+**Stack:** Codex plugin format, Python 3 (scripts), SCSS/CSS custom properties (generated output).
+
+The repo contains three plugins:
+
+- `plugins/acss-app-builder` — scaffolds Vite+React+TS apps with the fpkit design system
+- `plugins/acss-kit-builder` — generates fpkit-style components without an npm install
+- `plugins/acss-theme-builder` — generates and updates CSS themes for fpkit/acss projects
+
+Install plugins from a Codex session:
+```
+/plugin marketplace add shawn-sandy/acss-plugins
+/plugin install acss-app-builder@shawn-sandy-acss-plugins
+```
+
+## Plugin structure
+
+Every plugin lives under `plugins/` and follows this layout:
+
+```
+plugins/<plugin>/
+├── .Codex-plugin/plugin.json   # manifest — authoritative version source
+├── README.md                    # user-facing docs
+├── commands/*.md                # slash command definitions (YAML front-matter)
+├── skills/<plugin>/SKILL.md     # master skill invoked by Codex
+├── skills/<plugin>/references/  # knowledge base documents
+└── assets/                      # templates and code snippets
+```
+
+### Command file front-matter
+
+```yaml
+---
+description: <one-line description>
+argument-hint: [--option] [--force]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+```
+
+Body delegates to the master SKILL.md, never re-implements logic inline.
+
+## Version bumps
+
+Plugin versions live in **two places** — keep them in sync:
+
+- `<plugin>/.Codex-plugin/plugin.json` — **authoritative**; Codex and `/plugin update` read this
+- `.Codex-plugin/marketplace.json` — **omit the `version` field here** (the manifest always wins silently)
+
+Bump only `plugin.json`. Do not add a `version` key to `marketplace.json` entries.
+
+## Pre-submit checklist
+
+Before committing any plugin change:
+
+1. `plugin.json` version bumped (use `/release-plugin <plugin-name>`)
+2. All SKILL.md references to fpkit source use full GitHub URLs, not repo-relative paths
+3. `marketplace.json` description updated if the change is user-facing
+4. Plugin-level `README.md` updated if commands or behavior changed
+
+## Git workflow
+
+Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direct commits to `main` for plugin changes.
+
+`.Codex/worktrees/` is Codex session scratch — ignored by git.
+
+`Codex.local.md` (not committed) — use for machine-local or personal overrides.
+
+## Testing locally
+
+```bash
+# In a disposable project or Codex test session:
+/plugin marketplace add /absolute/path/to/acss-plugins
+/plugin install acss-app-builder@<local-marketplace-name>
+```
+
+Full validation: manual SKILL.md review → local install → smoke-test slash commands → run Python scripts against a sample project.
+
+## Python scripts
+
+Scripts in `plugins/acss-app-builder/scripts/` follow this contract:
+
+- Python 3 stdlib only, no external dependencies
+- Output JSON to stdout
+- Exit 0 on success, 1 on failure
+- Include a `"reasons"` array in JSON output for human-readable error messages
+
+See `plugins/acss-app-builder/scripts/` for the current script list and individual docstrings.
+
+## fpkit/acss cross-references
+
+All references to fpkit source in SKILL.md and reference docs must use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/...`). This allows plugin users and contributors to click through without a local clone.
+
+For contributors editing reference docs: keep `shawn-sandy/acss` cloned as a sibling directory for local verification — see `CONTRIBUTING.md`.


### PR DESCRIPTION
This pull request adds comprehensive documentation and validation skills for managing Codex plugins in the repository. It introduces new SKILL.md files for several automation tasks (like release checks, plugin validation, and command scaffolding), and centralizes best practices and structure requirements in a new `AGENTS.md` file. These changes aim to standardize plugin development, ensure release consistency, and reduce errors before publishing.

**Documentation and guidelines:**

* Added `AGENTS.md` to provide detailed guidance on repo purpose, plugin structure, versioning, pre-submit checklist, git workflow, local testing, Python script conventions, and fpkit cross-referencing requirements.

**New and improved skills for plugin management:**

* Introduced `/release-plugin` skill to automate plugin version bumps, ensure `marketplace.json` is updated correctly, and prompt for description updates.
* Added `/release-check` skill to audit release paperwork, confirming version bumps, CHANGELOG, and README updates before opening a PR.
* Added `/validate-plugin` skill for deep validation of a plugin’s structure, manifest, command files, SKILL.md, Python scripts, and assets before publishing.
* Added `/verify-plugins` skill for fast, repo-wide structural validation of all plugins, checking for required files and forbidden manifest fields.
* Added `/add-command` skill to scaffold new slash commands, create command files with proper front-matter, and insert stubs into the plugin’s SKILL.md.