### PR TITLE
feat(tests): automated structural validation harness + Storybook scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ CLAUDE.local.md
 
 # Local plugin testing
 tests/sandbox/
+tests/.tmp/
+tests/node_modules/
 
 # Python bytecode
 __pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,11 @@ Bump only `plugin.json`. Do not add a `version` key to `marketplace.json` entrie
 
 Before committing any plugin change:
 
-1. `plugin.json` version bumped (use `/release-plugin acss-kit`)
-2. All SKILL.md references to fpkit source use full GitHub URLs, not repo-relative paths
-3. `marketplace.json` description updated if the change is user-facing
-4. Plugin-level `README.md` and `CHANGELOG.md` updated if commands or behavior changed
+1. `tests/run.sh` is green (one-time install: `npm --prefix tests ci && pip3 install --user tinycss2`)
+2. `plugin.json` version bumped (use `/release-plugin acss-kit`)
+3. All SKILL.md references to fpkit source use full GitHub URLs, not repo-relative paths
+4. `marketplace.json` description updated if the change is user-facing
+5. Plugin-level `README.md` and `CHANGELOG.md` updated if commands or behavior changed
 
 ## Git workflow
 
@@ -80,7 +81,9 @@ Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direc
 
 ## Testing locally
 
-Run `tests/setup.sh` from the repo root to scaffold a disposable Vite+React+TS sandbox at `tests/sandbox/` (gitignored), then `cd tests/sandbox && claude` and paste the recipe the script printed. See [`tests/README.md`](./tests/README.md) for the full workflow, including the `--reset` flag.
+The default check is `tests/run.sh` from the repo root — automated structural validation in ~30 seconds. It extracts and syntax-checks every component reference, validates the SCSS contract, runs WCAG contrast on theme files, and replicates the manifest checks. One-time install: `npm --prefix tests ci` and `pip3 install --user tinycss2`.
+
+For end-to-end smoke testing of slash commands (rendering output, exercising `/kit-add` and `/theme-create`), `tests/setup.sh` scaffolds a disposable Vite+React+TS sandbox at `tests/sandbox/` (gitignored). For render-sensitive changes, `tests/storybook.sh` runs the optional Storybook + axe-playwright deep check (~3–4 min). See [`tests/README.md`](./tests/README.md) for the full workflow.
 
 Full validation: manual SKILL.md review → local install → smoke-test slash commands → run Python scripts against a sample project.
 

--- a/docs/plans/test-infrastructure-rewrite.md
+++ b/docs/plans/test-infrastructure-rewrite.md
@@ -1,0 +1,247 @@
+# Rewrite test structure: replace Vite sandbox with automated validation
+
+## Context
+
+Today there is no automated test suite. `tests/setup.sh` scaffolds a Vite+React+TS sandbox at `tests/sandbox/`; the developer then opens a `claude` session inside it, runs `/kit-add` and `/theme-create` by hand, and visually verifies that files land on disk and `npm run build` succeeds. Vite is not running tests — it is the host project the plugin's output gets imported into.
+
+Two pressures motivate the rewrite:
+
+1. **Manual smoke-testing scales poorly.** The plugin now ships ~18 components plus theme generation and a form skill. A regression in any one of them slips past human review unless the maintainer happens to re-run that exact command.
+2. **Markdown-as-source changes the testing options.** Since v0.3.0, the canonical TSX/SCSS for every component lives as fenced code blocks inside `plugins/acss-kit/skills/components/references/<component>.md`. That means the "plugin output" can be extracted and validated *without ever running Claude or booting a React app*. This was not true before the markdown-as-source consolidation.
+
+Goal: design a test harness that catches plugin-output regressions automatically on every PR, with the lowest dep cost that still meaningfully verifies the contract.
+
+## Objective
+
+Replace the manual `tests/setup.sh` workflow with an automated validation harness, after evaluating two candidate approaches and committing to one (or a hybrid).
+
+## Approaches considered
+
+### Approach A — Storybook + test-runner
+
+A Storybook harness at `plugins/acss-kit/.harness/` (gitignored after install). A Node extractor walks `references/components/*.md`, parses ` ```tsx ` / ` ```scss ` blocks, substitutes placeholders, and writes the components plus auto-generated stories from existing `## Usage Examples` blocks. CI runs `build-storybook` then `@storybook/test-runner` with `axe-playwright` for accessibility checks.
+
+**What it verifies well:** live render, runtime DOM a11y, real prop wiring, TS types at build time.
+**What it misses:** theme contrast (no story for CSS-only files), SCSS contract violations that render but break the rem-only / `var()`-fallback rules.
+**Cost:** ~12 npm devDeps including Playwright browser download (~350–500 MB), CI run ~3–4 minutes, new GitHub Actions workflow.
+
+### Approach B — Static structural & code validation
+
+A Bash entrypoint `tests/run.sh` orchestrates two validators: `plugins/acss-kit/scripts/validate_components.py` (Python stdlib — markdown structure + SCSS contract) and `plugins/acss-kit/scripts/validate_components.mjs` (Node + `typescript` — runs `tsc --noEmit` over extracted TSX). Themes get the existing [`validate_theme.py`](plugins/acss-kit/scripts/validate_theme.py); manifests get the existing `validate-plugin` / `verify-plugins` skills.
+
+**What it verifies well:** TS types, SCSS contract (rem-only, `var()` fallbacks, data-attribute selectors), WCAG contrast, manifest correctness, placeholder substitution, no `@fpkit/acss` imports leaking back in.
+**What it misses:** runtime render errors, live a11y bugs (e.g. focus-order regressions), real DOM behavior.
+**Cost:** 1 npm devDep (`typescript` ~70 MB), Python stays stdlib-only, CI run ~30 seconds.
+
+### Comparison summary
+
+| Axis | A (Storybook) | B (Static) |
+|---|---|---|
+| New devDeps | ~12 npm packages, browser download | 1 npm package |
+| CI runtime | 3–4 min | ~30 sec |
+| Catches theme contrast regressions | No | Yes (existing tool) |
+| Catches SCSS contract violations | No | Yes |
+| Catches runtime render errors | Yes | No |
+| Catches live a11y violations | Yes (axe) | Partial (textual checks only) |
+| Catches type errors in extracted TSX | Yes | Yes |
+| Catches `@fpkit/acss` import leak | Yes | Yes |
+| Fits markdown-as-source architecture | High | High |
+| Maintenance per new component | Auto from `## Usage Examples` | Auto from code blocks |
+
+## Decision: hybrid, B-as-default, local-only
+
+**Approach B becomes the default check** (`tests/run.sh`, ~30 sec, catches the silent regressions). **Approach A becomes opt-in local verification** invoked as `tests/run.sh --with-storybook` (developers run it before merging anything render-sensitive). The Vite sandbox at `tests/sandbox/` survives as the user-facing demo path documented in `RECIPE.md` — it stops being "the tests."
+
+No GitHub Actions workflow ships with this work. Validation runs locally; documenting `tests/run.sh` as a pre-PR ritual is the contract. CI is a future follow-up if the harness proves useful in practice.
+
+Why split this way: the silent regressions (missing rem unit, missing `var()` fallback, theme contrast drift, manifest/version desync) are cheap to detect statically and slip past human review reliably. The loud regressions (a `Dialog` that fails to mount) surface immediately when any developer first imports the component, so they do not need an automated gate to catch them — they need a local check on demand. Optimizing the default check for sensitivity-per-second favours Approach B; optimizing the local "deep check" for coverage favours Approach A.
+
+Pure-A would burn ~3–4 minutes per run on a browser download and miss theme/SCSS regressions entirely. Pure-B would miss the occasional runtime regression. The hybrid uses each tool where its yield is highest.
+
+## Steps
+
+### Phase 1 — Approach B: structural + code validation (CI gate)
+
+1. **Create the shared extractor** at `plugins/acss-kit/scripts/lib/extract.mjs` (Node, ESM). Walks a passed reference markdown file, parses ` ```tsx ` and ` ```scss ` fenced blocks under `## TSX Template` / `## SCSS Template`, substitutes `{{IMPORT_SOURCE:...}}` / `{{NAME}}` / `{{FIELDS}}` against a passed-in vars object, returns `{ tsx, scss }`. Used by all subsequent validators (and, if Phase 2 lands, by the Storybook harness too). *Why a single extractor:* tests assert the same generation logic that `/kit-add` performs at runtime — divergence between the two would defeat the test.
+
+2. **Create [`tests/validate_components.mjs`](tests/validate_components.mjs)** (Node). For every reference doc under `skills/components/references/components/`:
+   - Extracts `foundation.md`'s `## TSX Template` block first, writes to `tests/.tmp/ui.tsx` so component imports resolve. *No vendored TSX file* — extractor processes `foundation.md` as a first-class component.
+   - Calls the extractor with default fixture vars from `tests/fixtures/component-vars.json`.
+   - Writes outputs to `tests/.tmp/extracted/<component>/<component>.{tsx,scss}` (gitignored).
+   - Runs `tsc --noEmit --jsx react-jsx --strict` over the directory; fails if any diagnostic.
+   - Asserts: every `import` resolves to either `react` or a relative path; no `@fpkit/acss` imports.
+   - **Hard fails** (with the file path and the missing element in the error message) when a reference has a `## TSX Template` heading but no `tsx` fenced code block, or fences without a language. No skip-on-malformed mode.
+   *Why Node + `tsc`:* the only dependency that gives meaningful "does this TSX type-check" answers. Python regex cannot resolve module imports. *Why under `tests/` and not `plugins/acss-kit/scripts/`:* this is test infrastructure, not a runtime plugin script — it sits outside the plugin's stdlib-only contract.
+
+3. **Create [`tests/validate_components.py`](tests/validate_components.py)** (Python, may use `tinycss2` — test infra is exempt from the plugin's stdlib-only rule). Follows the existing detector contract: JSON to stdout, `reasons` array. For every extracted `.scss`:
+   - Parses each file with `tinycss2` (or libsass via subprocess) into compiled CSS, *then* runs regex assertions over the compiled output. *Why parse first:* SCSS nesting, `@if`/`@each`, and `#{$var}` interpolation produce false positives when scanned raw with regex; the parser flattens to AST-correct CSS.
+   - Asserts every `var(--color-*, ...)` and `var(--font-*, ...)` reference includes a fallback.
+   - Asserts every numeric value uses `rem`, `%`, `fr`, `vh|vw`, `calc()`, or `0` — bare `px` fails except in an allowlist (e.g. `1px solid` borders).
+   - Asserts no class-name conflicts across components (each `.<name>` declared at most once across the directory).
+   - Hard fails on malformed `## SCSS Template` sections, same contract as the TSX validator.
+
+4. **Create [`tests/validate_manifest.py`](tests/validate_manifest.py)** (Python). Replicates the manifest/structure checks currently performed by the `verify-plugins` skill: required `plugin.json` fields, no `version` key in `marketplace.json` plugin entries, required files present (`README.md`, `CHANGELOG.md`, `commands/*.md`, at least one `SKILL.md`). *Why replicate instead of invoke:* the `verify-plugins` skill is invoked from inside Claude sessions; there is no documented CLI bridge, so the harness needs its own copy to run standalone.
+
+5. **Create [`tests/run.sh`](tests/run.sh)** (Bash) as the single entrypoint. In order:
+   1. `rm -rf tests/.tmp && mkdir -p tests/.tmp` — wipe stale state. *Documented as serial-only:* concurrent runs in the same checkout are unsupported.
+   2. `node tests/validate_components.mjs` — extract + tsc.
+   3. `python3 tests/validate_components.py tests/.tmp/extracted` — SCSS contract.
+   4. `python3 plugins/acss-kit/scripts/validate_theme.py plugins/acss-kit/assets/theme/*.css` — existing WCAG validator (still lives under the plugin since it's a runtime script).
+   5. `python3 tests/validate_manifest.py` — manifest/structure replication.
+   6. Run the known-bad self-tests (step 7 below).
+   Exit non-zero if any step fails; print a summary line per step regardless of outcome. *Why Bash orchestrator:* matches the existing `setup.sh` location convention and keeps language polyglot without a Node-vs-Python build step.
+
+6. **Add `tests/fixtures/component-vars.json`** with realistic placeholder values (`NAME: "Button"`, `componentsDir: "src/components/fpkit"`, `IMPORT_SOURCE: "../ui"`, etc.). *Form fixture deferred:* `tests/fixtures/form-vars.json` is out of scope until the `component-form` skill enters validation scope (see step 11).
+
+7. **Add `tests/fixtures/known-bad/`** with two files: `known-bad.tsx` (banned `@fpkit/acss` import + missing `aria-disabled`) and `known-bad.scss` (missing `var()` fallback, bare `px` value). The harness runs both validators against this dir as a final step in `tests/run.sh` and **expects failure** — exits non-zero if either passes. *Why:* without this, a regex regression in either validator silently passes everything. Cheap insurance for the test-the-tests gap.
+
+8. **Add devDependency** `typescript` to a minimal `tests/package.json` (Node-only, no React imports). *Why a separate `tests/package.json`:* keeps the harness's lockfile out of the plugin's user-facing surface and avoids confusing `/plugin install` consumers who never need it.
+
+9. **Add `.gitignore` entries** for `tests/.tmp/`, `tests/node_modules/`. **Commit `tests/package-lock.json`** for reproducibility (one devDep, churn is minimal).
+
+10. **Update [`tests/README.md`](tests/README.md)** to document `tests/run.sh` as the primary path. Include:
+    - The serial-only constraint on `tests/.tmp/`.
+    - A "Component Form gap" callout: `skills/component-form/SKILL.md` is not yet covered by the harness; manual smoke-test via the demo sandbox is the current verification path.
+    - A literal escape-hatch instruction for harness regressions: *"If a bug in the validator itself is blocking your PR, comment out the failing step in `tests/run.sh` in your branch and link the bug report in the PR description."* Honest about reality without compromising the no-bypass default.
+    - One-line note explaining the `.mjs` extension (ESM by default, no `type: "module"` needed in `package.json`).
+    - The manual sandbox flow demoted to "User-facing demo (run before opening a PR that touches a slash command's prose)."
+
+11. **Update [`CLAUDE.md`](CLAUDE.md) "Testing locally" section** to point to `tests/run.sh` first, sandbox second.
+
+### Phase 2 — Approach A: optional Storybook deep check
+
+12. **Audit `## Usage Examples` blocks** before scaffolding anything. Run `grep -l "## Usage Examples" plugins/acss-kit/skills/components/references/components/*.md` and read 3 docs to confirm the section exists across the catalog and contains renderable JSX (not prose-only or wrapped in non-renderable contexts). If the assumption breaks, redesign the story-generation step before continuing. *Why first:* Phase 2's whole design depends on this assumption; better to confirm in 5 minutes than discover it after scaffolding.
+
+13. **Create the Storybook harness scaffold** at `plugins/acss-kit/.harness/` with `package.json`, `vite.config.ts`, `.storybook/main.ts`, `.storybook/preview.ts`. Add to `.gitignore` so installed deps never commit. *Why under the plugin and not under `tests/`:* the harness is plugin-internal; version-locking it to the plugin's references is a feature.
+
+14. **Create the story generator** `plugins/acss-kit/scripts/generate_stories.mjs`. Reuses Phase 1's `extract.mjs` to extract TSX, then walks `## Usage Examples` blocks in the same reference doc and emits one `<component>.stories.tsx` per component, one story per top-level JSX expression. Writes to `.harness/src/generated/`. *Why `## Usage Examples` and not a new `## Story` block:* every reference doc already has usage examples; adding a new required section would be migration cost without a coverage win.
+
+15. **Create [`tests/storybook.sh`](tests/storybook.sh)** as a separate entrypoint (not a flag on `run.sh`). Runs `npm --prefix plugins/acss-kit/.harness ci`, `node plugins/acss-kit/scripts/generate_stories.mjs`, `npm --prefix plugins/acss-kit/.harness run build-storybook`, `npm --prefix plugins/acss-kit/.harness run test-storybook`. *Why a separate script:* two single-purpose scripts beat one branch-heavy script when the second path is rarely run; keeps `tests/run.sh` simple.
+
+16. **Document the deep check** in `tests/README.md`: when to run it (before merging anything render-sensitive), what failure modes it catches that Phase 1 does not, and the local prerequisite of `npx playwright install`.
+
+### Phase 3 — Demote the manual workflow
+
+17. **Update [`tests/setup.sh`](tests/setup.sh)** to print a banner: "This scaffolds a demo sandbox; for automated tests run `tests/run.sh`." The script keeps working — it just stops being the documented testing path.
+
+18. **Remove the "Testing locally" section's claim that `tests/setup.sh` is the testing entrypoint** from any plugin-level README that asserts it.
+
+19. **Stop referencing the sandbox in PR review checklists** (if any exist in the repo or in `release-check`); replace with `tests/run.sh`.
+
+## Verification
+
+End-to-end checks after Phase 1 lands:
+
+1. Clean checkout: `cd plugins/acss-kit && find . -name "*.md"` → ensure references exist as expected. Then run `tests/run.sh` from the repo root. Expect exit 0, all four steps green.
+2. Inject a regression: edit one component reference doc to remove a `var()` fallback (e.g. `var(--color-primary, #4f46e5)` → `var(--color-primary)`). Re-run `tests/run.sh`. Expect exit 1 and the SCSS validator's `reasons` array calls out the file and the offending var.
+3. Inject a TS regression: edit a reference's TSX block to add `import x from '@fpkit/acss'`. Re-run. Expect exit 1 from the Node validator with a clear "import not allowed" message.
+4. Inject a theme regression: edit `assets/theme/light.css` to set `--color-text` to a low-contrast value against `--color-background`. Re-run. Expect exit 1 from `validate_theme.py`.
+5. Inject a manifest regression: bump `plugin.json` `version` without touching `CHANGELOG.md`. Re-run. Expect `release-check` (invoked indirectly) to flag the missing changelog entry.
+
+After Phase 2 lands:
+
+6. `tests/storybook.sh` on a clean checkout: expect Storybook to build, then test-runner to run all stories with no axe violations. (`tests/run.sh` should also still pass independently.)
+7. Inject a runtime regression in a `## TSX Template` block (e.g. throw inside a component on mount). Re-run `tests/storybook.sh`. Expect `tests/run.sh` to still pass (textual checks don't catch it) but Storybook test-runner to fail on that component's story.
+
+Self-tests (verify the harness catches its own contract violations):
+
+8. Run `tests/run.sh` on a clean checkout: the known-bad fixtures in `tests/fixtures/known-bad/` are intentionally malformed; the harness should treat them as **expected failures** and exit 0 only if both fail validation. If known-bad files start passing, the validator regex has regressed.
+
+## Critical files to create or modify
+
+**Phase 1:**
+- [`plugins/acss-kit/scripts/lib/extract.mjs`](plugins/acss-kit/scripts/lib/extract.mjs) — new, shared markdown-block extractor + placeholder substitution. Header comment documents the substitution contract and reminds maintainers to mirror changes in `/kit-add` prose.
+- [`tests/validate_components.mjs`](tests/validate_components.mjs) — new, Node + `tsc`. Test infra, not a runtime plugin script.
+- [`tests/validate_components.py`](tests/validate_components.py) — new, Python (may use `tinycss2`). Follows detector contract.
+- [`tests/validate_manifest.py`](tests/validate_manifest.py) — new, replicates `verify-plugins` skill's checks.
+- [`tests/run.sh`](tests/run.sh) — new, Bash orchestrator with `rm -rf tests/.tmp` as the first action.
+- [`tests/fixtures/component-vars.json`](tests/fixtures/component-vars.json) — new.
+- [`tests/fixtures/known-bad/`](tests/fixtures/known-bad/) — new, intentional-failure smoke test for the validators themselves.
+- [`tests/package.json`](tests/package.json) + [`tests/package-lock.json`](tests/package-lock.json) — new, single devDep `typescript`. Lockfile committed.
+- [`tests/README.md`](tests/README.md) — updated; primary path is `tests/run.sh`, includes Component Form gap callout, escape-hatch note, `.mjs` rationale.
+- [`.gitignore`](.gitignore) — add `tests/.tmp/` and `tests/node_modules/`.
+
+**Phase 2 (optional):**
+- `plugins/acss-kit/.harness/` (gitignored) — Storybook scaffold.
+- [`plugins/acss-kit/scripts/generate_stories.mjs`](plugins/acss-kit/scripts/generate_stories.mjs) — new, story generator that reuses `extract.mjs`.
+- [`tests/storybook.sh`](tests/storybook.sh) — new, separate entrypoint for the deep check.
+
+**Phase 3:**
+- [`tests/setup.sh`](tests/setup.sh) — updated banner only, otherwise unchanged.
+- [`CLAUDE.md`](CLAUDE.md) — updated Testing locally section.
+- [`plugins/acss-kit/README.md`](plugins/acss-kit/README.md) — remove any "Testing locally" claim that names `tests/setup.sh` as the entrypoint.
+
+## Existing utilities to reuse
+
+- [`plugins/acss-kit/scripts/validate_theme.py`](plugins/acss-kit/scripts/validate_theme.py) — WCAG 2.2 AA contrast pairings (already exists, just gets wrapped by `tests/run.sh`).
+- `validate-plugin`, `verify-plugins`, `release-check` skills at the repo root — manifest and structure validation.
+- The detector and generator script contracts documented in [`CLAUDE.md`](CLAUDE.md) — new Python validator follows the detector contract (JSON to stdout, `reasons` array).
+- The `{{IMPORT_SOURCE:...}}` / `{{NAME}}` / `{{FIELDS}}` placeholder convention used by `/kit-add` at runtime — the extractor in step 1 is a deterministic re-implementation of that same logic.
+
+## Next steps (out of scope)
+
+- Add `.github/workflows/validate.yml` to run `tests/run.sh` on every PR once the harness has proven useful in local practice.
+- Extend the harness to cover `skills/component-form/SKILL.md` once `{{FIELDS}}` substitution stabilizes. Add `tests/fixtures/form-vars.json` at that point.
+- A `/kit-test <component>` slash command that runs `tests/run.sh` scoped to one component for fast iteration during reference-doc edits.
+- A pre-commit hook in `.claude/hooks/` that runs `tests/run.sh` on edits to `references/**/*.md`.
+- Visual regression snapshots in the Storybook harness (Chromatic or `@storybook/test-runner`'s screenshot mode) — only worth it if the team wants pixel-level review.
+- Promoting Storybook from opt-in to a second CI job once the team has paid the browser-download cost ergonomically (caching Playwright in GHA).
+
+---
+
+## Interview Summary
+
+This section captures decisions and open risks surfaced during `/plan-interview` before implementation.
+
+### Key Decisions Confirmed
+
+**Extractor drift mitigation (Round 1):** Document the substitution contract in `extract.mjs` with a "mirror this in /kit-add" comment header. Cheapest path; relies on humans noticing when `/kit-add` prose changes. Acceptable while the placeholder rules stay simple (`{{NAME}}`, `{{IMPORT_SOURCE:...}}`, `{{FIELDS}}`).
+
+**SCSS parsing strategy (Round 1):** Use Python's `tinycss2` (or libsass via subprocess) to parse SCSS into compiled CSS first, then run regex assertions over the compiled output. AST-correct without stylelint's Node-deps cost. The validator lives under `tests/`, not `plugins/acss-kit/scripts/`, so the project's stdlib-only contract stays intact.
+
+**Skill invocation (Round 1):** Skip invoking `verify-plugins` from `tests/run.sh`. Replicate the manifest/structure checks as a dedicated `tests/validate_manifest.py` so the harness stays decoupled from any Claude runtime. Some logic duplication accepted as the cost of standalone-runnability.
+
+**Foundation handling (Round 1):** Extractor treats `foundation.md` as a first-class component — extracts its `## TSX Template` block into `tests/.tmp/ui.tsx` before processing any component. No fallback to a vendored `.tsx` file.
+
+**Form skill scope (Round 3):** `skills/component-form/SKILL.md` is excluded from this rewrite. Validator only walks `skills/components/references/components/`. Documented as a gap in `tests/README.md`.
+
+**Malformed reference handling (Round 3):** Hard fail with a clear error message identifying the file and the missing element (e.g. *"references/components/dialog.md has `## TSX Template` heading but no `tsx` fenced code block"*). No skip/warn modes.
+
+**Temp dir contract (Round 3):** `tests/run.sh` wipes `tests/.tmp/` (`rm -rf` then `mkdir`) at the start of every run. Documented as serial-only — concurrent runs in the same checkout are unsupported.
+
+**Bypass policy (Round 3):** No environment variable bypass, no skip flag. If `tests/run.sh` cannot run, the contributor cannot ship. The `tests/README.md` documents a literal escape hatch (comment out the failing step + link bug report) for harness regressions only.
+
+### Plan Naming
+
+| Element | Current | Issue | Suggested | User decision |
+|---------|---------|-------|-----------|---------------|
+| Filename | `i-want-to-rewrite-calm-hammock.md` | Random pattern (`calm-hammock`) unrelated to content | `test-infrastructure-rewrite.md` | Accepted — file renamed and moved to `docs/plans/` |
+| H1 Heading | `# Rewrite test structure: replace Vite sandbox with automated validation` | Pass — descriptive | _(no change)_ | n/a |
+
+### Open Risks & Concerns
+
+1. **Extractor↔runtime drift is accepted, not eliminated.** If `/kit-add` evolves its substitution rules and the comment in `extract.mjs` is missed during review, validator success becomes meaningless. Re-evaluate if a real divergence ever bites.
+2. **`tinycss2` is third-party.** It is permitted under `tests/` but introduces a new Python dependency for the test suite. Document the install step in `tests/README.md`. If `tinycss2` proves brittle, the libsass-via-subprocess fallback is a known-good alternative.
+3. **The harness has no automated rollback path.** With "no bypass" + "hard fail on malformed", a regression in the validator itself blocks every PR. Mitigation: the literal escape hatch documented in `tests/README.md`. Honest acknowledgement of reality.
+4. **Phase 2's `## Usage Examples` assumption is unverified.** Step 12 audits this before scaffolding; if it breaks, Phase 2's design must change.
+5. **Manifest replication can drift from `verify-plugins`.** Two implementations of the same contract diverge over time. If both are ever found out of sync, pick one as canonical and have the other invoke it.
+
+### Recommended Next Steps
+
+The following amendments from the interview have been integrated into the plan body above:
+
+1. Step 2 tightened to lock the foundation extraction path (no vendored TSX hedge).
+2. Step 3 declares `tinycss2` parsing strategy; validators moved from `plugins/acss-kit/scripts/` to `tests/` to honor the stdlib-only contract.
+3. New step 4 for `tests/validate_manifest.py` replacing the `verify-plugins` skill invocation.
+4. Step 5 adds `rm -rf tests/.tmp` as the first action; documents serial-only constraint.
+5. Step 6 drops `tests/fixtures/form-vars.json`; deferred until form is in scope.
+6. New step 7 adds `tests/fixtures/known-bad/` for harness self-tests.
+7. Step 9 commits `tests/package-lock.json` for reproducibility.
+8. Step 10 expands `tests/README.md` content with gap callout, escape hatch, and `.mjs` rationale.
+9. New step 12 audits `## Usage Examples` blocks before Phase 2 scaffolding.
+10. Step 15 replaces `tests/run.sh --with-storybook` flag with a separate `tests/storybook.sh` script.
+
+### Simplification Opportunities Applied
+
+- Replaced `--with-storybook` flag with a separate `tests/storybook.sh` script. Two single-purpose scripts beat one branch-heavy script.
+- Dropped `tests/fixtures/form-vars.json` from Phase 1. Form skill is out of scope; the second fixture is dead surface until that changes.

--- a/plugins/acss-kit/.harness/.gitignore
+++ b/plugins/acss-kit/.harness/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+src/generated/
+storybook-static/
+package-lock.json

--- a/plugins/acss-kit/.harness/.storybook/main.ts
+++ b/plugins/acss-kit/.harness/.storybook/main.ts
@@ -1,0 +1,13 @@
+import type { StorybookConfig } from '@storybook/react-vite'
+
+const config: StorybookConfig = {
+  stories: ['../src/generated/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-a11y'],
+  framework: { name: '@storybook/react-vite', options: {} },
+  typescript: {
+    check: false,
+    reactDocgen: false,
+  },
+}
+
+export default config

--- a/plugins/acss-kit/.harness/.storybook/preview.ts
+++ b/plugins/acss-kit/.harness/.storybook/preview.ts
@@ -1,0 +1,14 @@
+import type { Preview } from '@storybook/react-vite'
+
+const preview: Preview = {
+  parameters: {
+    a11y: {
+      // axe-playwright runs against the rendered DOM; this configures
+      // the addon panel for interactive Storybook usage.
+      element: '#storybook-root',
+      manual: false,
+    },
+  },
+}
+
+export default preview

--- a/plugins/acss-kit/.harness/.storybook/test-runner.ts
+++ b/plugins/acss-kit/.harness/.storybook/test-runner.ts
@@ -1,0 +1,21 @@
+// Storybook test-runner hook that injects axe-core into each story page
+// and runs `checkA11y` on the rendered DOM. Without this file,
+// `npm run test-storybook` only verifies that stories mount; the
+// accessibility audits we advertise in the harness README would silently
+// be no-ops.
+import { injectAxe, checkA11y } from 'axe-playwright'
+import type { TestRunnerConfig } from '@storybook/test-runner'
+
+const config: TestRunnerConfig = {
+  async preVisit(page) {
+    await injectAxe(page)
+  },
+  async postVisit(page) {
+    await checkA11y(page, '#storybook-root', {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    })
+  },
+}
+
+export default config

--- a/plugins/acss-kit/.harness/README.md
+++ b/plugins/acss-kit/.harness/README.md
@@ -1,0 +1,51 @@
+# acss-kit Storybook Harness
+
+Optional, opt-in deep check for live render and runtime accessibility audits of the components defined in `plugins/acss-kit/skills/components/references/components/*.md`.
+
+**This is not the default test gate.** For everyday PR validation, run `tests/run.sh` from the repo root — that catches the majority of contract regressions in ~30 seconds without a browser. This harness adds runtime DOM verification for changes that affect rendering.
+
+## When to use
+
+- Before merging a change that touches a component's TSX Template, especially focus-management or compound-component patterns.
+- After modifying `assets/foundation/ui.tsx` (or its markdown equivalent) where the polymorphic base could affect every consumer.
+- When investigating a runtime regression that the static harness cannot reproduce.
+
+## How to run
+
+From the repo root:
+
+```sh
+tests/storybook.sh
+```
+
+The script:
+
+1. Runs `npm --prefix plugins/acss-kit/.harness ci` if `node_modules/` is missing.
+2. Generates `<component>.stories.tsx` files into `src/generated/` from the `## Usage Examples` blocks of each reference doc.
+3. Builds Storybook (`storybook build`).
+4. Runs `@storybook/test-runner` with `axe-playwright` for accessibility checks.
+
+First run also requires `npx playwright install` to download the Playwright browser bundle (~300 MB). Subsequent runs reuse the cached bundle.
+
+## What this catches
+
+- Live render errors — a component throws on mount.
+- Runtime DOM accessibility violations from `axe-playwright` against every story.
+
+## What this does not catch
+
+- Theme contrast regressions (no Storybook story for CSS-only files) — see `validate_theme.py`.
+- SCSS contract violations that render but break the rules — see `tests/validate_components.py`.
+- Manifest / structure drift — see `tests/validate_manifest.py`.
+
+Run `tests/run.sh` first; this harness is supplementary.
+
+## Contents
+
+This directory ships only the configuration scaffolding. Generated stories and dependencies are produced on demand and gitignored:
+
+- `package.json` — Storybook + Vite + axe-playwright dependencies.
+- `vite.config.ts` — Vite + React plugin config.
+- `.storybook/main.ts` — Storybook entry pointing at `src/generated/`.
+- `.storybook/preview.ts` — runtime preview config for the a11y addon.
+- `src/generated/` (gitignored) — auto-generated stories from `## Usage Examples` blocks.

--- a/plugins/acss-kit/.harness/package.json
+++ b/plugins/acss-kit/.harness/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "acss-kit-harness",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Storybook deep-check harness for acss-kit. Not published. Generated artifacts under src/generated/ are produced by plugins/acss-kit/scripts/generate_stories.mjs.",
+  "type": "module",
+  "scripts": {
+    "build-storybook": "storybook build",
+    "test-storybook": "test-storybook",
+    "storybook": "storybook dev -p 6006"
+  },
+  "devDependencies": {
+    "@storybook/addon-a11y": "^8.0.0",
+    "@storybook/react-vite": "^8.0.0",
+    "@storybook/test-runner": "^0.19.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "axe-playwright": "^2.0.0",
+    "playwright": "^1.45.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "sass": "^1.77.0",
+    "storybook": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/plugins/acss-kit/.harness/vite.config.ts
+++ b/plugins/acss-kit/.harness/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -246,7 +246,15 @@ This table is the single source of truth for which components have been migrated
 
 ### 5. Verify locally
 
-Bootstrap a sandbox via `tests/setup.sh` from the repo root, then `cd tests/sandbox && claude` and run `/kit-add <component>`. Confirm the generated `.tsx` and `.scss` match what your reference doc declared.
+For automated structural validation (the default before opening a PR):
+
+```sh
+tests/run.sh
+```
+
+This extracts the new reference doc, syntax-checks the TSX, validates the SCSS contract (var fallbacks), and confirms the manifest is intact. See [`tests/README.md`](../../tests/README.md) for first-time setup.
+
+For end-to-end smoke testing — confirming `/kit-add <component>` actually writes a usable file — bootstrap the demo sandbox: `tests/setup.sh` from the repo root, then `cd tests/sandbox && claude` and run `/kit-add <component>`.
 
 ## Plugin Structure
 

--- a/plugins/acss-kit/scripts/generate_stories.mjs
+++ b/plugins/acss-kit/scripts/generate_stories.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Generate Storybook stories from the `## Usage Examples` blocks of each
+// component reference doc. Used by the Storybook deep-check harness at
+// plugins/acss-kit/.harness/.
+//
+// Strategy:
+//   1. For each reference doc, parse all ```tsx blocks under
+//      `## Usage Examples`. Each top-level JSX expression becomes one story.
+//   2. Stories are emitted under .harness/src/generated/<name>/<name>.stories.tsx.
+//   3. The component itself comes from extract.mjs's TSX extraction —
+//      we vendor extracted components into .harness/src/generated/<name>/
+//      so stories can `import { ComponentName } from './<name>'`.
+//
+// This script is wired up but currently best-effort: usage-example blocks
+// vary in shape (some are full snippets with `const x = ...`, some are
+// raw JSX, some are interspersed with explanatory prose). The story
+// generator captures what it can; manual review of the .harness/ output
+// is expected before merging render-sensitive changes.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { extractFromMarkdown } from './lib/extract.mjs'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '../../..')
+const REFS_DIR = join(
+  REPO_ROOT,
+  'plugins/acss-kit/skills/components/references/components',
+)
+const OUT_DIR = join(
+  REPO_ROOT,
+  'plugins/acss-kit/.harness/src/generated',
+)
+
+const SKIP = new Set(['catalog', 'foundation'])
+
+function parseUsageExamples(content) {
+  // Only look at the `## Usage Examples` section.
+  const lines = content.split('\n')
+  const blocks = []
+  let inSection = false
+  let inFence = false
+  let fenceLang = ''
+  let buffer = []
+
+  for (const line of lines) {
+    const heading = line.match(/^##\s+(.+?)\s*$/)
+    if (heading) {
+      const h = heading[1].trim()
+      if (/^Usage Examples\b/i.test(h)) {
+        inSection = true
+        continue
+      }
+      if (inSection) {
+        // Any subsequent ## ends the Usage Examples section.
+        break
+      }
+    }
+
+    const fence = line.match(/^```(\w*)\s*$/)
+    if (fence && inSection) {
+      if (!inFence) {
+        inFence = true
+        fenceLang = fence[1].toLowerCase()
+        buffer = []
+      } else {
+        if (fenceLang === 'tsx' || fenceLang === 'jsx') {
+          blocks.push(buffer.join('\n'))
+        }
+        inFence = false
+        buffer = []
+      }
+      continue
+    }
+
+    if (inFence) buffer.push(line)
+  }
+
+  return blocks
+}
+
+function pascalCase(name) {
+  return name
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join('')
+}
+
+function emitStoryFile(name, blocks) {
+  const componentName = pascalCase(name)
+  const stories = blocks
+    .map((body, i) => {
+      const storyName = `Example${i + 1}`
+      // Best-effort: dump the block body as a render() story. Authors are
+      // expected to clean these up if they include declarations or imports.
+      const cleaned = body
+        .replace(/^\s*import[^;\n]*[;\n]/gm, '')
+        .trim()
+      return `export const ${storyName}: StoryObj = {
+  render: () => {
+    return (
+      <>
+${cleaned
+  .split('\n')
+  .map((l) => '        ' + l)
+  .join('\n')}
+      </>
+    )
+  },
+}`
+    })
+    .join('\n\n')
+
+  return `// AUTO-GENERATED from ../references/components/${name}.md.
+// Run plugins/acss-kit/scripts/generate_stories.mjs to regenerate.
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ${componentName} } from './${name}'
+
+const meta: Meta = {
+  title: 'Components/${componentName}',
+  component: ${componentName} as never,
+}
+
+export default meta
+
+${stories}
+`
+}
+
+function main() {
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true, force: true })
+  mkdirSync(OUT_DIR, { recursive: true })
+
+  const refs = readdirSync(REFS_DIR).filter((f) => f.endsWith('.md'))
+  let storiesEmitted = 0
+
+  for (const refFile of refs) {
+    const name = refFile.replace(/\.md$/, '')
+    if (SKIP.has(name)) continue
+
+    const refPath = join(REFS_DIR, refFile)
+    const content = readFileSync(refPath, 'utf8')
+    const blocks = parseUsageExamples(content)
+    if (blocks.length === 0) continue
+
+    const componentDir = join(OUT_DIR, name)
+    mkdirSync(componentDir, { recursive: true })
+
+    // Vendor the component itself from the extractor's outputs.
+    const { tsx, scss } = extractFromMarkdown(content)
+    if (tsx) writeFileSync(join(componentDir, `${name}.tsx`), tsx)
+    if (scss) writeFileSync(join(componentDir, `${name}.scss`), scss)
+
+    const storyContent = emitStoryFile(name, blocks)
+    writeFileSync(join(componentDir, `${name}.stories.tsx`), storyContent)
+    storiesEmitted += blocks.length
+  }
+
+  console.log(
+    `generate_stories.mjs: emitted stories for ${
+      readdirSync(OUT_DIR).length
+    } components (${storiesEmitted} story exports)`,
+  )
+}
+
+main()

--- a/plugins/acss-kit/scripts/lib/extract.mjs
+++ b/plugins/acss-kit/scripts/lib/extract.mjs
@@ -8,7 +8,8 @@
 // validation harness.
 //
 // Public API:
-//   extractFromMarkdown(content, vars?) -> { tsx, scss, name, foundation }
+//   extractFromMarkdown(content, vars?) -> { tsx, scss }
+//   extractFromFile(path, vars?)        -> { tsx, scss, name }
 //
 // Extraction rules:
 //   - TSX: only ```tsx blocks under `## Props Interface(s)` and

--- a/plugins/acss-kit/scripts/lib/extract.mjs
+++ b/plugins/acss-kit/scripts/lib/extract.mjs
@@ -1,0 +1,134 @@
+// Shared markdown-as-source extractor for acss-kit reference docs.
+//
+// MIRROR THIS IN /kit-add: this module is a deterministic re-implementation
+// of the assembly logic that /kit-add performs at runtime. If you change
+// substitution rules, section names, or extraction order here, mirror the
+// change in plugins/acss-kit/skills/components/SKILL.md and any /kit-add
+// command prose. Drift between this module and /kit-add silently breaks the
+// validation harness.
+//
+// Public API:
+//   extractFromMarkdown(content, vars?) -> { tsx, scss, name, foundation }
+//
+// Extraction rules:
+//   - TSX: only ```tsx blocks under `## Props Interface(s)` and
+//     `## TSX Template`. Key Pattern sections are intentionally excluded
+//     because some contain illustrative JSX (e.g. `<Card><Card.Title>...`)
+//     or inline-only snippets (e.g. destructuring `props` outside a
+//     function body) that aren't valid at module scope. The TSX Template
+//     block is the canonical file `/kit-add` writes — Key Pattern bodies
+//     are inlined into it at runtime via marker comments, so we don't
+//     need to assemble them ourselves for syntax validation.
+//   - SCSS: only the first ```scss block within a `## SCSS Template`
+//     or `## SCSS Pattern` section. `## CSS Variables` blocks are
+//     documentation only — excluded.
+//   - Placeholder substitution: {{NAME}}, {{IMPORT_SOURCE:...}}, {{FIELDS}}
+//     against an optional vars object. Current reference docs use no
+//     placeholders; substitution is forward-compatible scaffolding.
+
+import { readFileSync } from 'node:fs'
+import { basename } from 'node:path'
+
+const TSX_SECTION_HEADINGS = [
+  /^Props Interfaces?\b/i,
+  /^TSX Template\b/i,
+]
+
+const SCSS_TEMPLATE_HEADINGS = [
+  /^SCSS Template\b/i,
+  /^SCSS Pattern\b/i,
+  /^CSS Variables \/ SCSS Template\b/i,
+]
+
+function isTsxSectionHeading(heading) {
+  return TSX_SECTION_HEADINGS.some((re) => re.test(heading))
+}
+
+function isScssTemplateHeading(heading) {
+  return SCSS_TEMPLATE_HEADINGS.some((re) => re.test(heading))
+}
+
+function substitute(text, vars) {
+  if (!vars) return text
+  let out = text
+  for (const [key, val] of Object.entries(vars)) {
+    if (key === 'IMPORT_SOURCE_MAP') continue
+    out = out.replaceAll(`{{${key}}}`, String(val))
+  }
+  if (vars.IMPORT_SOURCE_MAP && typeof vars.IMPORT_SOURCE_MAP === 'object') {
+    out = out.replaceAll(/\{\{IMPORT_SOURCE:([^}]+)\}\}/g, (_, names) => {
+      const list = names.split(',').map((n) => n.trim())
+      const sources = new Set(
+        list.map((n) => vars.IMPORT_SOURCE_MAP[n] ?? `'../${n.toLowerCase()}'`),
+      )
+      return [...sources].join(', ')
+    })
+  }
+  return out
+}
+
+export function extractFromMarkdown(content, vars) {
+  const lines = content.split('\n')
+  const tsxBlocks = []
+  let scssBlock = null
+  let inFence = false
+  let fenceLang = ''
+  let fenceBuffer = []
+  let inTsxSection = false
+  let inScssTemplateSection = false
+  let scssBlockClaimed = false
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^##\s+(.+?)\s*$/)
+    if (headingMatch && !inFence) {
+      const heading = headingMatch[1].trim()
+      inTsxSection = isTsxSectionHeading(heading)
+      inScssTemplateSection = isScssTemplateHeading(heading)
+      continue
+    }
+
+    const fenceMatch = line.match(/^```(\w*)\s*$/)
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true
+        fenceLang = fenceMatch[1].toLowerCase()
+        fenceBuffer = []
+      } else {
+        const body = fenceBuffer.join('\n')
+        if (fenceLang === 'tsx' && inTsxSection) {
+          tsxBlocks.push(body)
+        } else if (
+          fenceLang === 'scss' &&
+          inScssTemplateSection &&
+          !scssBlockClaimed
+        ) {
+          scssBlock = body
+          scssBlockClaimed = true
+        }
+        inFence = false
+        fenceLang = ''
+        fenceBuffer = []
+      }
+      continue
+    }
+
+    if (inFence) {
+      fenceBuffer.push(line)
+    }
+  }
+
+  const tsx = tsxBlocks.length > 0 ? tsxBlocks.join('\n\n') : null
+  const scss = scssBlock
+
+  return {
+    tsx: tsx ? substitute(tsx, vars) : null,
+    scss: scss ? substitute(scss, vars) : null,
+  }
+}
+
+export function extractFromFile(path, vars) {
+  const content = readFileSync(path, 'utf8')
+  const result = extractFromMarkdown(content, vars)
+  result.name = basename(path, '.md')
+  return result
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@ A full type-check would require either inlining helpers (fighting the markdown's
 
 ### `.mjs` extension
 
-The Node scripts under `tests/` and `plugins/acss-kit/scripts/lib/` use `.mjs` instead of `.js` so they parse as ES modules without requiring a `"type": "module"` field on `tests/package.json`.
+The Node scripts under `tests/` and `plugins/acss-kit/scripts/lib/` use `.mjs` to make their ES module format explicit at the file level. `tests/package.json` also sets `"type": "module"`; the explicit `.mjs` extension keeps the scripts unambiguous when read or executed in isolation, independent of which `package.json` is in scope.
 
 ### Escape hatch when the harness itself blocks unrelated work
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,15 +1,87 @@
 # Local Plugin Testing
 
-Smoke-test the `acss-kit` marketplace entry by installing it into a disposable Vite + React + TypeScript sandbox.
+Two complementary paths: an automated structural validation harness for catching contract regressions on every change, and a manual demo sandbox for exercising slash commands end-to-end.
 
-The sandbox lives at `tests/sandbox/` and is gitignored. Only the scaffolding (`setup.sh`, this file) is committed, so contributors can recreate the same starting point with one command.
+| Path | Command | When to run | What it catches |
+|------|---------|-------------|-----------------|
+| Structural validation | `tests/run.sh` | Before every PR; after editing any reference doc | Banned imports, malformed TSX, missing `var()` fallbacks, theme contrast regressions, manifest/structure drift |
+| Storybook deep check (optional) | `tests/storybook.sh` | Before merging anything render-sensitive | Live render errors, runtime DOM accessibility violations |
+| Demo sandbox | `tests/setup.sh` | When changing slash-command prose; for end-to-end smoke before release | Manual visual confirmation that `/kit-add`, `/theme-create`, etc. produce reasonable output |
 
-## Prerequisites
+## Structural validation: `tests/run.sh`
+
+The default check. ~30 seconds, no browser, single Node devDep.
+
+```sh
+# One-time setup
+npm --prefix tests ci
+pip3 install --user tinycss2
+
+# Every run
+tests/run.sh
+```
+
+What it does, in order:
+1. Wipes `tests/.tmp/`.
+2. Extracts TSX/SCSS code blocks from every `plugins/acss-kit/skills/components/references/components/*.md`. Syntax-checks the extracted TSX with TypeScript's parser API. Asserts no banned imports (`@fpkit/acss`).
+3. Validates the SCSS contract: every `var(--color-*)`, `var(--font-*)`, `var(--space-*)` reference must include a fallback.
+4. Runs the existing WCAG 2.2 AA contrast validator over any `plugins/acss-kit/assets/themes/*.css` (skipped silently if no theme files are present yet).
+5. Replicates the `verify-plugins` skill's manifest checks: required `plugin.json` fields, no `version` key in marketplace entries, required files present.
+6. Self-tests: runs the validators against `tests/fixtures/known-bad/` and asserts they FAIL. If known-bad starts passing, a validator regex has regressed.
+
+### Serial-only
+
+`tests/run.sh` wipes `tests/.tmp/` at the start of every run. Two concurrent runs in the same checkout will collide. If you need parallel runs, use separate worktrees.
+
+### Why syntax-only TSX validation
+
+The reference docs split TSX across several `## Key Pattern:` and `## Props Interface` sections, with the canonical file living under `## TSX Template`. The extractor pulls only `## Props Interface(s)` and `## TSX Template` — the two sections that match what `/kit-add` writes. Key Pattern sections are intentionally excluded because some contain illustrative JSX (e.g. `<Card><Card.Title>...`) or inline-only snippets (e.g. destructuring `props` outside a function body) that aren't valid at module scope.
+
+A full type-check would require either inlining helpers (fighting the markdown's documentary structure) or accepting non-trivial false negatives. Syntax-level validation via `ts.createSourceFile` catches what regex can't (malformed JSX, broken generics, unclosed strings) without that fight.
+
+### Component Form gap
+
+`skills/component-form/SKILL.md` is **not yet covered** by this harness. The form skill uses richer placeholder substitution (`{{FIELDS}}`) than the simple component references and is excluded from this iteration. Manual smoke-test via the demo sandbox below is the current verification path for form generation.
+
+### `.mjs` extension
+
+The Node scripts under `tests/` and `plugins/acss-kit/scripts/lib/` use `.mjs` instead of `.js` so they parse as ES modules without requiring a `"type": "module"` field on `tests/package.json`.
+
+### Escape hatch when the harness itself blocks unrelated work
+
+The harness has no `--skip` flag by design. If a regression in one of the validators is genuinely blocking work that has nothing to do with the failing check, the documented escape hatch is:
+
+1. In your branch only, comment out the offending step in `tests/run.sh`.
+2. Open a follow-up issue describing the validator bug and link it from your PR description.
+3. The reviewer can sign off as long as the bug fix is tracked.
+
+This is the literal-only escape — there is no `SKIP_TESTS=1` env var. Use it sparingly.
+
+## Storybook deep check: `tests/storybook.sh`
+
+Optional, opt-in. ~3–4 minutes including a Playwright browser download on first run. Run before merging anything render-sensitive.
+
+```sh
+npx playwright install      # one-time
+tests/storybook.sh
+```
+
+What it adds beyond `tests/run.sh`:
+- Live render verification (a component throws on mount).
+- Runtime DOM accessibility audits via `axe-playwright` against every story.
+
+What it does NOT add: theme contrast (no Storybook story for CSS-only files), SCSS contract violations that render but break the rules, manifest checks. Run `tests/run.sh` *first* — `tests/storybook.sh` is supplementary, not a replacement.
+
+## Demo sandbox: `tests/setup.sh`
+
+Recreates the original Vite + React + TypeScript sandbox flow for end-to-end slash-command verification.
+
+### Prerequisites
 
 - Node 20+ and npm on `PATH`
 - Claude Code CLI (`claude`) on `PATH`
 
-## One-Shot Setup
+### One-shot setup
 
 From the repo root:
 
@@ -27,7 +99,7 @@ The script:
 
 Re-run with `--reset` to wipe and recreate the sandbox.
 
-## Running The Recipe
+### Running the recipe
 
 ```sh
 cd tests/sandbox
@@ -43,9 +115,7 @@ Inside the Claude Code session, paste the block from `RECIPE.md`:
 
 The local marketplace suffix is `acss-plugins`, from the `name` field in `.claude-plugin/marketplace.json`.
 
-## Smoke Flow
-
-These commands prove the surviving consolidated plugin paths work:
+### Smoke flow
 
 ```text
 /plugin list
@@ -71,7 +141,7 @@ Create a signup form with email and password.
 
 The `component-form` skill should auto-trigger, vendor any missing form dependencies through `/kit-add`, and write a form under `src/forms/`.
 
-## Reset
+### Reset
 
 ```sh
 tests/setup.sh --reset
@@ -79,15 +149,17 @@ tests/setup.sh --reset
 
 Use this between unrelated test sessions or after a plugin run leaves the sandbox in a state you cannot easily reverse.
 
-## What This Does Not Cover
-
-- Automated assertions on Claude Code slash command output.
-- Full accessibility audits of generated React output.
-- Browser rendering checks.
-
 ## Troubleshooting
 
-**`Run this script from inside the acss-plugins repo`**
+**`tsc binary missing` or `typescript not installed`**
+
+Run `npm --prefix tests ci` from the repo root.
+
+**`tinycss2 not installed`**
+
+Run `pip3 install --user tinycss2`.
+
+**`Run this script from inside the acss-plugins repo` (setup.sh)**
 
 The script cannot find `.claude-plugin/marketplace.json`. `cd` to the repo root and re-run.
 
@@ -95,7 +167,7 @@ The script cannot find `.claude-plugin/marketplace.json`. `cd` to the repo root 
 
 Expected on a second run. Pass `--reset` if you want a clean rebuild.
 
-**`/plugin install acss-kit@acss-plugins` says "not found"`**
+**`/plugin install acss-kit@acss-plugins` says "not found"**
 
 Confirm the marketplace was added from the printed absolute repo path. Then run `/plugin marketplace list` and use the listed suffix if your Claude Code version normalizes it differently.
 

--- a/tests/fixtures/component-vars.json
+++ b/tests/fixtures/component-vars.json
@@ -1,0 +1,12 @@
+{
+  "NAME": "Button",
+  "componentsDir": "src/components/fpkit",
+  "IMPORT_SOURCE": "../ui",
+  "IMPORT_SOURCE_MAP": {
+    "UI": "'../ui'",
+    "Field": "'../field/field'",
+    "Input": "'../input/input'",
+    "Checkbox": "'../checkbox/checkbox'",
+    "Button": "'../button/button'"
+  }
+}

--- a/tests/fixtures/known-bad/known-bad.scss
+++ b/tests/fixtures/known-bad/known-bad.scss
@@ -1,0 +1,12 @@
+// Intentional contract violations. The harness must catch BOTH of these:
+//   1. var(--color-...) reference without a fallback.
+//   2. var(--font-...) reference without a fallback.
+//
+// If validate_components.py reports zero failures here, the var-fallback
+// regex has regressed. Add new known-bad cases when contract checks are
+// added or tightened.
+.known-bad {
+  color: var(--color-text);
+  background: var(--color-surface);
+  font-family: var(--font-body);
+}

--- a/tests/fixtures/known-bad/known-bad.tsx
+++ b/tests/fixtures/known-bad/known-bad.tsx
@@ -1,0 +1,10 @@
+// Intentional contract violations. The harness must catch BOTH of these:
+//   1. Banned import (`@fpkit/acss`).
+//   2. (Implicit) the file is in the known-bad/ tree and must trip
+//      the validators when run against it.
+//
+// If validate_components.mjs ever extracts and validates this without
+// failing, the validator's import-allowlist regex has regressed.
+import { Button } from '@fpkit/acss'
+
+export const KnownBad = () => <Button type="button">bad</Button>

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,55 @@
+{
+  "name": "acss-plugins-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "acss-plugins-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/react": "^18.3.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "acss-plugins-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Local test harness for the acss-plugins marketplace. Not published.",
+  "type": "module",
+  "scripts": {
+    "tsc": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/react": "^18.3.0"
+  }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Phase 1 test harness for acss-plugins.
+#
+# Runs the full structural validation gate. SERIAL ONLY — concurrent
+# runs in the same checkout will collide on tests/.tmp/. If you need
+# parallelism, run in separate worktrees.
+#
+# Steps:
+#   1. Wipe tests/.tmp/.
+#   2. Extract TSX/SCSS from acss-kit reference docs and syntax-check
+#      the extracted TSX with TypeScript's parser API.
+#   3. SCSS contract validation.
+#   4. WCAG theme contrast (existing tool, lives under the plugin).
+#   5. Manifest / structure replication of verify-plugins.
+#   6. Known-bad self-tests: confirm the validators catch their own
+#      contract violations.
+#
+# Why syntax-only TSX validation: the reference docs split TSX across
+# multiple Key Pattern sections containing illustrative JSX or
+# inline-only snippets that don't resolve at module scope. Full type
+# resolution would require either inlining helpers (fighting the docs'
+# documentary structure) or accepting non-trivial false negatives.
+# Syntax checks catch what regex can't (malformed JSX, broken generics)
+# without that fight.
+#
+# If a step in this script regresses and blocks unrelated work, the
+# documented escape hatch is to comment out the offending step in your
+# branch and link a bug report in the PR description (see tests/README.md).
+
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TMP_ROOT="$REPO_ROOT/tests/.tmp"
+EXTRACTED="$TMP_ROOT/extracted"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+section(){ printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+
+# Step 1
+section "1. wipe tests/.tmp/"
+rm -rf "$TMP_ROOT"
+mkdir -p "$EXTRACTED"
+
+# Step 2
+section "2. extract + syntax-check acss-kit references"
+node "$REPO_ROOT/tests/validate_components.mjs"
+
+# Step 3
+section "3. SCSS contract"
+python3 "$REPO_ROOT/tests/validate_components.py" "$EXTRACTED" >/dev/null
+green "SCSS contract OK"
+
+# Step 4
+section "4. WCAG theme contrast"
+THEME_DIR="$REPO_ROOT/plugins/acss-kit/assets"
+if compgen -G "$THEME_DIR/themes/*.css" > /dev/null; then
+  python3 "$REPO_ROOT/plugins/acss-kit/scripts/validate_theme.py" "$THEME_DIR/themes/"*.css >/dev/null
+  green "theme contrast OK"
+elif [ -f "$THEME_DIR/brand-template.css" ]; then
+  yellow "no themes/*.css yet; brand-template.css is the only theme on disk — skipping WCAG check"
+else
+  yellow "no theme css under $THEME_DIR — skipping WCAG check"
+fi
+
+# Step 5
+section "5. manifest / structure"
+python3 "$REPO_ROOT/tests/validate_manifest.py" >/dev/null
+green "manifest OK"
+
+# Step 6
+section "6. known-bad self-tests"
+KNOWN_BAD_TMP="$TMP_ROOT/known-bad"
+mkdir -p "$KNOWN_BAD_TMP"
+cp "$REPO_ROOT/tests/fixtures/known-bad/known-bad.scss" "$KNOWN_BAD_TMP/"
+
+# (a) SCSS validator must FAIL on known-bad.scss
+if python3 "$REPO_ROOT/tests/validate_components.py" "$KNOWN_BAD_TMP" >/dev/null 2>&1; then
+  red "known-bad: validate_components.py PASSED on known-bad fixtures (regex regressed)"
+  exit 1
+fi
+green "SCSS validator caught known-bad.scss"
+
+# (b) TSX validator must reject the banned import in known-bad.tsx.
+# Inject a synthetic reference that re-uses the known-bad.tsx as its TSX block,
+# then run the extractor — extraction must error on banned imports.
+KNOWN_BAD_REF="$KNOWN_BAD_TMP/known-bad.md"
+{
+  printf '%s\n\n' '# Component: KnownBad'
+  printf '%s\n\n' '## TSX Template'
+  printf '%s\n' '```tsx'
+  cat "$REPO_ROOT/tests/fixtures/known-bad/known-bad.tsx"
+  printf '%s\n' '```'
+  printf '%s\n\n' '## SCSS Template'
+  printf '%s\n' '```scss'
+  printf '%s\n' '.known-bad { padding: 1rem; }'
+  printf '%s\n' '```'
+  printf '%s\n' '## Accessibility'
+} > "$KNOWN_BAD_REF"
+
+# Run a synthetic extraction over this single file. Easiest: spawn a one-shot
+# Node script that imports extract.mjs and asserts the import check would fail.
+node --input-type=module -e "
+import { extractFromFile } from '$REPO_ROOT/plugins/acss-kit/scripts/lib/extract.mjs';
+const { tsx } = extractFromFile('$KNOWN_BAD_REF');
+if (!tsx) { console.error('known-bad: no tsx extracted'); process.exit(1); }
+if (!/@fpkit\/acss/.test(tsx)) { console.error('known-bad: banned import string not present in extracted TSX'); process.exit(1); }
+console.log('known-bad: TSX extraction surface intact');
+"
+
+green "TSX validator surface intact"
+
+section "ALL STEPS GREEN"
+green "Phase 1 harness passed."

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -51,15 +51,27 @@ node "$REPO_ROOT/tests/validate_components.mjs"
 
 # Step 3
 section "3. SCSS contract"
-python3 "$REPO_ROOT/tests/validate_components.py" "$EXTRACTED" >/dev/null
-green "SCSS contract OK"
+SCSS_LOG="$TMP_ROOT/scss-contract.log"
+if python3 "$REPO_ROOT/tests/validate_components.py" "$EXTRACTED" >"$SCSS_LOG"; then
+  green "SCSS contract OK"
+else
+  red "SCSS contract failed:"
+  cat "$SCSS_LOG"
+  exit 1
+fi
 
 # Step 4
 section "4. WCAG theme contrast"
 THEME_DIR="$REPO_ROOT/plugins/acss-kit/assets"
+THEME_LOG="$TMP_ROOT/theme-contrast.log"
 if compgen -G "$THEME_DIR/themes/*.css" > /dev/null; then
-  python3 "$REPO_ROOT/plugins/acss-kit/scripts/validate_theme.py" "$THEME_DIR/themes/"*.css >/dev/null
-  green "theme contrast OK"
+  if python3 "$REPO_ROOT/plugins/acss-kit/scripts/validate_theme.py" "$THEME_DIR/themes/"*.css >"$THEME_LOG"; then
+    green "theme contrast OK"
+  else
+    red "theme contrast failed:"
+    cat "$THEME_LOG"
+    exit 1
+  fi
 elif [ -f "$THEME_DIR/brand-template.css" ]; then
   yellow "no themes/*.css yet; brand-template.css is the only theme on disk — skipping WCAG check"
 else
@@ -68,8 +80,14 @@ fi
 
 # Step 5
 section "5. manifest / structure"
-python3 "$REPO_ROOT/tests/validate_manifest.py" >/dev/null
-green "manifest OK"
+MANIFEST_LOG="$TMP_ROOT/manifest.log"
+if python3 "$REPO_ROOT/tests/validate_manifest.py" >"$MANIFEST_LOG"; then
+  green "manifest OK"
+else
+  red "manifest validation failed:"
+  cat "$MANIFEST_LOG"
+  exit 1
+fi
 
 # Step 6
 section "6. known-bad self-tests"
@@ -85,33 +103,44 @@ fi
 green "SCSS validator caught known-bad.scss"
 
 # (b) TSX validator must reject the banned import in known-bad.tsx.
-# Inject a synthetic reference that re-uses the known-bad.tsx as its TSX block,
-# then run the extractor — extraction must error on banned imports.
+# Build a synthetic reference doc using known-bad.tsx as its TSX Template,
+# then call the *exported* checkImports() from validate_components.mjs
+# directly. This exercises the real validator code path; a stub regex
+# here would let import-allowlist regressions slip through.
 KNOWN_BAD_REF="$KNOWN_BAD_TMP/known-bad.md"
 {
   printf '%s\n\n' '# Component: KnownBad'
-  printf '%s\n\n' '## TSX Template'
+  printf '%s\n\n' '## Props Interface'
+  printf '%s\n' '```tsx'
+  printf '%s\n' 'export type KnownBadProps = { children?: React.ReactNode }'
+  printf '%s\n' '```'
+  printf '\n%s\n\n' '## TSX Template'
   printf '%s\n' '```tsx'
   cat "$REPO_ROOT/tests/fixtures/known-bad/known-bad.tsx"
   printf '%s\n' '```'
-  printf '%s\n\n' '## SCSS Template'
+  printf '\n%s\n\n' '## SCSS Template'
   printf '%s\n' '```scss'
   printf '%s\n' '.known-bad { padding: 1rem; }'
   printf '%s\n' '```'
-  printf '%s\n' '## Accessibility'
+  printf '\n%s\n' '## Accessibility'
 } > "$KNOWN_BAD_REF"
 
-# Run a synthetic extraction over this single file. Easiest: spawn a one-shot
-# Node script that imports extract.mjs and asserts the import check would fail.
-node --input-type=module -e "
+KNOWN_BAD_REF_PATH="$KNOWN_BAD_REF" node --input-type=module -e "
 import { extractFromFile } from '$REPO_ROOT/plugins/acss-kit/scripts/lib/extract.mjs';
-const { tsx } = extractFromFile('$KNOWN_BAD_REF');
+import { checkImports } from '$REPO_ROOT/tests/validate_components.mjs';
+
+const { tsx } = extractFromFile(process.env.KNOWN_BAD_REF_PATH);
 if (!tsx) { console.error('known-bad: no tsx extracted'); process.exit(1); }
-if (!/@fpkit\/acss/.test(tsx)) { console.error('known-bad: banned import string not present in extracted TSX'); process.exit(1); }
-console.log('known-bad: TSX extraction surface intact');
+
+const failures = checkImports('known-bad', tsx);
+if (failures.length === 0) {
+  console.error('known-bad: validate_components.mjs accepted banned import in synthetic reference');
+  process.exit(1);
+}
+console.log('known-bad: TSX validator caught', failures.length, 'failure(s)');
 "
 
-green "TSX validator surface intact"
+green "TSX validator caught known-bad.tsx"
 
 section "ALL STEPS GREEN"
 green "Phase 1 harness passed."

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Scaffold a disposable Vite + React + TypeScript sandbox at tests/sandbox/
-# for smoke-testing the acss-plugins marketplace locally.
+# for end-to-end demo and smoke-testing of the acss-plugins marketplace.
+#
+# This is the DEMO path. For automated test verification, run:
+#
+#     tests/run.sh
+#
+# The demo sandbox is appropriate when you are changing slash-command prose,
+# investigating a regression by running /kit-add or /theme-create by hand, or
+# verifying end-to-end output before a release. For everyday PR validation,
+# tests/run.sh is the documented entry point.
 #
 # Usage:
 #   tests/setup.sh           # first-time setup (errors if sandbox exists)
@@ -11,6 +20,12 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SANDBOX="$REPO_ROOT/tests/sandbox"
 RESET=0
+
+cat >&2 <<'BANNER'
+[tests/setup.sh] This scaffolds a demo sandbox for manual verification.
+                 For automated tests, run: tests/run.sh
+
+BANNER
 
 if [[ $# -gt 1 ]]; then
   echo "Too many arguments: $*" >&2

--- a/tests/storybook.sh
+++ b/tests/storybook.sh
@@ -30,8 +30,11 @@ fi
 # Step 1
 section "1. install storybook deps (if needed)"
 if [ ! -d "$HARNESS/node_modules" ]; then
-  yellow "node_modules/ missing — running npm ci (one-time, ~2-3 min)"
-  npm --prefix "$HARNESS" ci
+  # `npm install` (not `ci`): the harness gitignores its package-lock.json
+  # because the deep-check is opt-in dev tooling, not a reproducible
+  # build artifact.
+  yellow "node_modules/ missing — running npm install (one-time, ~2-3 min)"
+  npm --prefix "$HARNESS" install
 else
   green "deps already installed"
 fi

--- a/tests/storybook.sh
+++ b/tests/storybook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Phase 2 deep-check harness: Storybook + axe-playwright.
+#
+# Runs the optional Storybook deep check. Slower than tests/run.sh
+# (~3-4 min including Playwright browser download on first run).
+# Catches live render errors and runtime DOM accessibility violations
+# that the static harness cannot.
+#
+# Run tests/run.sh FIRST. This script does not duplicate its checks.
+#
+# Prerequisites:
+#   - Node 20+ and npm.
+#   - Playwright browser bundle (`npx playwright install` once).
+
+set -eo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HARNESS="$REPO_ROOT/plugins/acss-kit/.harness"
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+section(){ printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+
+if [ ! -d "$HARNESS" ]; then
+  red "Harness scaffold missing at $HARNESS"
+  exit 1
+fi
+
+# Step 1
+section "1. install storybook deps (if needed)"
+if [ ! -d "$HARNESS/node_modules" ]; then
+  yellow "node_modules/ missing — running npm ci (one-time, ~2-3 min)"
+  npm --prefix "$HARNESS" ci
+else
+  green "deps already installed"
+fi
+
+# Step 2
+section "2. generate stories from Usage Examples"
+node "$REPO_ROOT/plugins/acss-kit/scripts/generate_stories.mjs"
+
+# Step 3
+section "3. build storybook"
+npm --prefix "$HARNESS" run build-storybook
+
+# Step 4
+section "4. run test-storybook"
+yellow "If this is the first run on this machine, run \`npx playwright install\` first."
+npm --prefix "$HARNESS" run test-storybook
+
+green "Storybook deep check passed."

--- a/tests/validate_components.mjs
+++ b/tests/validate_components.mjs
@@ -25,8 +25,8 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { createRequire } from 'node:module'
 
 import { extractFromFile } from '../plugins/acss-kit/scripts/lib/extract.mjs'
@@ -61,7 +61,7 @@ function listReferences() {
     .map((f) => join(REFS_DIR, f))
 }
 
-function findImports(tsx) {
+export function findImports(tsx) {
   const re = /^\s*import\s+[^'"]+from\s+['"]([^'"]+)['"]/gm
   const sources = []
   let m
@@ -69,7 +69,7 @@ function findImports(tsx) {
   return sources
 }
 
-function checkImports(name, tsx) {
+export function checkImports(name, tsx) {
   const failures = []
   for (const src of findImports(tsx)) {
     for (const banned of BANNED_IMPORTS) {
@@ -123,7 +123,9 @@ function main() {
 
     if (!tsx) {
       failures.push(
-        `${name}: reference doc has no \`\`\`tsx fenced block before Accessibility/Usage Examples`,
+        `${name}: reference doc must include \`## Props Interface(s)\` and ` +
+          `\`## TSX Template\` sections, with at least one \`\`\`tsx fenced block ` +
+          `under one of those headings`,
       )
       continue
     }
@@ -168,7 +170,7 @@ function main() {
   const tsxFiles = []
   if (foundationWritten) tsxFiles.push(['foundation', join(TMP_DIR, 'ui.tsx')])
   for (const refPath of refs) {
-    const name = refPath.split('/').pop().replace(/\.md$/, '')
+    const name = basename(refPath, '.md')
     if (name === 'foundation') continue
     const candidate = join(TMP_DIR, name, `${name}.tsx`)
     if (existsSync(candidate)) tsxFiles.push([name, candidate])
@@ -190,4 +192,11 @@ function report(failures) {
   process.exit(1)
 }
 
-main()
+// Run main() only when invoked as a script, not when imported (e.g. by
+// the known-bad self-test in tests/run.sh which imports `checkImports`).
+if (
+  process.argv[1] &&
+  pathToFileURL(process.argv[1]).href === import.meta.url
+) {
+  main()
+}

--- a/tests/validate_components.mjs
+++ b/tests/validate_components.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Extract TSX/SCSS from acss-kit reference docs into tests/.tmp/extracted/
+// and validate the extracted TSX with TypeScript's parser API.
+//
+// What this validates:
+//   - Reference docs have the required sections (TSX Template + SCSS Template
+//     unless the component is in COMPONENTS_WITHOUT_SCSS).
+//   - Extracted TSX has no banned imports (e.g. @fpkit/acss).
+//   - Every import resolves to react or a relative path.
+//   - Extracted TSX parses successfully via ts.createSourceFile.
+//
+// What this does NOT validate (deliberately):
+//   - Full type resolution. The reference docs split TSX across Key Pattern
+//     sections that contain illustrative JSX or inline-only snippets (e.g.
+//     destructuring of `props` outside a function body). Trying to assemble
+//     a fully type-checking module fights the markdown's documentary
+//     structure. Syntax-level validation catches what regex can't (malformed
+//     JSX, broken generics, unclosed strings) without that fight.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+import { extractFromFile } from '../plugins/acss-kit/scripts/lib/extract.mjs'
+
+const requireCjs = createRequire(import.meta.url)
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+const REFS_DIR = join(
+  REPO_ROOT,
+  'plugins/acss-kit/skills/components/references/components',
+)
+const TMP_DIR = join(REPO_ROOT, 'tests/.tmp/extracted')
+const FIXTURES = join(REPO_ROOT, 'tests/fixtures/component-vars.json')
+
+// Components that legitimately ship without their own SCSS file:
+//   - icon: pure SVG dispatcher, no styles
+//   - foundation: polymorphic UI base, prose-only SCSS section
+//   - form: composes Field/Input/Checkbox; styling lives in those components
+const COMPONENTS_WITHOUT_SCSS = new Set(['icon', 'foundation', 'form'])
+const BANNED_IMPORTS = [/@fpkit\/acss/]
+const ALLOWED_IMPORT_PREFIXES = [/^react$/, /^\.\.?\//]
+
+function loadVars() {
+  if (!existsSync(FIXTURES)) return {}
+  return JSON.parse(readFileSync(FIXTURES, 'utf8'))
+}
+
+function listReferences() {
+  return readdirSync(REFS_DIR)
+    .filter((f) => f.endsWith('.md') && f !== 'catalog.md')
+    .map((f) => join(REFS_DIR, f))
+}
+
+function findImports(tsx) {
+  const re = /^\s*import\s+[^'"]+from\s+['"]([^'"]+)['"]/gm
+  const sources = []
+  let m
+  while ((m = re.exec(tsx)) !== null) sources.push(m[1])
+  return sources
+}
+
+function checkImports(name, tsx) {
+  const failures = []
+  for (const src of findImports(tsx)) {
+    for (const banned of BANNED_IMPORTS) {
+      if (banned.test(src)) {
+        failures.push(`${name}: banned import "${src}"`)
+      }
+    }
+    const allowed = ALLOWED_IMPORT_PREFIXES.some((re) => re.test(src))
+    if (!allowed) {
+      failures.push(
+        `${name}: import "${src}" is not react or relative path`,
+      )
+    }
+  }
+  return failures
+}
+
+function syntaxCheck(name, filePath, ts) {
+  const content = readFileSync(filePath, 'utf8')
+  const sf = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.ES2022,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX,
+  )
+  // ts.createSourceFile collects parser errors on `.parseDiagnostics`
+  // (an internal field — but stable enough for this use). Fall back to
+  // re-parsing with the public preProcessFile + scanner if needed.
+  const diags = sf.parseDiagnostics ?? []
+  return diags.map((d) => {
+    const start = d.start ?? 0
+    const { line, character } = ts.getLineAndCharacterOfPosition(sf, start)
+    const msg = ts.flattenDiagnosticMessageText(d.messageText, '\n')
+    return `${name}: parse error at ${line + 1}:${character + 1} — ${msg}`
+  })
+}
+
+function main() {
+  const vars = loadVars()
+  if (existsSync(TMP_DIR)) rmSync(TMP_DIR, { recursive: true, force: true })
+  mkdirSync(TMP_DIR, { recursive: true })
+
+  const failures = []
+  const refs = listReferences()
+  let foundationWritten = false
+
+  for (const refPath of refs) {
+    const { tsx, scss, name } = extractFromFile(refPath, vars)
+    const requiresScss = !COMPONENTS_WITHOUT_SCSS.has(name)
+
+    if (!tsx) {
+      failures.push(
+        `${name}: reference doc has no \`\`\`tsx fenced block before Accessibility/Usage Examples`,
+      )
+      continue
+    }
+    if (requiresScss && !scss) {
+      failures.push(
+        `${name}: reference doc has no \`## SCSS Template\` section with a \`\`\`scss block`,
+      )
+    }
+
+    failures.push(...checkImports(name, tsx))
+
+    if (name === 'foundation') {
+      writeFileSync(join(TMP_DIR, 'ui.tsx'), tsx)
+      foundationWritten = true
+    } else {
+      const componentDir = join(TMP_DIR, name)
+      mkdirSync(componentDir, { recursive: true })
+      writeFileSync(join(componentDir, `${name}.tsx`), tsx)
+      if (scss) writeFileSync(join(componentDir, `${name}.scss`), scss)
+    }
+  }
+
+  if (!foundationWritten) {
+    failures.push(
+      'foundation.md not extracted; component imports of `../ui` will not resolve',
+    )
+  }
+
+  // Syntax check every written .tsx via TypeScript's parser API.
+  // Loaded lazily so we only require typescript when extraction succeeded.
+  let ts
+  try {
+    ts = requireCjs('typescript')
+  } catch {
+    failures.push(
+      'typescript not installed: run `npm --prefix tests ci` first',
+    )
+    report(failures)
+    return
+  }
+
+  const tsxFiles = []
+  if (foundationWritten) tsxFiles.push(['foundation', join(TMP_DIR, 'ui.tsx')])
+  for (const refPath of refs) {
+    const name = refPath.split('/').pop().replace(/\.md$/, '')
+    if (name === 'foundation') continue
+    const candidate = join(TMP_DIR, name, `${name}.tsx`)
+    if (existsSync(candidate)) tsxFiles.push([name, candidate])
+  }
+  for (const [name, file] of tsxFiles) {
+    failures.push(...syntaxCheck(name, file, ts))
+  }
+
+  report(failures)
+}
+
+function report(failures) {
+  if (failures.length === 0) {
+    console.log('validate_components.mjs: extraction OK')
+    process.exit(0)
+  }
+  console.error('validate_components.mjs: extraction FAIL')
+  for (const f of failures) console.error('  -', f)
+  process.exit(1)
+}
+
+main()

--- a/tests/validate_components.py
+++ b/tests/validate_components.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Validate the SCSS contract for extracted acss-kit component styles.
 
-Walks the directory passed as argv[1] (default: tests/.tmp/extracted),
-reads every .scss file, strips SCSS-only single-line comments (`// ...`)
-that tinycss2 cannot parse, parses the remaining content with tinycss2,
-then asserts:
+Walks the directory passed as argv[1], reads every .scss file, strips
+SCSS-only single-line comments (`// ...`) that tinycss2 cannot parse,
+parses the remaining content with tinycss2, then asserts:
 
   - Every var(--color-*, ...), var(--font-*, ...), and var(--space-*, ...)
     reference includes a fallback. This is the load-bearing contract:

--- a/tests/validate_components.py
+++ b/tests/validate_components.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate the SCSS contract for extracted acss-kit component styles.
+
+Walks the directory passed as argv[1] (default: tests/.tmp/extracted),
+reads every .scss file, strips SCSS-only single-line comments (`// ...`)
+that tinycss2 cannot parse, parses the remaining content with tinycss2,
+then asserts:
+
+  - Every var(--color-*, ...), var(--font-*, ...), and var(--space-*, ...)
+    reference includes a fallback. This is the load-bearing contract:
+    components must render correctly when consumed in projects whose
+    theme CSS hasn't loaded yet.
+
+The looser checks originally proposed (bare-px detection, cross-file
+class conflicts) were dropped after the initial run revealed the
+existing references legitimately use px (e.g. 999px for pill shapes,
+1-2px borders) and intentionally share class names across components
+for inheritance (icon-button extends button via .btn). Re-enable those
+checks if a future contract change makes them load-bearing.
+
+Output contract: detector style — JSON to stdout, "reasons" array
+populated on failure, exit 0 on success and 1 on logical failure (2 on
+usage / IO errors). Mirrors the shape of detect_target.py.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tinycss2
+except ImportError:
+    print(
+        json.dumps(
+            {
+                "ok": False,
+                "reasons": [
+                    "tinycss2 not installed: run "
+                    "`pip3 install --user tinycss2`",
+                ],
+            },
+        ),
+    )
+    sys.exit(2)
+
+
+VAR_NO_FALLBACK_RE = re.compile(
+    r"var\(\s*--(?:color|font|space)-[A-Za-z0-9_-]+\s*\)",
+)
+
+
+def strip_scss_comments(content: str) -> str:
+    """Remove SCSS `//` single-line comments so tinycss2 can parse the rest."""
+    out_lines = []
+    for line in content.splitlines():
+        idx = -1
+        in_string = False
+        quote = ""
+        i = 0
+        while i < len(line) - 1:
+            ch = line[i]
+            if in_string:
+                if ch == quote and line[i - 1] != "\\":
+                    in_string = False
+            elif ch in ("'", '"'):
+                in_string = True
+                quote = ch
+            elif ch == "/" and line[i + 1] == "/":
+                idx = i
+                break
+            i += 1
+        out_lines.append(line if idx < 0 else line[:idx])
+    return "\n".join(out_lines)
+
+
+def serialize_value(rule):
+    return tinycss2.serialize(rule.content) if rule.content else ""
+
+
+def collect_failures_for_file(path: Path):
+    failures = []
+    raw = path.read_text(encoding="utf-8")
+    stripped = strip_scss_comments(raw)
+    rules = tinycss2.parse_stylesheet(
+        stripped, skip_whitespace=True, skip_comments=True,
+    )
+
+    for rule in rules:
+        if rule.type == "error":
+            failures.append(
+                f"{path.name}: parser error at line {rule.source_line}: {rule.message}",
+            )
+            continue
+        if rule.type != "qualified-rule":
+            continue
+
+        body = serialize_value(rule)
+
+        for match in VAR_NO_FALLBACK_RE.finditer(body):
+            failures.append(
+                f"{path.name}: var() without fallback: {match.group(0)}",
+            )
+
+    return failures
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reasons": ["usage: validate_components.py <extracted-dir>"],
+                },
+            ),
+        )
+        return 2
+
+    target = Path(sys.argv[1])
+    if not target.is_dir():
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reasons": [f"not a directory: {target}"],
+                },
+            ),
+        )
+        return 2
+
+    failures = []
+
+    scss_files = sorted(target.rglob("*.scss"))
+    if not scss_files:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "reasons": [f"no .scss files under {target}"],
+                },
+            ),
+        )
+        return 1
+
+    for path in scss_files:
+        failures.extend(collect_failures_for_file(path))
+
+    payload = {
+        "ok": len(failures) == 0,
+        "filesScanned": len(scss_files),
+        "reasons": failures,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/validate_manifest.py
+++ b/tests/validate_manifest.py
@@ -40,9 +40,22 @@ def ok(detail: dict) -> int:
     return 0
 
 
+def is_within_repo(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
 def check_plugin_dir(name: str, source: str) -> list[str]:
     failures: list[str] = []
     plugin_dir = (REPO_ROOT / source).resolve()
+    if not is_within_repo(plugin_dir, REPO_ROOT):
+        failures.append(
+            f"{name}: source path escapes repository root: {source!r}",
+        )
+        return failures
     if not plugin_dir.is_dir():
         failures.append(f"{name}: source path not found: {source}")
         return failures
@@ -111,7 +124,13 @@ def main() -> int:
         failures.append("marketplace.json plugins must be a non-empty array")
         return fail(failures)
 
-    for entry in plugins:
+    for idx, entry in enumerate(plugins):
+        if not isinstance(entry, dict):
+            failures.append(
+                "marketplace.json plugins entry at index "
+                f"{idx} must be an object, got {type(entry).__name__}",
+            )
+            continue
         name = entry.get("name", "<unnamed>")
         entry_missing = REQUIRED_PLUGIN_ENTRY_FIELDS - entry.keys()
         if entry_missing:

--- a/tests/validate_manifest.py
+++ b/tests/validate_manifest.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Validate marketplace.json + each plugin's plugin.json + required files.
+
+Replicates the structural checks performed by the verify-plugins skill so
+the harness can run standalone without a Claude session. Mirrors the
+detector contract: JSON to stdout, "reasons" array, exit 0 on success
+and 1 on logical failure.
+
+Checks:
+  - Repo-level marketplace.json: required fields, well-formed plugins
+    array, and **no `version` key inside any plugin entry** (silent
+    override hazard documented in CLAUDE.md).
+  - Each referenced plugin: plugin.json present + required fields
+    + semver-shaped version.
+  - Each plugin directory contains: README.md, CHANGELOG.md, at least
+    one commands/*.md, at least one SKILL.md anywhere under skills/.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE_PATH = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+REQUIRED_MARKETPLACE_FIELDS = {"name", "description", "owner", "plugins"}
+REQUIRED_PLUGIN_ENTRY_FIELDS = {"name", "source", "description"}
+REQUIRED_PLUGIN_MANIFEST_FIELDS = {"name", "description", "version", "author"}
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$")
+
+
+def fail(reasons: list[str]) -> int:
+    print(json.dumps({"ok": False, "reasons": reasons}, indent=2))
+    return 1
+
+
+def ok(detail: dict) -> int:
+    print(json.dumps({"ok": True, "reasons": [], **detail}, indent=2))
+    return 0
+
+
+def check_plugin_dir(name: str, source: str) -> list[str]:
+    failures: list[str] = []
+    plugin_dir = (REPO_ROOT / source).resolve()
+    if not plugin_dir.is_dir():
+        failures.append(f"{name}: source path not found: {source}")
+        return failures
+
+    manifest_path = plugin_dir / ".claude-plugin" / "plugin.json"
+    if not manifest_path.exists():
+        failures.append(f"{name}: missing .claude-plugin/plugin.json")
+    else:
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as e:
+            failures.append(f"{name}: plugin.json is invalid JSON: {e}")
+            manifest = None
+        if manifest is not None:
+            missing = REQUIRED_PLUGIN_MANIFEST_FIELDS - manifest.keys()
+            if missing:
+                failures.append(
+                    f"{name}: plugin.json missing required fields: {sorted(missing)}",
+                )
+            version = manifest.get("version")
+            if version and not SEMVER_RE.match(version):
+                failures.append(
+                    f"{name}: plugin.json version {version!r} is not semver",
+                )
+
+    for required in ("README.md", "CHANGELOG.md"):
+        if not (plugin_dir / required).exists():
+            failures.append(f"{name}: missing {required}")
+
+    commands_dir = plugin_dir / "commands"
+    if commands_dir.is_dir():
+        if not list(commands_dir.glob("*.md")):
+            failures.append(f"{name}: commands/ directory has no .md files")
+    else:
+        failures.append(f"{name}: missing commands/ directory")
+
+    skills_dir = plugin_dir / "skills"
+    if skills_dir.is_dir():
+        if not list(skills_dir.rglob("SKILL.md")):
+            failures.append(f"{name}: no SKILL.md anywhere under skills/")
+    else:
+        failures.append(f"{name}: missing skills/ directory")
+
+    return failures
+
+
+def main() -> int:
+    if not MARKETPLACE_PATH.exists():
+        return fail([f"marketplace.json not found at {MARKETPLACE_PATH}"])
+
+    try:
+        marketplace = json.loads(MARKETPLACE_PATH.read_text())
+    except json.JSONDecodeError as e:
+        return fail([f"marketplace.json is invalid JSON: {e}"])
+
+    failures: list[str] = []
+
+    missing = REQUIRED_MARKETPLACE_FIELDS - marketplace.keys()
+    if missing:
+        failures.append(
+            f"marketplace.json missing required fields: {sorted(missing)}",
+        )
+
+    plugins = marketplace.get("plugins", [])
+    if not isinstance(plugins, list) or not plugins:
+        failures.append("marketplace.json plugins must be a non-empty array")
+        return fail(failures)
+
+    for entry in plugins:
+        name = entry.get("name", "<unnamed>")
+        entry_missing = REQUIRED_PLUGIN_ENTRY_FIELDS - entry.keys()
+        if entry_missing:
+            failures.append(
+                f"{name}: marketplace entry missing required fields: {sorted(entry_missing)}",
+            )
+        if "version" in entry:
+            failures.append(
+                f"{name}: marketplace entry has a `version` key. Remove it — "
+                "plugin.json is the authoritative source and the marketplace "
+                "version is silently overridden (see CLAUDE.md).",
+            )
+        if "source" in entry:
+            failures.extend(check_plugin_dir(name, entry["source"]))
+
+    if failures:
+        return fail(failures)
+    return ok({"plugins": [p.get("name") for p in plugins]})
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Replaces the manual Vite-sandbox smoke-test workflow as the documented test gate with an automated structural validation harness (`tests/run.sh`) that runs in ~1 second without a browser. Adds an opt-in Storybook + axe-playwright deep check (`tests/storybook.sh`) for render-sensitive changes, and demotes the existing sandbox to a documented demo path.

Plan and rationale: [docs/plans/test-infrastructure-rewrite.md](https://github.com/shawn-sandy/acss-plugins/blob/claude/quizzical-johnson-3fee7e/docs/plans/test-infrastructure-rewrite.md).

## What changed

**Phase 1 — default check (`tests/run.sh`)**
- `extract.mjs`: shared markdown-as-source extractor (Props Interface + TSX Template + SCSS Template). Used by both Phase 1 and Phase 2.
- `validate_components.mjs`: Node + TypeScript parser API for syntax-only TSX check. Blocks `@fpkit/acss` imports; enforces relative-or-react import allowlist.
- `validate_components.py`: `tinycss2`-backed SCSS validator. Enforces `var(--color-*|--font-*|--space-*)` fallbacks.
- `validate_manifest.py`: standalone replication of the `verify-plugins` skill (manifest + structure checks, no Claude session needed).
- `tests/run.sh`: serial-only Bash orchestrator. Wipes `tests/.tmp/` first, runs each validator, finishes with known-bad self-tests.
- `tests/fixtures/known-bad/`: intentional contract violations the harness must fail on (insurance against silent regex regressions).
- `tests/package.json` + lockfile: single dev dep (`typescript` + `@types/react`).

**Phase 2 — opt-in Storybook deep check (`tests/storybook.sh`)**
- `plugins/acss-kit/.harness/`: Storybook + Vite + axe-playwright scaffold (gitignored after install).
- `plugins/acss-kit/scripts/generate_stories.mjs`: auto-generates stories from `## Usage Examples` blocks; documented as best-effort given the documentary nature of those blocks.

**Phase 3 — demote manual workflow**
- `tests/setup.sh`: prints a banner directing users to `tests/run.sh` for automated tests.
- `plugins/acss-kit/README.md` "Verify locally": run.sh first, sandbox second.
- `CLAUDE.md` "Testing locally" + pre-submit checklist: `tests/run.sh` is now the default gate.

## Two deliberate scope deviations from the plan

Both are documented in `tests/README.md`:

1. **TSX validation is syntax-only, not strict `tsc`.** The reference docs split TSX across `## Key Pattern:` sections that contain illustrative JSX or inline-only snippets (e.g. destructuring `props` outside a function body). Full type resolution would fight the markdown's documentary structure. Syntax-level validation via `ts.createSourceFile` catches what regex can't (malformed JSX, broken generics) without that fight.

2. **SCSS contract is var-fallback-only.** The originally-planned bare-px and class-conflict checks were dropped after the existing references showed legitimate use of `999px` (pill shapes), `1-2px solid` (borders), `0.15em` (type rhythm), and shared class names (`.btn` declared in both `button.scss` and `icon-button.scss` for inheritance). Principle: the existing code IS the contract; re-enable the stricter checks if a future contract change makes them load-bearing.

## Why no GitHub Actions workflow

The plan-interview phase explicitly resolved this: ship local-only first, add CI in a follow-up if the harness proves useful. `tests/run.sh` is documented as a pre-PR ritual; CI gating is in `Next steps (out of scope)`.

## Test plan

- [ ] On a clean checkout: `npm --prefix tests ci && pip3 install --user tinycss2 && tests/run.sh` exits 0 with all six steps green.
- [ ] Inject a regression: edit a reference doc to remove a `var()` fallback (e.g. `var(--color-primary, #4f46e5)` → `var(--color-primary)`). Re-run `tests/run.sh`. Expect exit 1 and the SCSS validator's `reasons` array calls out the file and the offending var.
- [ ] Inject a TSX regression: add `import x from '@fpkit/acss'` to a reference's TSX block. Re-run. Expect exit 1 from `validate_components.mjs`.
- [ ] Inject a manifest regression: add `"version": "0.0.0"` to the marketplace.json plugins entry. Re-run. Expect `validate_manifest.py` to flag the silent-override hazard.
- [ ] Verify known-bad self-tests still flag: temporarily comment out the var-fallback regex in `validate_components.py`. Re-run. Expect step 6 to fail with "validate_components.py PASSED on known-bad fixtures (regex regressed)".
- [ ] Sandbox flow still works: `tests/setup.sh` prints the new banner and continues to scaffold a usable sandbox.
- [ ] (Optional) `tests/storybook.sh` builds Storybook and runs `test-storybook` after `npx playwright install` (slow; not required for this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)