### PR TITLE
feat(tooling): component & theme lifecycle skills and reviewers

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -99,6 +99,92 @@ Reviewing: plugins/acss-theme-builder/scripts/generate_palette.py
 
 ---
 
+## component-reference-reviewer
+
+**File:** `component-reference-reviewer.md`
+
+Reviews a single component reference doc under `plugins/acss-kit/skills/components/references/components/<name>.md` against the canonical embedded-markdown shape and the catalog parity table. Pairs with the `/component-author` and `/component-update` skills.
+
+### Checks
+
+| Check | What it verifies |
+|---|---|
+| Verification banner | Top-of-file blockquote with `**Verified against fpkit source:**` and an `@fpkit/acss@<version>` reference |
+| Canonical sections | All nine sections present and in order (Overview → Generation Contract → Props Interface → TSX Template → CSS Variables → SCSS Template → Accessibility → Usage Examples) |
+| Generation Contract fields | `export_name`, `file`, `scss`, `imports`, `dependencies` all present |
+| fpkit URL hygiene | All `github.com/shawn-sandy/acss` URLs pin to a tag/SHA, never `blob/main` |
+| Catalog entry | Component appears in `catalog.md` "Verification Status" table |
+| TSX Template imports | Only `react`, `'../ui'`, and relative paths to vendored components — never `@fpkit/acss` |
+
+### When Claude invokes it automatically
+
+When you write or significantly edit a `references/components/<name>.md` file, or via the `/component-update` skill.
+
+### Manual invocation
+
+```
+/review-component plugins/acss-kit/skills/components/references/components/button.md
+```
+
+### Sample output
+
+```
+Reviewing: plugins/acss-kit/skills/components/references/components/button.md
+
+  [PASS] Verification banner
+  [PASS] Canonical sections
+  [PASS] Generation Contract fields
+  [PASS] fpkit URL hygiene
+  [PASS] Catalog entry
+  [PASS] TSX Template imports
+
+All checks passed — reference doc follows the canonical shape.
+```
+
+---
+
+## theme-reference-reviewer
+
+**File:** `theme-reference-reviewer.md`
+
+Reviews the acss-kit theme references and bundled brand presets for cross-source parity. Cross-checks role names, contrast pair definitions, and OKLCH algorithm constants between markdown documentation, the JSON schema, and the Python scripts. Pairs with the `/style-author`, `/style-update`, and `/plugin-health` skills.
+
+### Checks
+
+| Check | What it verifies |
+|---|---|
+| Role parity | Roles in `role-catalogue.md`, `theme.schema.json` `$defs.palette`, and `tokens_to_css.py:ROLE_GROUPS` are identical sets |
+| Required vs optional | Required-role annotations in markdown match the `required` array in `theme.schema.json` |
+| WCAG contrast pair parity | Contrast pair table in `styles/SKILL.md` matches `validate_theme.py:PAIRS` |
+| OKLCH algorithm parity | Lightness anchors and hue offsets in `palette-algorithm.md` match constants in `generate_palette.py` |
+| Bundled brand preset validation | Every `assets/brand-presets/*.css` passes `validate_theme.py` (SKIP if directory absent) |
+
+### When Claude invokes it automatically
+
+When you write or significantly edit `references/role-catalogue.md`, `references/palette-algorithm.md`, `references/theme-schema.md`, or `assets/theme.schema.json`.
+
+### Manual invocation
+
+```
+/review-themes
+```
+
+### Sample output
+
+```
+Reviewing: theme references
+
+  [PASS] Role parity
+  [PASS] Required vs optional consistency
+  [PASS] WCAG contrast pair parity
+  [PASS] OKLCH algorithm parity
+  [PASS] Bundled brand preset validation
+
+All checks passed — theme references are internally consistent.
+```
+
+---
+
 ## Adding a new agent
 
 1. Create `.claude/agents/<name>.md` with a YAML front-matter block:

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -116,9 +116,13 @@ Reviews a single component reference doc under `plugins/acss-kit/skills/componen
 | Catalog entry | Component appears in `catalog.md` "Verification Status" table |
 | TSX Template imports | Only `react`, `'../ui'`, and relative paths to vendored components — never `@fpkit/acss` |
 
-### When Claude invokes it automatically
+### How it gets invoked
 
-When you write or significantly edit a `references/components/<name>.md` file, or via the `/component-update` skill.
+Three triggers, none of them via a `settings.json` hook (no PostToolUse hook for component reference docs is currently wired):
+
+- **Model-invocation** — Claude routes to the agent when the request matches its `description` (e.g. authoring or editing a `references/components/<name>.md` file in a maintenance conversation).
+- **From the `/component-update` skill** — that skill explicitly delegates to this agent on every run.
+- **Manually via slash command** — `/review-component <path>` (see below).
 
 ### Manual invocation
 
@@ -159,9 +163,13 @@ Reviews the acss-kit theme references and bundled brand presets for cross-source
 | OKLCH algorithm parity | Lightness anchors and hue offsets in `palette-algorithm.md` match constants in `generate_palette.py` |
 | Bundled brand preset validation | Every `assets/brand-presets/*.css` passes `validate_theme.py` (SKIP if directory absent) |
 
-### When Claude invokes it automatically
+### How it gets invoked
 
-When you write or significantly edit `references/role-catalogue.md`, `references/palette-algorithm.md`, `references/theme-schema.md`, or `assets/theme.schema.json`.
+Three triggers, none of them via a `settings.json` hook (no PostToolUse hook for theme references is currently wired):
+
+- **Model-invocation** — Claude routes to the agent when the request matches its `description` (e.g. authoring or editing a file under `skills/styles/references/` or `assets/theme.schema.json` in a maintenance conversation).
+- **From the `/style-author`, `/style-update`, and `/plugin-health` skills** — each of those calls this agent during their own workflow.
+- **Manually via slash command** — `/review-themes` (no arguments).
 
 ### Manual invocation
 

--- a/.claude/agents/component-reference-reviewer.md
+++ b/.claude/agents/component-reference-reviewer.md
@@ -1,0 +1,96 @@
+---
+name: component-reference-reviewer
+description: Reviews a single component reference doc (plugins/acss-kit/skills/components/references/components/<name>.md) against the canonical embedded-markdown shape and the catalog.md verification table. Use when authoring or editing a component reference doc.
+---
+
+You are a component reference doc reviewer for the acss-plugins repository. When given a component reference doc path, read the file and the sibling `catalog.md`, then check all of the following. Report PASS or FAIL for each check with file:line citations on failures.
+
+## Canonical shape
+
+The canonical embedded-markdown shape for a component reference doc is documented in [`plugins/acss-kit/skills/components/SKILL.md`](../../plugins/acss-kit/skills/components/SKILL.md) under "Authoring New Components". Every reference doc must contain (in order):
+
+1. Verification banner — top of file, blockquote starting with `**Verified against fpkit source:**`
+2. `## Overview`
+3. `## Generation Contract`
+4. `## Props Interface`
+5. `## TSX Template`
+6. `## CSS Variables`
+7. `## SCSS Template`
+8. `## Accessibility`
+9. `## Usage Examples`
+
+## Checks
+
+### 1. Verification banner
+
+Read the first 10 lines of the file.
+
+- PASS if a blockquote (`>` lead) appears that includes the literal string `**Verified against fpkit source:**` followed by an `@fpkit/acss@<version>` reference.
+- FAIL if the banner is missing or the version reference is absent.
+
+### 2. Canonical sections present and in order
+
+Search for the nine section headers listed above.
+
+- PASS if all nine are present and appear in the order listed.
+- FAIL listing each missing section by name and any out-of-order section.
+
+### 3. Generation Contract fields
+
+Read the contents under `## Generation Contract` (typically a fenced code block).
+
+- PASS if all five required fields are present: `export_name`, `file`, `scss`, `imports`, `dependencies`.
+- FAIL listing each missing field. (Some components legitimately set `scss: (none)` or `dependencies: []` — those count as present.)
+
+### 4. fpkit URL hygiene
+
+Search the entire file for any URL referencing `github.com/shawn-sandy/acss`.
+
+- PASS if every such URL pins to a tag, SHA, or version-style ref (e.g., `/blob/v6.5.0/`, `/blob/<40-char-sha>/`, `/blob/6.5.0/`).
+- FAIL listing any URL that uses `/blob/main/` or omits a ref entirely. The verification banner pins to a captured ref; URLs in the body should match that ref.
+
+### 5. Catalog entry
+
+Read `plugins/acss-kit/skills/components/references/components/catalog.md` and search the "Verification Status" table for a row whose first cell matches the component name (derived from the filename without `.md`).
+
+- PASS if a row exists for this component.
+- FAIL if no row is found.
+
+### 6. TSX Template imports
+
+Read the contents of the `## TSX Template` fenced code block.
+
+- PASS if all imports come from one of: `react`, `'../ui'` (the polymorphic UI foundation), or relative paths to other vendored components in the same directory tree.
+- FAIL listing any import that references `@fpkit/acss`, `@acss/*`, or any package that would require an npm install. Also FAIL on any non-relative third-party import other than `react`.
+
+## Output format
+
+```
+Reviewing: plugins/acss-kit/skills/components/references/components/<name>.md
+
+  [PASS] Verification banner
+  [FAIL] Canonical sections — "## CSS Variables" missing (expected after Props Interface, line ~45)
+  [PASS] Generation Contract fields
+  [PASS] fpkit URL hygiene
+  [PASS] Catalog entry
+  [PASS] TSX Template imports
+
+1 issue found.
+```
+
+If all checks pass, output:
+
+```
+Reviewing: plugins/acss-kit/skills/components/references/components/<name>.md
+
+  [PASS] Verification banner
+  [PASS] Canonical sections
+  [PASS] Generation Contract fields
+  [PASS] fpkit URL hygiene
+  [PASS] Catalog entry
+  [PASS] TSX Template imports
+
+All checks passed — reference doc follows the canonical shape.
+```
+
+Do not modify any files. Report only.

--- a/.claude/agents/theme-reference-reviewer.md
+++ b/.claude/agents/theme-reference-reviewer.md
@@ -1,0 +1,93 @@
+---
+name: theme-reference-reviewer
+description: Reviews theme references (role-catalogue, palette-algorithm, theme-schema) for internal consistency and parity with the Python scripts (generate_palette.py, tokens_to_css.py, validate_theme.py) and the JSON schema. Use when authoring or editing files under plugins/acss-kit/skills/styles/references/ or plugins/acss-kit/assets/theme.schema.json.
+---
+
+You are a theme reference reviewer for the acss-plugins repository. When invoked, read each of the following files and check for cross-source parity. Report PASS or FAIL for each check with file:line citations on failures.
+
+## Source files to read
+
+- `plugins/acss-kit/skills/styles/SKILL.md` — defines required roles and the 10 WCAG contrast pairs.
+- `plugins/acss-kit/skills/styles/references/role-catalogue.md` — full role catalog.
+- `plugins/acss-kit/skills/styles/references/palette-algorithm.md` — OKLCH lightness/hue rules.
+- `plugins/acss-kit/skills/styles/references/theme-schema.md` — JSON schema docs.
+- `plugins/acss-kit/assets/theme.schema.json` — actual JSON schema (`$defs/palette` properties).
+- `plugins/acss-kit/scripts/tokens_to_css.py` — read the `ROLE_GROUPS` constant.
+- `plugins/acss-kit/scripts/validate_theme.py` — read the `PAIRS` constant.
+- `plugins/acss-kit/scripts/generate_palette.py` — read the OKLCH lightness/hue constants.
+- `plugins/acss-kit/assets/brand-presets/` — read every `.css` file (directory may not exist yet; treat absence as a SKIP, not a FAIL).
+
+## Checks
+
+### 1. Role parity (role-catalogue ↔ schema ↔ tokens_to_css)
+
+Build three sets of role names:
+
+- **A**: roles documented in `role-catalogue.md` (and the inline list in `styles/SKILL.md`)
+- **B**: keys under `$defs.palette.properties` in `theme.schema.json`
+- **C**: every role name listed across the `ROLE_GROUPS` dict in `tokens_to_css.py`
+
+- PASS if A == B == C.
+- FAIL listing each role that appears in one set but not all three. Distinguish required vs optional roles per `styles/SKILL.md`.
+
+### 2. Required vs optional consistency
+
+Cross-check the required/optional annotation for each role:
+
+- Required roles: must be in `theme.schema.json` `$defs.palette.required` array.
+- Optional roles (`--color-surface-subtle`, `--color-text-subtle`, `--color-brand-accent`): must NOT be in the `required` array.
+
+- PASS if `styles/SKILL.md` markings match `theme.schema.json`.
+- FAIL listing any role whose required/optional annotation disagrees between the two sources.
+
+### 3. WCAG contrast pair parity
+
+Compare the contrast pair table in `styles/SKILL.md` ("Required Contrast Pairings (WCAG 2.2 AA)") against the `PAIRS` constant in `validate_theme.py`.
+
+- PASS if every (foreground, background, min_ratio) tuple in the SKILL.md table appears in `PAIRS`, and vice versa.
+- FAIL listing each missing or mismatched pair.
+
+### 4. OKLCH algorithm parity
+
+Compare the lightness anchors and state-color hue offsets documented in `palette-algorithm.md` against the corresponding constants in `generate_palette.py`.
+
+- PASS if the documented values match the script constants.
+- FAIL listing each mismatch (e.g., "Documented light-mode background L=0.99 but generate_palette.py uses L=0.98").
+
+### 5. Bundled brand preset validation
+
+For each `.css` file under `plugins/acss-kit/assets/brand-presets/`, run `python3 plugins/acss-kit/scripts/validate_theme.py <file>` and capture exit code + output.
+
+- PASS if every preset exits 0 (all WCAG pairs satisfied).
+- FAIL listing each preset that fails, with the failing pair names.
+- SKIP if the `brand-presets/` directory does not exist yet (the bundled-presets feature may not be active).
+
+## Output format
+
+```
+Reviewing: theme references (role-catalogue, palette-algorithm, theme-schema, brand-presets)
+
+  [PASS] Role parity (role-catalogue ↔ schema ↔ tokens_to_css)
+  [FAIL] Required vs optional consistency — --color-surface-subtle marked required in theme-schema.md but optional in styles/SKILL.md
+  [PASS] WCAG contrast pair parity
+  [PASS] OKLCH algorithm parity
+  [SKIP] Bundled brand preset validation (assets/brand-presets/ does not exist)
+
+1 issue found.
+```
+
+If all checks pass:
+
+```
+Reviewing: theme references
+
+  [PASS] Role parity
+  [PASS] Required vs optional consistency
+  [PASS] WCAG contrast pair parity
+  [PASS] OKLCH algorithm parity
+  [PASS] Bundled brand preset validation
+
+All checks passed — theme references are internally consistent.
+```
+
+Do not modify any files. Report only. You may run `python3 plugins/acss-kit/scripts/validate_theme.py <file>` for check 5; do not run any other scripts.

--- a/.claude/agents/theme-reference-reviewer.md
+++ b/.claude/agents/theme-reference-reviewer.md
@@ -32,13 +32,14 @@ Build three sets of role names:
 
 ### 2. Required vs optional consistency
 
-Cross-check the required/optional annotation for each role:
+Derive the required/optional classification from the documents themselves rather than embedding a fixed list — the optional set may grow whenever `style-author` adds a new role:
 
-- Required roles: must be in `theme.schema.json` `$defs.palette.required` array.
-- Optional roles (`--color-surface-subtle`, `--color-text-subtle`, `--color-brand-accent`): must NOT be in the `required` array.
+- Parse `plugins/acss-kit/skills/styles/SKILL.md` (and the same annotations in `role-catalogue.md` if present) and build two sets: roles annotated `*(required)*` and roles annotated `*(optional)*`.
+- Read `theme.schema.json` `$defs.palette.required` as the schema-required set.
+- For each role: every role marked `*(required)*` in `styles/SKILL.md` must appear in the schema's `required` array; every role marked `*(optional)*` must NOT appear there. Roles in the schema's `required` array but missing or marked optional in `styles/SKILL.md` are also a mismatch.
 
-- PASS if `styles/SKILL.md` markings match `theme.schema.json`.
-- FAIL listing any role whose required/optional annotation disagrees between the two sources.
+- PASS if the derived classifications match for every role.
+- FAIL listing each role whose required/optional annotation disagrees, with file:line citations on both sides.
 
 ### 3. WCAG contrast pair parity
 
@@ -56,10 +57,14 @@ Compare the lightness anchors and state-color hue offsets documented in `palette
 
 ### 5. Bundled brand preset validation
 
-For each `.css` file under `plugins/acss-kit/assets/brand-presets/`, run `python3 plugins/acss-kit/scripts/validate_theme.py <file>` and capture exit code + output.
+For each `.css` file under `plugins/acss-kit/assets/brand-presets/`, run `python3 plugins/acss-kit/scripts/validate_theme.py <file>` and capture exit code + stdout.
 
-- PASS if every preset exits 0 (all WCAG pairs satisfied).
-- FAIL listing each preset that fails, with the failing pair names.
+`validate_theme.py` requires filenames matching `^(light|dark|brand-[\w-]+)\.css$`. Any other filename is silently skipped with `validate_theme: skipped (no palette files found)` and exit 0 — that path must be treated as a FAIL here, not a PASS, because a misnamed preset would never be validated in production.
+
+- PASS if every preset exits 0 AND its stdout contains `validate_theme: OK ...` (i.e., the file matched the regex and passed every WCAG pair).
+- FAIL listing:
+  - Each preset that exits 1, with the failing pair names.
+  - Each preset whose stdout contains `no palette files found` — annotate with: `<file>: filename does not match the brand-<slug>.css convention; rename to be validated`.
 - SKIP if the `brand-presets/` directory does not exist yet (the bundled-presets feature may not be active).
 
 ## Output format

--- a/.claude/commands/review-component.md
+++ b/.claude/commands/review-component.md
@@ -1,0 +1,9 @@
+---
+description: Review a component reference doc against the canonical embedded-markdown shape and catalog parity. Runs in the background.
+argument-hint: <path/to/references/components/file.md>
+allowed-tools: Agent
+---
+
+Review the component reference doc at `$ARGUMENTS` using the `component-reference-reviewer` agent. Run the agent in the background so the user can continue working. When the agent completes, report its findings.
+
+If no argument is provided, ask the user which reference doc to review. The expected location is `plugins/acss-kit/skills/components/references/components/<name>.md`.

--- a/.claude/commands/review-themes.md
+++ b/.claude/commands/review-themes.md
@@ -1,0 +1,8 @@
+---
+description: Review the acss-kit theme references for cross-source parity (role-catalogue, palette-algorithm, theme-schema, brand-presets) against the Python scripts and JSON schema.
+allowed-tools: Agent
+---
+
+Invoke the `theme-reference-reviewer` agent to audit the theme references and bundled brand presets. The agent reads `plugins/acss-kit/skills/styles/references/*`, `plugins/acss-kit/assets/theme.schema.json`, the theme-related Python scripts, and any bundled brand presets, then reports cross-source parity findings.
+
+Run the agent in the background so the user can continue working. When the agent completes, report its findings.

--- a/.claude/skills/component-author/SKILL.md
+++ b/.claude/skills/component-author/SKILL.md
@@ -25,87 +25,87 @@ Scaffolds `plugins/acss-kit/skills/components/references/components/<component-n
 3. **Capture intentional divergences via AskUserQuestion.**
    Ask whether this component will diverge from upstream in any documented way (inlined hooks, simplified compound API, dropped subcomponents, etc.). Default: "none". Capture as `<divergences>`. The verification banner is load-bearing for future maintainers — if there are no divergences, write "none" rather than leaving the field empty.
 
-4. **Write the reference doc skeleton** to `plugins/acss-kit/skills/components/references/components/<component-name>.md`:
+4. **Write the reference doc skeleton** to `plugins/acss-kit/skills/components/references/components/<component-name>.md`. Outer fence uses 4 backticks so the inner triple-backtick blocks render correctly:
 
-   ```markdown
-   # Component: <PascalCaseName>
+    ````markdown
+    # Component: <PascalCaseName>
 
-   > **Verified against fpkit source:** `<ref>`. Intentional divergences from upstream: <divergences>.
+    > **Verified against fpkit source:** `<ref>`. Intentional divergences from upstream: <divergences>.
 
-   ## Overview
+    ## Overview
 
-   <One-paragraph summary of the component's purpose. Note key WCAG patterns it addresses.>
+    <One-paragraph summary of the component's purpose. Note key WCAG patterns it addresses.>
 
-   ## Generation Contract
+    ## Generation Contract
 
-   ```
-   export_name: <PascalCaseName>
-   file: <component-name>.tsx
-   scss: <component-name>.scss
-   imports: UI from '../ui'
-   dependencies: []
-   ```
+    ```
+    export_name: <PascalCaseName>
+    file: <component-name>.tsx
+    scss: <component-name>.scss
+    imports: UI from '../ui'
+    dependencies: []
+    ```
 
-   ## Props Interface
+    ## Props Interface
 
-   ```tsx
-   export type <PascalCaseName>Props = {
-     children?: React.ReactNode
-     // TODO: copy props from fpkit source at <ref>
-   } & React.ComponentPropsWithoutRef<'div'>
-   ```
+    ```tsx
+    export type <PascalCaseName>Props = {
+      children?: React.ReactNode
+      // TODO: copy props from fpkit source at <ref>
+    } & React.ComponentPropsWithoutRef<'div'>
+    ```
 
-   ## TSX Template
+    ## TSX Template
 
-   ```tsx
-   // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx
-   import React from 'react'
-   import UI from '../ui'
+    ```tsx
+    // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx
+    import React from 'react'
+    import UI from '../ui'
 
-   export default function <PascalCaseName>({ children, ...rest }: <PascalCaseName>Props) {
-     return <UI as="div" {...rest}>{children}</UI>
-   }
-   ```
+    export default function <PascalCaseName>({ children, ...rest }: <PascalCaseName>Props) {
+      return <UI as="div" {...rest}>{children}</UI>
+    }
+    ```
 
-   ## CSS Variables
+    ## CSS Variables
 
-   ```scss
-   // CSS custom properties this component reads
-   // --<component-name>-bg
-   // --<component-name>-color
-   // (extend with the full variable list)
-   ```
+    ```scss
+    // CSS custom properties this component reads
+    // --<component-name>-bg
+    // --<component-name>-color
+    // (extend with the full variable list)
+    ```
 
-   ## SCSS Template
+    ## SCSS Template
 
-   ```scss
-   // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.scss
-   .<component-name> {
-     background: var(--<component-name>-bg, transparent);
-     color: var(--<component-name>-color, currentColor);
-   }
-   ```
+    ```scss
+    // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.scss
+    .<component-name> {
+      background: var(--<component-name>-bg, transparent);
+      color: var(--<component-name>-color, currentColor);
+    }
+    ```
 
-   ## Accessibility
+    ## Accessibility
 
-   - Keyboard interaction: <TODO>
-   - ARIA: <TODO>
-   - Focus management: <TODO>
-   - Target size: <TODO>
-   - Color contrast: <TODO>
-   - WCAG 2.2 AA criteria addressed: <TODO>
+    - Keyboard interaction: <TODO>
+    - ARIA: <TODO>
+    - Focus management: <TODO>
+    - Target size: <TODO>
+    - Color contrast: <TODO>
+    - WCAG 2.2 AA criteria addressed: <TODO>
 
-   ## Usage Examples
+    ## Usage Examples
 
-   ```tsx
-   import <PascalCaseName> from './components/fpkit/<component-name>/<component-name>'
-   import './components/fpkit/<component-name>/<component-name>.scss'
+    ```tsx
+    import <PascalCaseName> from './<component-name>/<component-name>'
+    import './<component-name>/<component-name>.scss'
 
-   <<PascalCaseName>>Hello</<PascalCaseName>>
-   ```
-   ```
+    <<PascalCaseName>>Hello</<PascalCaseName>>
+    ```
+    ````
 
-   Substitute `<component-name>`, `<PascalCaseName>`, `<ref>`, `<tag-or-sha>`, and `<divergences>` at write time. Leave every `TODO:` marker for the maintainer to fill in.
+   Substitute `<component-name>`, `<PascalCaseName>`, `<ref>`, `<tag-or-sha>`, and `<divergences>` at write time. Leave every `TODO:` marker for the maintainer to fill in. The Usage Examples import path uses `./<component-name>/<component-name>` to match the convention in existing reference docs (e.g. `button.md`, `alert.md`) — the `src/components/fpkit/` portion is the project-level path the developer chose during `/kit-add` initialization, not part of the relative import.
 
 5. **Add a row to `catalog.md` Verification Status.**
    Read `plugins/acss-kit/skills/components/references/components/catalog.md`. Find the "Verification Status" table and append a row before the next section header:

--- a/.claude/skills/component-author/SKILL.md
+++ b/.claude/skills/component-author/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: component-author
+description: Scaffold a new component reference doc for the acss-kit plugin in the canonical embedded-markdown shape. Use when the maintainer asks to add a new component to acss-kit, create a new reference doc under references/components, or scaffold a component spec like Tabs, Toast, Tooltip.
+disable-model-invocation: false
+---
+
+# /component-author
+
+Usage: `/component-author <component-name>`
+
+Example: `/component-author tabs`
+
+Scaffolds `plugins/acss-kit/skills/components/references/components/<component-name>.md` with all nine canonical sections and adds a placeholder row to the catalog. Does NOT implement the TSX/SCSS — the maintainer fills those in after consulting the upstream fpkit source.
+
+## Steps
+
+1. **Validate inputs.**
+   - `<component-name>` must be lowercase kebab-case (alphanumeric + hyphens).
+   - Refuse if `plugins/acss-kit/skills/components/references/components/<component-name>.md` already exists.
+   - Refuse if a row matching the component already appears in `catalog.md` "Verification Status".
+
+2. **Capture the fpkit ref via AskUserQuestion.**
+   Ask the maintainer for the fpkit version this reference will be verified against. Default to the most-common existing ceiling — read the verification banner of `plugins/acss-kit/skills/components/references/components/button.md` (line ~3) and offer that as the default option (currently `@fpkit/acss@6.5.0`). Capture the answer as `<ref>` for the banner and as `<tag-or-sha>` for any GitHub URLs in the body.
+
+3. **Capture intentional divergences via AskUserQuestion.**
+   Ask whether this component will diverge from upstream in any documented way (inlined hooks, simplified compound API, dropped subcomponents, etc.). Default: "none". Capture as `<divergences>`. The verification banner is load-bearing for future maintainers — if there are no divergences, write "none" rather than leaving the field empty.
+
+4. **Write the reference doc skeleton** to `plugins/acss-kit/skills/components/references/components/<component-name>.md`:
+
+   ```markdown
+   # Component: <PascalCaseName>
+
+   > **Verified against fpkit source:** `<ref>`. Intentional divergences from upstream: <divergences>.
+
+   ## Overview
+
+   <One-paragraph summary of the component's purpose. Note key WCAG patterns it addresses.>
+
+   ## Generation Contract
+
+   ```
+   export_name: <PascalCaseName>
+   file: <component-name>.tsx
+   scss: <component-name>.scss
+   imports: UI from '../ui'
+   dependencies: []
+   ```
+
+   ## Props Interface
+
+   ```tsx
+   export type <PascalCaseName>Props = {
+     children?: React.ReactNode
+     // TODO: copy props from fpkit source at <ref>
+   } & React.ComponentPropsWithoutRef<'div'>
+   ```
+
+   ## TSX Template
+
+   ```tsx
+   // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx
+   import React from 'react'
+   import UI from '../ui'
+
+   export default function <PascalCaseName>({ children, ...rest }: <PascalCaseName>Props) {
+     return <UI as="div" {...rest}>{children}</UI>
+   }
+   ```
+
+   ## CSS Variables
+
+   ```scss
+   // CSS custom properties this component reads
+   // --<component-name>-bg
+   // --<component-name>-color
+   // (extend with the full variable list)
+   ```
+
+   ## SCSS Template
+
+   ```scss
+   // TODO: copy from https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.scss
+   .<component-name> {
+     background: var(--<component-name>-bg, transparent);
+     color: var(--<component-name>-color, currentColor);
+   }
+   ```
+
+   ## Accessibility
+
+   - Keyboard interaction: <TODO>
+   - ARIA: <TODO>
+   - Focus management: <TODO>
+   - Target size: <TODO>
+   - Color contrast: <TODO>
+   - WCAG 2.2 AA criteria addressed: <TODO>
+
+   ## Usage Examples
+
+   ```tsx
+   import <PascalCaseName> from './components/fpkit/<component-name>/<component-name>'
+   import './components/fpkit/<component-name>/<component-name>.scss'
+
+   <<PascalCaseName>>Hello</<PascalCaseName>>
+   ```
+   ```
+
+   Substitute `<component-name>`, `<PascalCaseName>`, `<ref>`, `<tag-or-sha>`, and `<divergences>` at write time. Leave every `TODO:` marker for the maintainer to fill in.
+
+5. **Add a row to `catalog.md` Verification Status.**
+   Read `plugins/acss-kit/skills/components/references/components/catalog.md`. Find the "Verification Status" table and append a row before the next section header:
+
+   ```
+   | <PascalCaseName> | [`<component-name>.md`](<component-name>.md) | `<ref>` | New — pending fpkit verification |
+   ```
+
+   Preserve existing rows and table alignment.
+
+6. **Run the reviewer agent.**
+   Invoke the `component-reference-reviewer` agent against the new file. Expected outcome on a fresh skeleton: all checks PASS except possibly TSX Template imports (the placeholder uses only React + `'../ui'`, which should pass). Surface the agent's report inline.
+
+7. **Print a summary.**
+   - Files created: `<component-name>.md`
+   - Files modified: `catalog.md`
+   - Reminders:
+     - Resolve every `TODO:` placeholder before committing.
+     - If the component has dependencies (e.g. wraps Button), update the `dependencies:` field in the Generation Contract.
+     - Re-run `/review-component <path>` after filling in the TSX/SCSS templates.
+     - Update the catalog row's Status column from "New — pending fpkit verification" to "Verified" after the maintainer confirms parity.
+
+Do not write the TSX or SCSS implementation — those come from the upstream fpkit source at the captured ref. The maintainer fills them in.

--- a/.claude/skills/component-update/SKILL.md
+++ b/.claude/skills/component-update/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: component-update
+description: Re-verify and refresh an existing component reference doc against its captured fpkit ref. Use when the maintainer asks to update a component, refresh a button reference doc, bump the fpkit verification on a component, or check whether a component has drifted from upstream.
+disable-model-invocation: false
+---
+
+# /component-update
+
+Usage: `/component-update <component-name>`
+
+Example: `/component-update button`
+
+Re-verifies an existing component reference doc against its captured fpkit ref, surfaces any drift in the TSX or SCSS templates, and runs the canonical-shape reviewer agent. Does NOT scaffold new components — use `/component-author` for that.
+
+## Steps
+
+1. **Confirm the reference doc exists.**
+   - Resolve `<component-name>` to `plugins/acss-kit/skills/components/references/components/<component-name>.md`.
+   - If the file does not exist, halt and suggest `/component-author <component-name>` instead.
+
+2. **Read the verification banner and Generation Contract.**
+   - Capture `<ref>` from the `**Verified against fpkit source:**` line at the top of the file.
+   - Capture `<export_name>`, `<file>`, `<scss>`, `<imports>`, `<dependencies>` from the Generation Contract.
+   - Capture the existing `<divergences>` from the verification banner (everything after "Intentional divergences from upstream:").
+
+3. **Fetch the upstream fpkit source at `<ref>`.**
+   - Build the GitHub URL: `https://github.com/shawn-sandy/acss/blob/<ref-as-tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx`. Use WebFetch to retrieve the raw source. If the captured `<ref>` is `@fpkit/acss@<version>`, translate to the matching git tag (typically `v<version>` or `<version>`).
+   - Repeat for the `.scss` companion if `<scss>` is not `(none)`.
+   - If WebFetch returns 404, fall back to `https://raw.githubusercontent.com/shawn-sandy/acss/<ref>/packages/fpkit/src/components/<component-name>/<component-name>.tsx`. If still 404, surface the error and ask the maintainer for a corrected ref or path.
+
+4. **Diff upstream vs local templates.**
+   - Read the `## TSX Template` fenced block from the local reference doc.
+   - Compare structurally to the upstream TSX (ignore the documented `<divergences>` — those are expected gaps).
+   - Repeat for `## SCSS Template`.
+   - Surface drift as a unified diff or section-by-section summary: "Upstream adds prop X", "Upstream renames hook Y", etc.
+
+5. **Surface findings via AskUserQuestion.**
+   Present the drift summary and ask the maintainer:
+   - Is the upstream change intentional and should be applied? (If yes, edit the TSX/SCSS Template blocks to match.)
+   - Does the verification banner need an updated divergence note? (If yes, edit the banner.)
+   - Should the catalog row's Status be updated? (Default: keep current.)
+   If the maintainer chooses "No drift detected", proceed to step 7 without edits.
+
+6. **Apply approved edits.**
+   - Use Edit to replace the TSX Template fence content if the maintainer approved an upstream pull.
+   - Use Edit to replace the SCSS Template fence content if approved.
+   - Use Edit to update the verification banner if `<divergences>` changed or the maintainer wants to bump `<ref>` to a newer tag.
+   - Use Edit to update the catalog row in `plugins/acss-kit/skills/components/references/components/catalog.md` if the Status changed.
+
+7. **Warn about export_name changes.**
+   If the maintainer's edits changed `<export_name>` in the Generation Contract, print a prominent warning:
+
+   > Changing `export_name` is a breaking change for existing `/kit-add` consumers. The generated `<file>` will export a different identifier; downstream imports will break on regenerate. Confirm this is intentional before committing.
+
+   Use Grep to scan `plugins/acss-kit/skills/components/SKILL.md` and the catalog for any other references to the old export_name and surface them.
+
+8. **Run the reviewer agent.**
+   Invoke `component-reference-reviewer` against the file. Surface its report inline.
+
+9. **Print a summary.**
+   - Files modified (or "No changes — no drift detected").
+   - Reviewer agent verdict (PASS / N issues found).
+   - Reminder if `<export_name>` changed: re-run any downstream consumers.
+
+This skill does not bump the plugin version. After committing the reference doc change, run `/release-plugin acss-kit <new-version>` if the change should ship.

--- a/.claude/skills/component-update/SKILL.md
+++ b/.claude/skills/component-update/SKILL.md
@@ -24,9 +24,10 @@ Re-verifies an existing component reference doc against its captured fpkit ref, 
    - Capture the existing `<divergences>` from the verification banner (everything after "Intentional divergences from upstream:").
 
 3. **Fetch the upstream fpkit source at `<ref>`.**
-   - Build the GitHub URL: `https://github.com/shawn-sandy/acss/blob/<ref-as-tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx`. Use WebFetch to retrieve the raw source. If the captured `<ref>` is `@fpkit/acss@<version>`, translate to the matching git tag (typically `v<version>` or `<version>`).
-   - Repeat for the `.scss` companion if `<scss>` is not `(none)`.
-   - If WebFetch returns 404, fall back to `https://raw.githubusercontent.com/shawn-sandy/acss/<ref>/packages/fpkit/src/components/<component-name>/<component-name>.tsx`. If still 404, surface the error and ask the maintainer for a corrected ref or path.
+   - Build the raw URL first: `https://raw.githubusercontent.com/shawn-sandy/acss/<ref-as-tag-or-sha>/packages/fpkit/src/components/<component-name>/<component-name>.tsx`. The raw form returns the actual file contents; the `github.com/.../blob/...` form returns rendered HTML, which would corrupt the diff in step 4.
+   - Use WebFetch on the raw URL. If the captured `<ref>` is `@fpkit/acss@<version>`, translate to the matching git tag (typically `v<version>` or `<version>`).
+   - Repeat for the `.scss` companion if `<scss>` is not `(none)`, using the same raw URL form.
+   - If WebFetch returns 404, try the alternate translated ref (e.g. `<version>` if `v<version>` failed) or verify the component path. Only as a last resort fall back to the rendered `https://github.com/shawn-sandy/acss/blob/<ref>/...` URL and warn the maintainer that the diff may include HTML noise. If still 404, surface the error and ask the maintainer for a corrected ref or path.
 
 4. **Diff upstream vs local templates.**
    - Read the `## TSX Template` fenced block from the local reference doc.

--- a/.claude/skills/plugin-health/SKILL.md
+++ b/.claude/skills/plugin-health/SKILL.md
@@ -43,13 +43,20 @@ Invoke the `theme-reference-reviewer` agent. Capture its check verdicts. Each FA
 
 ## Step 6 — Bundled theme validation
 
-For each `.css` file under `plugins/<plugin-name>/assets/` and `plugins/<plugin-name>/assets/brand-presets/` (if it exists):
+`validate_theme.py` only validates files whose name matches `^(light|dark|brand-[\w-]+)\.css$`. Anything else (including `<preset>.css` without the `brand-` prefix) is silently skipped with `validate_theme: skipped (no palette files found)` and exit 0 — that path must NOT be treated as a passing validation.
 
-1. Run `python3 plugins/<plugin-name>/scripts/validate_theme.py <file>` with timeout 30s.
-2. Capture exit code (0 = pass, 1 = WCAG failures).
-3. List failures with the failing pair names.
-
-Mark `OK` if all bundled themes pass, `FIX` otherwise.
+1. Build the candidate file list:
+   - Top-level `assets/`: include any `.css` file matching the regex above.
+   - `assets/brand-presets/` (if it exists): include any `.css` file matching the regex.
+2. For each candidate file, run `python3 plugins/<plugin-name>/scripts/validate_theme.py <file>` with timeout 30s. Capture exit code and stdout.
+3. Classify each result:
+   - exit 0 + `validate_theme: OK ...` → PASS
+   - exit 1 → FAIL with the listed failing pair names
+   - stdout contains `no palette files found` → INFO ("filename did not match the validator regex"), do NOT count as PASS
+4. Mark the section overall:
+   - `OK` if every candidate file is PASS.
+   - `FIX` if any candidate is FAIL.
+   - `SKIP` if no candidate files were found at all (no bundled themes to validate).
 
 ## Step 7 — Render the dashboard
 

--- a/.claude/skills/plugin-health/SKILL.md
+++ b/.claude/skills/plugin-health/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: plugin-health
+description: One-shot audit dashboard for the acss-kit plugin — runs structural validation, scans component references for canonical-shape compliance, cross-checks the catalog table, and validates bundled theme assets. Use when the maintainer asks for a plugin health check, what's missing before release, an acss-kit audit, or a status overview.
+disable-model-invocation: false
+---
+
+# /plugin-health
+
+Usage: `/plugin-health` (defaults to `acss-kit`) or `/plugin-health <plugin-name>`
+
+Produces a single dashboard summarizing the structural and content health of the plugin. Read-only — does NOT modify any files. Run before release or whenever the maintainer wants to know "what's left to fix".
+
+## Step 1 — Resolve target
+
+If no argument is provided, default to `acss-kit`. Confirm `plugins/<plugin-name>/.claude-plugin/plugin.json` exists. If not, list available plugins from `.claude-plugin/marketplace.json` and halt.
+
+## Step 2 — Structural validation
+
+Invoke the existing `validate-plugin` skill on `<plugin-name>`. Capture its output. Surface as the first section of the dashboard ("Structure").
+
+## Step 3 — Component reference scan
+
+For each file under `plugins/<plugin-name>/skills/components/references/components/*.md` (excluding `catalog.md`):
+
+1. Check whether the file contains all nine canonical sections (verification banner, Overview, Generation Contract, Props Interface, TSX Template, CSS Variables, SCSS Template, Accessibility, Usage Examples).
+2. Mark the file `OK` if all present, `FIX` if any are missing or out of order.
+3. Capture the missing section names for the FIX rows.
+
+Roll up to: `N components OK / M components FIX`. Detailed list goes in the "Components" section.
+
+## Step 4 — Catalog parity
+
+1. Read `plugins/<plugin-name>/skills/components/references/components/catalog.md`. Extract every component name from the "Verification Status" table.
+2. Compare to the set of `*.md` files actually present in `references/components/` (excluding `catalog.md`).
+3. Report:
+   - Files without a catalog row (orphans)
+   - Catalog rows without a file (stale)
+4. Mark `OK` if both sets match, `FIX` otherwise.
+
+## Step 5 — Theme reference parity
+
+Invoke the `theme-reference-reviewer` agent. Capture its check verdicts. Each FAIL becomes a row in the "Themes" section of the dashboard.
+
+## Step 6 — Bundled theme validation
+
+For each `.css` file under `plugins/<plugin-name>/assets/` and `plugins/<plugin-name>/assets/brand-presets/` (if it exists):
+
+1. Run `python3 plugins/<plugin-name>/scripts/validate_theme.py <file>` with timeout 30s.
+2. Capture exit code (0 = pass, 1 = WCAG failures).
+3. List failures with the failing pair names.
+
+Mark `OK` if all bundled themes pass, `FIX` otherwise.
+
+## Step 7 — Render the dashboard
+
+Print a single block:
+
+```
+== plugin-health: <plugin-name> @ v<version> ==
+
+Structure              [OK | FIX] <one-line summary from validate-plugin>
+Components             [OK | FIX] N OK / M FIX
+Catalog parity         [OK | FIX] <orphans/stale counts>
+Theme references       [OK | FIX] <fail count from theme-reference-reviewer>
+Bundled themes         [OK | FIX] <preset pass/fail counts>
+
+-- Detail --
+
+Components needing attention:
+  - <name>.md — missing: Accessibility
+  - <name>.md — missing: Usage Examples, out-of-order: SCSS Template
+
+Catalog issues:
+  - Orphan: <name>.md (file present, no catalog row)
+  - Stale: <name> (catalog row, no file)
+
+Theme reference findings:
+  - <check name> — <one-line failure>
+
+Bundled theme failures:
+  - <file> — <failing pair name>
+
+-- Suggested fixes --
+
+  Run /component-update <name>           (for each FIX row in Components)
+  Run /style-update <path>               (for each FIX row in Themes)
+  Manual: edit catalog.md                (for each Catalog issue)
+```
+
+If everything is OK, replace the Detail section with: `All systems green. Plugin is release-ready.`
+
+## Step 8 — Pre-release reminder
+
+Append:
+
+```
+Before opening a PR:
+  1. Run /release-plugin <plugin-name> <new-version>
+  2. Run /release-check <plugin-name>
+  3. Confirm plugins/<plugin-name>/CHANGELOG.md mentions user-visible changes
+```
+
+This skill does not modify any files. The maintainer applies fixes via the suggested sub-skills.

--- a/.claude/skills/style-author/SKILL.md
+++ b/.claude/skills/style-author/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: style-author
+description: Scaffold a new bundled brand preset, palette role, or theme-schema field for the acss-kit plugin. Use when the maintainer asks to add a brand preset to the plugin, extend the role catalogue with a new color role, scaffold a bundled brand template, or tweak the OKLCH palette algorithm.
+disable-model-invocation: false
+---
+
+# /style-author
+
+Three sub-flows scaffold new style assets bundled with the acss-kit plugin. The maintainer picks one at the start. Each sub-flow ends with a contrast-pair re-validation summary so any change is gated by WCAG 2.2 AA.
+
+This skill is for **maintainer-side** scaffolding (extending the plugin itself). It is NOT the same as the user-facing `/theme-create` and `/theme-brand` commands which generate themes for end-user projects.
+
+## Step 0 — Choose a sub-flow
+
+Use AskUserQuestion to ask which kind of style asset to scaffold:
+
+- **Brand preset** — add a new `assets/brand-presets/<name>.css` file shipped with the plugin
+- **New role** — add a new `--color-*` role to the role catalogue, schema, and Python role groups
+- **Palette algorithm tweak** — adjust the OKLCH lightness anchors or hue offsets
+
+Branch to the matching step set below.
+
+---
+
+## Sub-flow A — Brand preset
+
+Usage: `/style-author <preset-name> --from=<hex>` (e.g. `/style-author sunset --from=#f97316`)
+
+### A1. Validate inputs
+
+- `<preset-name>` is lowercase kebab-case (alphanumeric + hyphens).
+- `<hex>` is a 3- or 6-digit hex color.
+- Refuse if `plugins/acss-kit/assets/brand-presets/<preset-name>.css` already exists.
+
+### A2. Create the brand-presets directory if missing
+
+If `plugins/acss-kit/assets/brand-presets/` does not exist, create it. This directory is a new convention for bundled brand presets — distinct from the existing `assets/brand-template.css` user-facing template.
+
+### A3. Generate the palette
+
+Run from the worktree root:
+
+```
+python3 plugins/acss-kit/scripts/generate_palette.py <hex> --mode=brand
+```
+
+Capture the JSON stdout. If exit code is 1, print the `reasons` array and halt.
+
+### A4. Convert palette to CSS
+
+Pipe the palette JSON into:
+
+```
+python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/brand-presets/
+```
+
+Rename the output file to `<preset-name>.css` if `tokens_to_css.py` writes a generic name. Confirm the file was written.
+
+### A5. Validate WCAG contrast
+
+Run:
+
+```
+python3 plugins/acss-kit/scripts/validate_theme.py plugins/acss-kit/assets/brand-presets/<preset-name>.css
+```
+
+If any contrast pair fails, surface the failures. Ask the maintainer whether to (a) keep the preset as-is with documented divergences, (b) tune the seed hex and regenerate, or (c) discard. Only proceed if the maintainer accepts the result.
+
+### A6. Update styles SKILL.md
+
+Read `plugins/acss-kit/skills/styles/SKILL.md`. Find or create a "Bundled brand presets" section (place it just before the "Error handling" section near the bottom). Append:
+
+```markdown
+- **<preset-name>** (`assets/brand-presets/<preset-name>.css`) — derived from `<hex>` via `generate_palette.py --mode=brand`. <one-line description>
+```
+
+If the section did not exist, create it with a short intro line.
+
+### A7. Print summary
+
+- Files created: `assets/brand-presets/<preset-name>.css`
+- Files modified: `skills/styles/SKILL.md`
+- WCAG validation: PASS / N pairs failed (with names)
+- Reminder: bump `acss-kit` plugin version via `/release-plugin acss-kit <new-version>` if this preset should ship.
+
+---
+
+## Sub-flow B — New role
+
+Usage: `/style-author --role=<--color-name>` (e.g. `/style-author --role=--color-accent-muted`)
+
+### B1. Validate the role name
+
+- Must start with `--color-`.
+- Must be kebab-case after the prefix.
+- Refuse if the role already appears in `plugins/acss-kit/assets/theme.schema.json` `$defs.palette.properties`.
+
+### B2. Capture role metadata via AskUserQuestion
+
+Ask:
+- **Group** — Backgrounds / Text / Borders / Brand & semantic / Focus
+- **Required vs optional** — default optional (new roles should not break existing themes)
+- **Description** — one line describing the role's purpose
+- **Suggested fallback hex** — used when generating brand presets that do not override this role
+
+### B3. Update `assets/theme.schema.json`
+
+Use Edit to add the role to `$defs.palette.properties`. If "required" was selected in B2, also add the role name to `$defs.palette.required` array.
+
+### B4. Update `references/role-catalogue.md`
+
+Use Edit to add a row under the matching group section, mirroring the existing format. Include the role name, description, and any contrast pairings if it interacts with text/background.
+
+### B5. Update `skills/styles/SKILL.md`
+
+Use Edit to add the role to the appropriate group bullet list under "Semantic role names". Mark required vs optional with the same `*(required)*` / `*(optional)*` annotation used by neighboring roles.
+
+### B6. Update `references/theme-schema.md`
+
+Use Edit to document the new role in the schema reference, mirroring existing entries.
+
+### B7. Remind the maintainer about Python parity
+
+Print a prominent reminder:
+
+> The new role must also be added to `plugins/acss-kit/scripts/tokens_to_css.py` `ROLE_GROUPS` constant. Without that update, generated theme files will not include the new role. Edit the appropriate group entry by hand — this skill does not modify Python source.
+
+If the role is required (not optional), also remind:
+
+> Required roles must be present in every bundled `light.css`, `dark.css`, and brand preset. Run `/style-update` after adding the role to backfill existing themes.
+
+### B8. Run the reviewer agent
+
+Invoke `theme-reference-reviewer` to confirm the role appears consistently across markdown and the JSON schema. Surface its report inline.
+
+### B9. Print summary
+
+- Files modified: list them
+- Manual follow-up: tokens_to_css.py:ROLE_GROUPS, downstream theme files (if required role)
+
+---
+
+## Sub-flow C — Palette algorithm tweak
+
+Usage: `/style-author --algorithm`
+
+### C1. Confirm scope via AskUserQuestion
+
+Ask which algorithm parameter to tweak:
+- Lightness anchors (light-mode background, surface, text, etc.)
+- State-color hue offsets (success, warning, danger, info)
+- Brand-mode primary derivation (primary-hover, primary-pressed)
+- Other (free-text)
+
+### C2. Edit `references/palette-algorithm.md`
+
+Use Edit to apply the maintainer's change to the relevant section. Preserve the existing structure (anchors → offsets → derivation rules).
+
+### C3. Remind about generate_palette.py parity
+
+The OKLCH constants live in both `references/palette-algorithm.md` (documentation) and `plugins/acss-kit/scripts/generate_palette.py` (implementation). Print:
+
+> Update the matching constant in `plugins/acss-kit/scripts/generate_palette.py` to keep the doc and implementation in sync. The `theme-reference-reviewer` agent will flag drift between them.
+
+### C4. Regenerate the bundled brand template
+
+If `plugins/acss-kit/assets/brand-template.css` is derived from a known seed (check the file header for a comment), regenerate it after the maintainer updates `generate_palette.py`:
+
+```
+python3 plugins/acss-kit/scripts/generate_palette.py <seed> --mode=brand | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/
+```
+
+(Adjust paths to overwrite `brand-template.css`.) If the brand-template was hand-authored, skip this step and note it in the summary.
+
+### C5. Re-validate every bundled preset
+
+Run `validate_theme.py` against `assets/brand-template.css` and every file under `assets/brand-presets/` (if any). Surface any failures.
+
+### C6. Run the reviewer agent
+
+Invoke `theme-reference-reviewer` to confirm the algorithm constants in markdown match the Python script. Surface its report.
+
+### C7. Print summary
+
+- Files modified
+- Bundled presets re-validated (PASS / FAIL counts)
+- Manual follow-up: bump `acss-kit` version if the algorithm change is user-visible.
+
+---
+
+## Error handling (all sub-flows)
+
+| Situation | Action |
+|---|---|
+| Seed hex invalid | Halt with: `"<value>" is not a valid hex color. Use #rrggbb or #rgb.` |
+| `generate_palette.py` exits 1 | Print each reason from `"reasons"` array. Halt. |
+| Output file already exists | Halt with the conflict path. Maintainer must rename or delete. |
+| WCAG validation fails | Surface failures and ask the maintainer whether to keep, retune, or discard. |
+| theme-reference-reviewer reports drift | Surface findings inline; do not block — the maintainer fixes the drift on next commit. |

--- a/.claude/skills/style-author/SKILL.md
+++ b/.claude/skills/style-author/SKILL.md
@@ -26,59 +26,60 @@ Branch to the matching step set below.
 
 Usage: `/style-author <preset-name> --from=<hex>` (e.g. `/style-author sunset --from=#f97316`)
 
+The output filename is always `brand-<preset-name>.css` (with the `brand-` prefix). Two scripts are involved:
+- `generate_palette.py --mode=brand` outputs `{seed, reasons, brand_overrides: {light, dark}}` — note the singular `brand_overrides` shape, distinct from the `modes` shape `--mode=both` produces.
+- `tokens_to_css.py` consumes a tokens document with `{brands: {<name>: {light, dark}}}` and writes one CSS file per brand named `brand-<name>.css`.
+- Because the two shapes differ, sub-flow A inserts a JSON reshape step between them.
+
 ### A1. Validate inputs
 
-- `<preset-name>` is lowercase kebab-case (alphanumeric + hyphens).
+- `<preset-name>` is lowercase kebab-case (alphanumeric + hyphens). The `brand-` prefix is added automatically — do not include it in `<preset-name>`.
 - `<hex>` is a 3- or 6-digit hex color.
-- Refuse if `plugins/acss-kit/assets/brand-presets/<preset-name>.css` already exists.
+- Refuse if `plugins/acss-kit/assets/brand-presets/brand-<preset-name>.css` already exists.
 
 ### A2. Create the brand-presets directory if missing
 
 If `plugins/acss-kit/assets/brand-presets/` does not exist, create it. This directory is a new convention for bundled brand presets — distinct from the existing `assets/brand-template.css` user-facing template.
 
-### A3. Generate the palette
+### A3. Generate, reshape, and write CSS
 
-Run from the worktree root:
-
-```
-python3 plugins/acss-kit/scripts/generate_palette.py <hex> --mode=brand
-```
-
-Capture the JSON stdout. If exit code is 1, print the `reasons` array and halt.
-
-### A4. Convert palette to CSS
-
-Pipe the palette JSON into:
+Run from the worktree root as a single pipeline:
 
 ```
-python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/brand-presets/
+python3 plugins/acss-kit/scripts/generate_palette.py "<hex>" --mode=brand \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps({'brands': {'<preset-name>': d['brand_overrides']}}))" \
+  | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/brand-presets/
 ```
 
-Rename the output file to `<preset-name>.css` if `tokens_to_css.py` writes a generic name. Confirm the file was written.
+The middle stage transforms `{brand_overrides: {...}}` into `{brands: {'<preset-name>': {...}}}`, which is what `tokens_to_css.py` consumes. It also short-circuits on `reasons` from `generate_palette.py` (non-empty `reasons` ⇒ exit 1, JSON to stderr).
 
-### A5. Validate WCAG contrast
+If any stage of the pipeline returns non-zero, print the captured stderr and halt. Confirm the output file `plugins/acss-kit/assets/brand-presets/brand-<preset-name>.css` was written (`tokens_to_css.py` prints `wrote: <path>` on success).
+
+### A4. Validate WCAG contrast
 
 Run:
 
 ```
-python3 plugins/acss-kit/scripts/validate_theme.py plugins/acss-kit/assets/brand-presets/<preset-name>.css
+python3 plugins/acss-kit/scripts/validate_theme.py plugins/acss-kit/assets/brand-presets/brand-<preset-name>.css
 ```
 
-If any contrast pair fails, surface the failures. Ask the maintainer whether to (a) keep the preset as-is with documented divergences, (b) tune the seed hex and regenerate, or (c) discard. Only proceed if the maintainer accepts the result.
+The filename `brand-<preset-name>.css` matches the `^(light|dark|brand-[\w-]+)\.css$` regex in `validate_theme.py`. If validation prints `validate_theme: skipped (no palette files found)`, the filename is wrong — verify the brand- prefix was added by `tokens_to_css.py` and re-run.
 
-### A6. Update styles SKILL.md
+If any contrast pair fails (exit code 1), surface the failures. Ask the maintainer whether to (a) keep the preset as-is with documented divergences (add a `/* divergences: ... */` comment header to the file), (b) tune the seed hex and regenerate, or (c) discard. Only proceed if the maintainer accepts the result.
+
+### A5. Update styles SKILL.md
 
 Read `plugins/acss-kit/skills/styles/SKILL.md`. Find or create a "Bundled brand presets" section (place it just before the "Error handling" section near the bottom). Append:
 
 ```markdown
-- **<preset-name>** (`assets/brand-presets/<preset-name>.css`) — derived from `<hex>` via `generate_palette.py --mode=brand`. <one-line description>
+- **<preset-name>** (`assets/brand-presets/brand-<preset-name>.css`) — derived from `<hex>` via `generate_palette.py --mode=brand`. <one-line description>
 ```
 
 If the section did not exist, create it with a short intro line.
 
-### A7. Print summary
+### A6. Print summary
 
-- Files created: `assets/brand-presets/<preset-name>.css`
+- Files created: `assets/brand-presets/brand-<preset-name>.css`
 - Files modified: `skills/styles/SKILL.md`
 - WCAG validation: PASS / N pairs failed (with names)
 - Reminder: bump `acss-kit` plugin version via `/release-plugin acss-kit <new-version>` if this preset should ship.
@@ -162,19 +163,28 @@ The OKLCH constants live in both `references/palette-algorithm.md` (documentatio
 
 > Update the matching constant in `plugins/acss-kit/scripts/generate_palette.py` to keep the doc and implementation in sync. The `theme-reference-reviewer` agent will flag drift between them.
 
-### C4. Regenerate the bundled brand template
+### C4. Regenerate every bundled brand preset (not the user-facing template)
 
-If `plugins/acss-kit/assets/brand-template.css` is derived from a known seed (check the file header for a comment), regenerate it after the maintainer updates `generate_palette.py`:
+`assets/brand-template.css` is the user-facing starter template the consumer copies into their project — it is hand-authored and not a candidate for regeneration. The targets here are the bundled `assets/brand-presets/brand-*.css` files (if any exist), each of which records a seed hex in a header comment of the form `/* seed: #rrggbb */`.
 
-```
-python3 plugins/acss-kit/scripts/generate_palette.py <seed> --mode=brand | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/
-```
+For each `brand-<name>.css` under `assets/brand-presets/`:
 
-(Adjust paths to overwrite `brand-template.css`.) If the brand-template was hand-authored, skip this step and note it in the summary.
+1. Parse the `/* seed: #rrggbb */` header to recover `<seed>`. If no seed is recorded, skip the file and note it in the summary (hand-authored preset).
+2. Re-run the same reshape pipeline used by sub-flow A:
+
+   ```
+   python3 plugins/acss-kit/scripts/generate_palette.py "<seed>" --mode=brand \
+     | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps({'brands': {'<name>': d['brand_overrides']}}))" \
+     | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/brand-presets/
+   ```
+
+   This rewrites `brand-<name>.css` in place using the updated algorithm constants.
+
+If `assets/brand-presets/` does not exist or is empty, note "no bundled presets to regenerate" and continue.
 
 ### C5. Re-validate every bundled preset
 
-Run `validate_theme.py` against `assets/brand-template.css` and every file under `assets/brand-presets/` (if any). Surface any failures.
+Run `python3 plugins/acss-kit/scripts/validate_theme.py <file>` against each `brand-*.css` under `assets/brand-presets/`. Skip `assets/brand-template.css` (it is hand-authored and not part of the algorithmic regeneration target). Surface any contrast failures with the failing pair names.
 
 ### C6. Run the reviewer agent
 

--- a/.claude/skills/style-update/SKILL.md
+++ b/.claude/skills/style-update/SKILL.md
@@ -42,19 +42,26 @@ A new role or modified description in the role catalogue should propagate to the
 
 ## Step 3 — palette-algorithm change
 
-A change to the OKLCH lightness anchors or hue offsets should be reflected in `generate_palette.py` and re-validated against the bundled brand template + presets.
+A change to the OKLCH lightness anchors or hue offsets should be reflected in `generate_palette.py` and re-validated against any bundled brand presets that were derived algorithmically.
 
 1. Read `plugins/acss-kit/skills/styles/references/palette-algorithm.md` and extract the documented constants (lightness anchors per role group, hue offsets for state colors).
 2. Read `plugins/acss-kit/scripts/generate_palette.py` and extract the corresponding constants.
 3. Diff and surface any drift. If drift is detected, surface the exact line and suggested edit; do not modify the Python automatically.
-4. After confirming parity (or on the maintainer's confirmation that they will reconcile), regenerate the bundled `assets/brand-template.css` if it has a derivable seed (look for a `/* seed: #... */` header comment). Run:
+4. After confirming parity (or on the maintainer's confirmation that they will reconcile), regenerate every algorithmically-derived brand preset. `assets/brand-template.css` is the user-facing starter template — hand-authored and explicitly NOT a regeneration target.
 
-   ```
-   python3 plugins/acss-kit/scripts/generate_palette.py <seed> --mode=brand | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/
-   ```
+   For each `brand-<name>.css` under `assets/brand-presets/`:
+   - Parse the `/* seed: #rrggbb */` header comment to recover the seed. If no seed is recorded, skip the file and note it (hand-authored preset).
+   - Run the same reshape pipeline used by `style-author` sub-flow A:
 
-   If no seed is recorded, skip the regeneration and note it.
-5. Run `python3 plugins/acss-kit/scripts/validate_theme.py` against `assets/brand-template.css` and every file under `assets/brand-presets/`.
+     ```
+     python3 plugins/acss-kit/scripts/generate_palette.py "<seed>" --mode=brand \
+       | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps({'brands': {'<name>': d['brand_overrides']}}))" \
+       | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/brand-presets/
+     ```
+
+   If `assets/brand-presets/` does not exist or is empty, note "no bundled presets to regenerate" and continue.
+
+5. Re-validate every regenerated preset by running `python3 plugins/acss-kit/scripts/validate_theme.py <file>` per `brand-*.css` file under `assets/brand-presets/`. Skip `assets/brand-template.css` (hand-authored, not part of the algorithmic regeneration target).
 6. Run the `theme-reference-reviewer` agent.
 
 ---

--- a/.claude/skills/style-update/SKILL.md
+++ b/.claude/skills/style-update/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: style-update
+description: Re-validate and roll forward existing theme assets after a maintainer edits role-catalogue, palette-algorithm, theme-schema, or a bundled brand preset. Use when the maintainer asks to update a theme reference, refine the palette algorithm, refresh the role catalogue, or re-validate themes after a role change.
+disable-model-invocation: false
+---
+
+# /style-update
+
+Usage: `/style-update <path>` (e.g. `/style-update plugins/acss-kit/skills/styles/references/role-catalogue.md`)
+
+Detects which kind of theme asset was edited and runs the appropriate downstream re-validation. Does not author new assets — use `/style-author` for that.
+
+## Step 1 — Detect the asset kind
+
+Inspect `<path>`. Branch on the matching pattern:
+
+| Path matches | Asset kind | Skip to |
+|---|---|---|
+| `references/role-catalogue.md` | role-catalogue | Step 2 |
+| `references/palette-algorithm.md` | palette-algorithm | Step 3 |
+| `references/theme-schema.md` or `assets/theme.schema.json` | theme-schema | Step 4 |
+| `assets/brand-template.css` or `assets/brand-presets/*.css` | brand-preset | Step 5 |
+| `skills/styles/SKILL.md` | styles SKILL | Step 6 |
+| anything else | unknown | Halt with message: `<path> is not a recognized theme asset. Edit role-catalogue.md, palette-algorithm.md, theme-schema.md, theme.schema.json, or a CSS file under assets/.` |
+
+If `<path>` is omitted, ask the maintainer which file they edited via AskUserQuestion.
+
+---
+
+## Step 2 — role-catalogue change
+
+A new role or modified description in the role catalogue should propagate to the JSON schema, the styles SKILL.md inline list, and the Python `ROLE_GROUPS` constant.
+
+1. Read `plugins/acss-kit/skills/styles/references/role-catalogue.md`. Extract the full set of `--color-*` role names.
+2. Read `plugins/acss-kit/assets/theme.schema.json` `$defs.palette.properties` keys.
+3. Read `plugins/acss-kit/scripts/tokens_to_css.py` `ROLE_GROUPS` constant. Extract every role name across all groups.
+4. Diff the three sets. Surface any role that appears in one but not the others.
+5. If `theme.schema.json` is missing a role, prompt the maintainer to confirm and Edit the schema. If `tokens_to_css.py:ROLE_GROUPS` is missing a role, surface the manual edit needed (do NOT modify the Python source automatically — print the exact diff the maintainer should apply).
+6. Run the `theme-reference-reviewer` agent. Surface its report.
+
+---
+
+## Step 3 — palette-algorithm change
+
+A change to the OKLCH lightness anchors or hue offsets should be reflected in `generate_palette.py` and re-validated against the bundled brand template + presets.
+
+1. Read `plugins/acss-kit/skills/styles/references/palette-algorithm.md` and extract the documented constants (lightness anchors per role group, hue offsets for state colors).
+2. Read `plugins/acss-kit/scripts/generate_palette.py` and extract the corresponding constants.
+3. Diff and surface any drift. If drift is detected, surface the exact line and suggested edit; do not modify the Python automatically.
+4. After confirming parity (or on the maintainer's confirmation that they will reconcile), regenerate the bundled `assets/brand-template.css` if it has a derivable seed (look for a `/* seed: #... */` header comment). Run:
+
+   ```
+   python3 plugins/acss-kit/scripts/generate_palette.py <seed> --mode=brand | python3 plugins/acss-kit/scripts/tokens_to_css.py --stdin --out-dir=plugins/acss-kit/assets/
+   ```
+
+   If no seed is recorded, skip the regeneration and note it.
+5. Run `python3 plugins/acss-kit/scripts/validate_theme.py` against `assets/brand-template.css` and every file under `assets/brand-presets/`.
+6. Run the `theme-reference-reviewer` agent.
+
+---
+
+## Step 4 — theme-schema change
+
+A schema change must keep markdown documentation, the JSON schema, and downstream brand presets in agreement.
+
+1. If `<path>` was the markdown reference, also read `assets/theme.schema.json` (and vice versa). Surface drift between the two.
+2. For each new property added to the schema, confirm:
+   - It is documented in `references/role-catalogue.md` (if it is a role).
+   - It is documented in `references/theme-schema.md` (if it is a structural change like a new $defs section).
+   - It is reflected in `tokens_to_css.py` if it affects CSS output.
+3. Re-run `python3 plugins/acss-kit/scripts/validate_theme.py` against `assets/brand-template.css` and `assets/brand-presets/*.css` to catch schema-related regressions.
+4. Run the `theme-reference-reviewer` agent.
+
+---
+
+## Step 5 — brand-preset change
+
+A change to a bundled brand preset CSS file must still satisfy WCAG 2.2 AA contrast pairs.
+
+1. Run `python3 plugins/acss-kit/scripts/validate_theme.py <path>`. Capture exit code + output.
+2. If validation fails:
+   - Surface the failing pairs.
+   - Ask the maintainer whether to (a) accept failures with documented divergences in a comment header in the file, (b) revert the change, or (c) tune the seed and regenerate via `/style-author --from=<hex> <preset-name>`.
+3. If validation passes, surface the contrast ratio summary and confirm the file's header comment still records the seed (`/* seed: #... */`) — if missing, prompt the maintainer to add it for future reproducibility.
+
+---
+
+## Step 6 — styles SKILL.md change
+
+A change to the styles SKILL itself usually touches the role list, contrast pair table, or workflow descriptions.
+
+1. Run the `theme-reference-reviewer` agent — it cross-checks the SKILL.md role list and contrast pair table against the schema and `validate_theme.py:PAIRS`.
+2. If the change touches command workflows (`/theme-create`, `/theme-brand`, `/theme-update`, `/theme-extract`), also run the `skill-quality-reviewer` agent on the file.
+3. Surface both reports inline.
+
+---
+
+## Final summary
+
+Every sub-flow ends with:
+- Files modified during the skill run (typically just the schema edit if Step 2 found drift).
+- Validation results: contrast pass/fail, reviewer agent verdict.
+- Manual follow-ups: any Python edits the maintainer must apply by hand.
+- Reminder to bump `acss-kit` version via `/release-plugin acss-kit <new-version>` if the change is user-visible.

--- a/docs/plans/project-skills-component-theme-lifecycle.md
+++ b/docs/plans/project-skills-component-theme-lifecycle.md
@@ -1,0 +1,145 @@
+---
+title: Project-level skills and agents for component & theme lifecycle
+status: completed
+type: standard
+plugins-touched: project-level (.claude/) only — no plugin code changed
+---
+
+# Project-level skills and agents for component & theme lifecycle
+
+## Context
+
+The `acss-kit` plugin (currently v0.3.0) ships three skills (`components`, `styles`, `component-form`), 6 user-facing slash commands (`/kit-add`, `/kit-list`, `/theme-create`, `/theme-brand`, `/theme-update`, `/theme-extract`), and 5 Python scripts. The plugin is in active iteration — recent commits show frequent component reference doc additions, canonical-shape backfills, and Codex review cycles.
+
+Project-level (`.claude/`) tooling currently covers **release** (`release-plugin`, `release-check`) and **structural validation** (`validate-plugin`, `verify-plugins`, `add-command`), plus two reviewer agents (`skill-quality-reviewer`, `python-script-reviewer`). What is **missing** is tooling to streamline the day-to-day authoring loop: scaffolding new component reference docs in the canonical embedded-markdown shape, scaffolding new theme assets/roles, re-validating existing assets after edits, and getting a single-glance plugin-health audit before release.
+
+This plan adds five maintainer-side skills and two reviewer agents (with two thin command wrappers) to close that gap. All new tooling lives at the project level (`.claude/`), so it is invisible to plugin end users and only loads when the maintainer is working in this repo.
+
+## Objective
+
+Make it cheap and predictable for the maintainer to add or update components and themes without re-reading the canonical shape spec each time, and without forgetting catalog updates, fpkit verification banners, or downstream re-validation.
+
+## Scope
+
+Five skills, two agents, two command wrappers, one README touch-up. Nine new files plus one edit. No changes to the `acss-kit` plugin itself.
+
+| Type    | Path                                                          | Trigger / use                                                                |
+| ------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Skill   | `.claude/skills/component-author/SKILL.md`                    | Scaffold a new component reference doc + catalog entry                       |
+| Skill   | `.claude/skills/component-update/SKILL.md`                    | Re-verify and refresh an existing component reference doc                    |
+| Skill   | `.claude/skills/style-author/SKILL.md`                        | Scaffold a new bundled brand preset, palette role, or theme-schema field     |
+| Skill   | `.claude/skills/style-update/SKILL.md`                        | Re-validate and roll forward existing theme assets after edits               |
+| Skill   | `.claude/skills/plugin-health/SKILL.md`                       | One-shot plugin audit dashboard (validate + canonical-shape + catalog drift) |
+| Agent   | `.claude/agents/component-reference-reviewer.md`              | Audit a single component reference doc against canonical shape rules         |
+| Agent   | `.claude/agents/theme-reference-reviewer.md`                  | Audit theme references (role-catalogue, palette-algorithm, theme-schema)     |
+| Command | `.claude/commands/review-component.md`                        | Slash wrapper for `component-reference-reviewer`                             |
+| Command | `.claude/commands/review-themes.md`                           | Slash wrapper for `theme-reference-reviewer`                                 |
+| Edit    | `.claude/agents/README.md`                                    | Document the two new agents alongside existing entries                       |
+
+## Design rationale (alternatives considered)
+
+- **Author/update split vs. unified `component-edit`.** Chose split. Splitting gives Claude unambiguous trigger phrases ("add Tabs component" → `component-author`; "update button to support aria-pressed" → `component-update`), and the workflows differ enough (scaffolding vs. re-verification) that one merged skill would either bloat or under-specify both flows. Cost: two skill files instead of one.
+- **Skills vs. agents vs. commands.** Mirrors the existing pattern: skills for multi-step workflows, agents for read-only review, commands as thin slash wrappers around agents (the `review-script` / `python-script-reviewer` pair is the precedent). Skills auto-discover by name and don't need command files unless we want a short slash invocation — left out here to keep scope tight.
+- **Auto-trigger via hooks.** Deferred to Next Steps. The reviewer agents are designed to work both manually and as hook callbacks; wiring the PostToolUse hook on `references/components/*.md` is a separate one-line `settings.json` edit.
+- **New Python helpers.** Not added. The reviewer agents do canonical-shape checking in Markdown by reading section headers — adequate for the current 17-component catalog. A `verify_canonical_shape.py` helper is on the Next Steps list if the agent's checks become slow or noisy.
+
+## Critical files (read before implementing)
+
+Implementer should skim these to keep new content consistent:
+
+- [plugins/acss-kit/skills/components/SKILL.md](plugins/acss-kit/skills/components/SKILL.md) — canonical 9-section spec lives in the "Authoring New Components" section at the bottom (line ~414).
+- [plugins/acss-kit/skills/components/references/components/button.md](plugins/acss-kit/skills/components/references/components/button.md) — reference example of the canonical shape (verification banner at line 3, generation contract at line 9).
+- [plugins/acss-kit/skills/components/references/components/catalog.md](plugins/acss-kit/skills/components/references/components/catalog.md) — single source of truth for verification status table.
+- [plugins/acss-kit/skills/styles/SKILL.md](plugins/acss-kit/skills/styles/SKILL.md) — role catalogue (15 required + 3 optional roles), 10 WCAG contrast pairs, 4 theme commands.
+- [plugins/acss-kit/skills/styles/references/role-catalogue.md](plugins/acss-kit/skills/styles/references/role-catalogue.md) — full role list and contrast targets.
+- [plugins/acss-kit/skills/styles/references/palette-algorithm.md](plugins/acss-kit/skills/styles/references/palette-algorithm.md) — OKLCH lightness / hue rules.
+- [plugins/acss-kit/skills/styles/references/theme-schema.md](plugins/acss-kit/skills/styles/references/theme-schema.md) — JSON schema and round-trip contract.
+- [plugins/acss-kit/assets/brand-template.css](plugins/acss-kit/assets/brand-template.css) — bundled brand template (only one currently; `style-author` may add more).
+- [.claude/skills/add-command/SKILL.md](.claude/skills/add-command/SKILL.md) — reference template for a project-level scaffolder skill.
+- [.claude/skills/release-plugin/SKILL.md](.claude/skills/release-plugin/SKILL.md) — reference template for a project-level action skill.
+- [.claude/agents/skill-quality-reviewer.md](.claude/agents/skill-quality-reviewer.md) — reference template for a reviewer agent (front-matter + check structure + output format).
+
+## Existing tooling that gets reused (do not duplicate)
+
+- `python3 plugins/acss-kit/scripts/generate_palette.py` — used by `style-author` for new brand presets.
+- `python3 plugins/acss-kit/scripts/validate_theme.py` — used by `style-author` and `style-update` for WCAG re-validation.
+- `python3 plugins/acss-kit/scripts/tokens_to_css.py` — used by `style-author` for palette JSON → CSS conversion.
+- `validate-plugin` skill — invoked by `plugin-health` for structural checks.
+- `release-check` skill — referenced by `plugin-health` as the "what's left before commit" pointer.
+- `skill-quality-reviewer` agent — referenced by `plugin-health` for SKILL.md drift checks.
+
+## Implementation steps
+
+1. **Create `.claude/skills/component-author/SKILL.md`.**
+   - Front-matter: `name: component-author`, description matching trigger phrases like "add a new component", "scaffold a component reference doc", "create a Tabs component for acss-kit".
+   - Steps: validate `<component-name>` (lowercase, kebab-case, not already in catalog) → ask for fpkit ref version (default the captured ceiling from existing reference docs) → generate `plugins/acss-kit/skills/components/references/components/<name>.md` skeleton with all 9 canonical sections (verification banner, Overview, Generation Contract, Props Interface, TSX Template, CSS Variables, SCSS Template, Accessibility, Usage Examples) → add a row to `catalog.md` "Verification Status" table marked `Status: New — pending fpkit verification` → print summary listing the file paths and a reminder to fill in the TSX Template and Accessibility sections before committing.
+   - Do not implement the TSX/SCSS — leave fenced code blocks with `// TODO: copy from fpkit ${ref}` placeholders.
+
+2. **Create `.claude/skills/component-update/SKILL.md`.**
+   - Front-matter: `name: component-update`, description matching "update an existing component", "refresh button reference doc", "bump fpkit verification on a component".
+   - Steps: confirm the reference doc exists → re-fetch the upstream fpkit source at the captured ref (full GitHub URL, never `blob/main`) → diff against the local TSX/SCSS templates and surface drift → prompt the user to update the verification banner and bump the catalog entry status → call the `component-reference-reviewer` agent on the file → if generation_contract.export_name changed, warn that downstream `/kit-add` consumers may break.
+   - Preserves the canonical shape; does not introduce new sections.
+
+3. **Create `.claude/skills/style-author/SKILL.md`.**
+   - Front-matter: `name: style-author`, description matching "add a brand preset", "add a new theme role", "scaffold a bundled brand template", "extend the role catalogue".
+   - Three sub-flows (the user picks one via AskUserQuestion at the start):
+     - **Brand preset** — generate `plugins/acss-kit/assets/brand-presets/<name>.css` from a seed hex by running `generate_palette.py <hex> --mode=brand` and writing the CSS, then re-validating with `validate_theme.py`. Updates the `styles` SKILL.md "Bundled brand presets" list (creating that section on first run).
+     - **New role** — guided edit of `references/role-catalogue.md`, `references/theme-schema.md`, and `assets/theme.schema.json` to add a new optional role. Reminds the user to update `tokens_to_css.py:ROLE_GROUPS` and to flag whether the new role should be required (default: optional).
+     - **Palette algorithm tweak** — guided edit of `references/palette-algorithm.md` followed by regeneration of the bundled brand template via `generate_palette.py` and re-validation.
+   - All flows finish with a contrast-pair re-validation summary.
+
+4. **Create `.claude/skills/style-update/SKILL.md`.**
+   - Front-matter: `name: style-update`, description matching "update theme reference", "refine the palette algorithm", "re-validate themes after a role change".
+   - Steps: detect which file the user is editing (role-catalogue / palette-algorithm / theme-schema / brand-presets/*) → run the appropriate downstream re-validation (e.g., role catalogue change → re-run `tokens_to_css.py` + `validate_theme.py` on bundled presets; schema change → confirm `theme.schema.json` is in sync; algorithm change → regenerate bundled presets) → call `theme-reference-reviewer` agent.
+
+5. **Create `.claude/skills/plugin-health/SKILL.md`.**
+   - Front-matter: `name: plugin-health`, description matching "audit acss-kit", "plugin health check", "what's missing before release".
+   - Steps: invoke `validate-plugin acss-kit` (existing skill) → walk `references/components/*.md` and report any missing canonical sections → cross-check `catalog.md` Verification Status against actual files → run `validate_theme.py` on bundled brand presets → summarize "OK / FIX" per category → if any failures, suggest the precise sub-skill to fix (e.g., "5 components missing canonical Accessibility sections — run `/component-update <name>` for each").
+   - Output is a single dashboard, no edits.
+
+6. **Create `.claude/agents/component-reference-reviewer.md`.**
+   - Front-matter: `name: component-reference-reviewer`, description "Reviews a single component reference doc against the canonical embedded-markdown shape and catalog.md verification table. Use when authoring or editing references/components/<name>.md."
+   - Checks: (1) verification banner present at top with `**Verified against fpkit source:**` blockquote; (2) all 9 canonical sections present in correct order; (3) Generation Contract has `export_name`, `file`, `scss`, `imports`, `dependencies`; (4) all fpkit URLs are full `https://github.com/shawn-sandy/acss/...` links pinned to a tag/SHA (not `blob/main`); (5) component appears in `catalog.md` Verification Status table; (6) TSX Template imports only `UI from '../ui'`, React, and other vendored components — never `@fpkit/acss`.
+   - Output: PASS / FAIL per check, exact line numbers for failures, no file modifications.
+
+7. **Create `.claude/agents/theme-reference-reviewer.md`.**
+   - Front-matter: `name: theme-reference-reviewer`, description "Reviews theme references (role-catalogue, palette-algorithm, theme-schema) for internal consistency and parity with the Python scripts."
+   - Checks: (1) every role in `role-catalogue.md` appears in `assets/theme.schema.json` `$defs/palette` and in `tokens_to_css.py:ROLE_GROUPS`; (2) the 10 WCAG contrast pairs in `styles/SKILL.md` match `validate_theme.py:PAIRS`; (3) the OKLCH lightness anchors in `palette-algorithm.md` match constants in `generate_palette.py`; (4) bundled brand presets validate cleanly via `validate_theme.py`.
+   - Output: PASS / FAIL per check with file:line citations.
+
+8. **Create `.claude/commands/review-component.md`.**
+   - Thin wrapper: `argument-hint: <path/to/references/components/file.md>`, body delegates to `component-reference-reviewer` agent. Mirror the structure of `review-script.md`.
+
+9. **Create `.claude/commands/review-themes.md`.**
+   - Thin wrapper: no arguments, body delegates to `theme-reference-reviewer` agent. Mirror the structure of `review-scripts.md`.
+
+10. **Edit `.claude/agents/README.md`.**
+    - Add two entries (one paragraph each) describing the new agents, mirroring the existing entry style. Keep the file index-shaped; long content lives in the agent files themselves.
+
+## Verification
+
+After implementation, exercise each new skill end-to-end:
+
+1. **`component-author` smoke test.** Run on a fictional component (e.g., `tabs-test`). Confirm the file is created with all 9 sections and that `catalog.md` gets a new row. Delete the test file and revert the catalog edit.
+2. **`component-update` smoke test.** Run against `references/components/button.md` (which is already canonical-shape ✓). The skill should report "no drift detected" and re-run the reviewer agent cleanly.
+3. **`style-author` brand preset smoke test.** Run with a seed hex (e.g., `#0f766e`). Confirm a new file lands under `assets/brand-presets/`, palette JSON is valid, and `validate_theme.py` reports passing pairs.
+4. **`style-update` smoke test.** Edit a comment-only line in `role-catalogue.md`, run the skill, confirm it re-validates without spurious failures.
+5. **`plugin-health` smoke test.** Run on the current branch. Output should be a clean dashboard with mostly OK status (the catalog has known legacy `nav.md` and `form.md` entries — these should appear as "FIX" with a pointer to `/component-update`).
+6. **`component-reference-reviewer` direct invocation.** `/review-component plugins/acss-kit/skills/components/references/components/button.md` — should report all PASS.
+7. **`theme-reference-reviewer` direct invocation.** `/review-themes` — should report all PASS against the current state.
+
+After verification, do the standard pre-submit checklist: bump `acss-kit` plugin? **No** — these are project-level files only, no plugin version bump required. Do update the root `CLAUDE.md` if it documents the project-level toolchain (it currently mentions some skills by name; check for additions worth listing).
+
+## Next Steps (out of scope)
+
+- **Auto-trigger reviewer agents via hooks.** Add PostToolUse hook entries in `.claude/settings.json` matching `references/components/*.md` and `references/{role-catalogue,palette-algorithm,theme-schema}.md` paths to auto-invoke the reviewer agents on save.
+- **`verify_canonical_shape.py` helper.** A stdlib Python script that asserts the 9 sections are present in correct order; replaces the agent's markdown-grep approach if it becomes slow.
+- **`/release-check` integration.** Have `release-check` call `plugin-health` automatically and surface the dashboard before clearing the release.
+- **Component spec extraction.** If the legacy `acss-component-specs` parity check is reactivated in the future, add a `/component-sync` skill that pulls upstream spec changes into reference docs.
+- **Maintainer command index.** Add a project-level `/help-maint` command that lists every project-level skill and one-line usage.
+
+## Unresolved Questions
+
+- Should `style-author` create a new `assets/brand-presets/` directory for bundled brand presets, or extend the existing `assets/brand-template.css` pattern? (Plan currently assumes a new `brand-presets/` directory; flagging because this introduces a new convention.)
+- Should the reviewer agents auto-load via `disable-model-invocation: false` so they trigger on natural-language phrases ("review this component"), or should they only run when explicitly invoked from a skill or `/review-*` command?
+- Should I bump the project-wide tooling under a new `tools/` umbrella (e.g., `.claude/skills/maint/component-author/`) instead of flat at `.claude/skills/`? Existing project skills are flat, so the plan keeps the flat layout — confirm.

--- a/docs/plans/project-skills-component-theme-lifecycle.md
+++ b/docs/plans/project-skills-component-theme-lifecycle.md
@@ -83,7 +83,7 @@ Implementer should skim these to keep new content consistent:
 3. **Create `.claude/skills/style-author/SKILL.md`.**
    - Front-matter: `name: style-author`, description matching "add a brand preset", "add a new theme role", "scaffold a bundled brand template", "extend the role catalogue".
    - Three sub-flows (the user picks one via AskUserQuestion at the start):
-     - **Brand preset** — generate `plugins/acss-kit/assets/brand-presets/<name>.css` from a seed hex by running `generate_palette.py <hex> --mode=brand` and writing the CSS, then re-validating with `validate_theme.py`. Updates the `styles` SKILL.md "Bundled brand presets" list (creating that section on first run).
+     - **Brand preset** — generate `plugins/acss-kit/assets/brand-presets/brand-<name>.css` (the `brand-` prefix is required so the file matches `validate_theme.py`'s `^(light|dark|brand-[\w-]+)\.css$` regex) by piping `generate_palette.py <hex> --mode=brand` through a JSON reshape stage (`{brand_overrides}` → `{brands: {<name>: ...}}`) into `tokens_to_css.py --stdin`, then re-validating with `validate_theme.py`. Updates the `styles` SKILL.md "Bundled brand presets" list (creating that section on first run).
      - **New role** — guided edit of `references/role-catalogue.md`, `references/theme-schema.md`, and `assets/theme.schema.json` to add a new optional role. Reminds the user to update `tokens_to_css.py:ROLE_GROUPS` and to flag whether the new role should be required (default: optional).
      - **Palette algorithm tweak** — guided edit of `references/palette-algorithm.md` followed by regeneration of the bundled brand template via `generate_palette.py` and re-validation.
    - All flows finish with a contrast-pair re-validation summary.
@@ -122,7 +122,7 @@ After implementation, exercise each new skill end-to-end:
 
 1. **`component-author` smoke test.** Run on a fictional component (e.g., `tabs-test`). Confirm the file is created with all 9 sections and that `catalog.md` gets a new row. Delete the test file and revert the catalog edit.
 2. **`component-update` smoke test.** Run against `references/components/button.md` (which is already canonical-shape ✓). The skill should report "no drift detected" and re-run the reviewer agent cleanly.
-3. **`style-author` brand preset smoke test.** Run with a seed hex (e.g., `#0f766e`). Confirm a new file lands under `assets/brand-presets/`, palette JSON is valid, and `validate_theme.py` reports passing pairs.
+3. **`style-author` brand preset smoke test.** Run with a seed hex (e.g., `#0f766e`). Confirm a new file lands at `assets/brand-presets/brand-<name>.css` (with the `brand-` prefix added by `tokens_to_css.py`), palette JSON is valid, and `validate_theme.py` reports `validate_theme: OK` (not `no palette files found` — that would mean the filename did not match the regex and the validation was silently skipped).
 4. **`style-update` smoke test.** Edit a comment-only line in `role-catalogue.md`, run the skill, confirm it re-validates without spurious failures.
 5. **`plugin-health` smoke test.** Run on the current branch. Output should be a clean dashboard with mostly OK status (the catalog has known legacy `nav.md` and `form.md` entries — these should appear as "FIX" with a pointer to `/component-update`).
 6. **`component-reference-reviewer` direct invocation.** `/review-component plugins/acss-kit/skills/components/references/components/button.md` — should report all PASS.


### PR DESCRIPTION
## Summary

Adds maintainer-side project-level tooling (`.claude/`) for streamlining day-to-day acss-kit component and theme authoring. No changes to plugin code.

- **5 skills** at `.claude/skills/`: `component-author`, `component-update`, `style-author`, `style-update`, `plugin-health`
- **2 reviewer agents** at `.claude/agents/`: `component-reference-reviewer` (canonical embedded-markdown shape + catalog parity), `theme-reference-reviewer` (markdown ↔ JSON schema ↔ Python script parity)
- **2 slash commands** at `.claude/commands/`: `/review-component`, `/review-themes`
- Updates `.claude/agents/README.md` to document the two new agents
- Plan committed at `docs/plans/project-skills-component-theme-lifecycle.md`

## Why

The current project-level toolkit covers releases (`release-plugin`, `release-check`) and structural validation (`validate-plugin`, `verify-plugins`, `add-command`), but the **authoring loop** for components and themes still requires re-reading the canonical embedded-markdown spec, remembering catalog updates, and remembering downstream re-validation steps. This change closes that gap with explicit scaffolding skills, lightweight update workflows, and reviewer agents that audit canonical shape and cross-source parity.

## Reviewer notes

- All new skills follow the existing project-skill template (see [`add-command`](.claude/skills/add-command/SKILL.md) and [`release-plugin`](.claude/skills/release-plugin/SKILL.md) for the precedent).
- Reviewer agents mirror the structure of [`skill-quality-reviewer`](.claude/agents/skill-quality-reviewer.md) and [`python-script-reviewer`](.claude/agents/python-script-reviewer.md) — read-only, PASS/FAIL per check, predictable output format.
- Reviewer auto-trigger via `disable-model-invocation` is **off** (manual + slash-command only). PostToolUse hooks for auto-triggering are listed under "Next Steps" in the plan.
- The `style-author` brand-preset sub-flow introduces a new convention: `plugins/acss-kit/assets/brand-presets/` for bundled brand presets (distinct from the existing user-facing `assets/brand-template.css`).
- No `acss-kit` plugin version bump — this is project-level tooling only.

## Test plan

- [ ] Smoke-test `/component-author tabs-test` and confirm the file lands at `plugins/acss-kit/skills/components/references/components/tabs-test.md` with all 9 canonical sections, plus a new row in `catalog.md`. Then revert.
- [ ] Smoke-test `/component-update button` against the existing canonical-shape `button.md`. Should report no drift.
- [ ] Smoke-test `/style-author --from=#0f766e sunset` and confirm `assets/brand-presets/sunset.css` is created and `validate_theme.py` reports passing pairs. Then revert.
- [ ] Run `/plugin-health acss-kit` and verify the dashboard renders cleanly.
- [ ] Run `/review-component plugins/acss-kit/skills/components/references/components/button.md` — should report all PASS.
- [ ] Run `/review-themes` — should report all PASS against current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)