### PR TITLE
docs(.claude): document maintainer tooling, hooks, and rules

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,62 @@
+# Maintainer tooling
+
+Project-local Claude Code definitions for working on the `acss-kit` plugin. Contributors use these to scaffold new artifacts, audit existing ones, and gate releases. End-user docs for the plugin itself live at [GUIDE.md](../GUIDE.md), the [root README](../README.md), and [plugins/acss-kit/README.md](../plugins/acss-kit/README.md).
+
+## I want to...
+
+| Task | Tool |
+|---|---|
+| Add a new component reference | `/component-author <name>` |
+| Update an existing component reference | `/component-update <name>` |
+| Add a brand preset, palette role, or schema field | `/style-author` |
+| Update a theme reference, then re-validate | `/style-update <path>` |
+| Bump the plugin version before committing | `/release-plugin <plugin> <version>` |
+| Audit release paperwork before opening a PR | `/release-check <plugin>` |
+| One-shot health audit on the plugin | `/plugin-health` |
+| Validate a single plugin's structure | `/validate-plugin <name>` |
+| Audit every plugin in the repo | `/verify-plugins` |
+| Audit a SKILL.md or command file for shape | ask Claude — routes to [`skill-quality-reviewer`](agents/README.md#skill-quality-reviewer) |
+| Audit a single Python script | `/review-script <path>` |
+| Audit every Python script in parallel | `/review-scripts` |
+| Audit a component reference doc | `/review-component <path>` |
+| Audit theme cross-source parity | `/review-themes` |
+| Add a new slash command to a plugin | `/add-command <plugin> <command>` |
+
+## Catalogs
+
+| Category | Count | Reference |
+|---|---|---|
+| Skills | 10 | [skills/README.md](skills/README.md) |
+| Commands | 4 | [commands.md](commands.md) |
+| Agents | 4 | [agents/README.md](agents/README.md) |
+| Rules | 2 | [rules/README.md](rules/README.md) |
+| Hooks | 6 | [hooks.md](hooks.md) |
+
+## Layout
+
+```
+.claude/
+├── README.md            # this file — index
+├── commands.md          # slash-command catalog (lives here, not in commands/, to avoid the loader)
+├── hooks.md             # settings.json hook reference
+├── settings.json        # hooks (committed)
+├── settings.local.json  # personal permissions allowlist (gitignored)
+├── agents/<name>.md     # review-only sub-agents (+ agents/README.md catalog)
+├── commands/<name>.md   # slash command files
+├── rules/<name>.md      # advisory text injected by path glob
+└── skills/<name>/SKILL.md  # multi-step authoring/release workflows
+```
+
+## Adding a new tool
+
+- **Skill** — `mkdir .claude/skills/<name>/`, then write `SKILL.md` per [skills/README.md](skills/README.md).
+- **Command** — write `.claude/commands/<name>.md` with `description:` and `allowed-tools:` front-matter; see [commands.md](commands.md).
+- **Agent** — see "Adding a new agent" in [agents/README.md](agents/README.md).
+- **Rule** — see [rules/README.md](rules/README.md).
+- **Hook** — edit `.claude/settings.json` and document in [hooks.md](hooks.md).
+
+## See also
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — sibling-clone workflow, pre-PR checklist
+- [AGENTS.md](../AGENTS.md) — coding-agent guidance for working in this repo
+- [GUIDE.md](../GUIDE.md) — end-user guide for the `acss-kit` plugin

--- a/.claude/commands.md
+++ b/.claude/commands.md
@@ -1,0 +1,25 @@
+# Maintainer Commands
+
+Slash commands at the repo root that delegate to one of the [review agents](agents/README.md). All four are **read-only** — they spawn a background agent that reports findings and writes nothing.
+
+| Command | Argument | Description | Dispatches to |
+|---|---|---|---|
+| [`/review-component`](commands/review-component.md) | `<path/to/references/components/<name>.md>` | Verify a component reference doc against the canonical embedded-markdown shape and catalog parity table. | [`component-reference-reviewer`](agents/README.md#component-reference-reviewer) |
+| [`/review-script`](commands/review-script.md) | `<path/to/script.py>` | Audit a single Python script against the project contract (stdlib only, JSON to stdout, exit codes, reasons array). | [`python-script-reviewer`](agents/README.md#python-script-reviewer) |
+| [`/review-scripts`](commands/review-scripts.md) | _(none)_ | Audit every `plugins/*/scripts/*.py` in parallel and report a summary table. | [`python-script-reviewer`](agents/README.md#python-script-reviewer) (one per script) |
+| [`/review-themes`](commands/review-themes.md) | _(none)_ | Cross-source parity audit of the acss-kit theme references — role catalogue, palette algorithm, theme schema, bundled brand presets — against the Python scripts. | [`theme-reference-reviewer`](agents/README.md#theme-reference-reviewer) |
+
+## How invocation works
+
+Each command file is a thin wrapper: front-matter declares `allowed-tools: Agent`, and the body asks Claude to invoke the named agent in the background. The agent reads the target file(s), runs its checks, and reports findings — no edits.
+
+If you want the agent to *also* fix what it finds, run the corresponding **authoring/updating skill** instead (see [`skills/README.md`](skills/README.md)). For example, `/component-update` runs the same review and surfaces drift; `/review-component` only reports.
+
+## Adding a new command
+
+The repo's [`/add-command`](skills/add-command/SKILL.md) skill scaffolds a new command in a plugin (`plugins/<name>/commands/`). For a repo-root maintainer command like the ones above, write the `.md` file directly:
+
+1. Create `.claude/commands/<command-name>.md`.
+2. Front-matter: `description:`, `argument-hint:` (if it takes an argument), `allowed-tools:` (usually just `Agent`).
+3. Body: one paragraph instructing Claude to dispatch to the named agent in the background.
+4. Add a row to the table above.

--- a/.claude/hooks.md
+++ b/.claude/hooks.md
@@ -21,7 +21,7 @@ These run after Claude writes or edits a file. They warn or fail loudly so issue
 |---|---|
 | Matcher | `Write\|Edit` |
 | Status message | `Validating JSON...` |
-| Behaviour | If the touched file ends in `.json`, parses it with `python3 json.load`. Stderr surfaces the parse error, but does not exit non-zero. |
+| Behaviour | If the touched file ends in `.json`, parses it with `python3 json.load`. Parse errors print to stdout (the hook redirects stderr via `2>&1`) and the command exits non-zero, surfacing as a PostToolUse error. |
 | Why | Catches truncated edits in `plugin.json`, `marketplace.json`, `theme.tokens.json` before they propagate. |
 
 ### 2. plugin.json schema check

--- a/.claude/hooks.md
+++ b/.claude/hooks.md
@@ -1,0 +1,85 @@
+# Project Hooks
+
+Hooks defined in `.claude/settings.json` run before or after specific tool calls. They enforce repo conventions automatically — every contributor on every machine, no opt-in needed.
+
+## Files
+
+| File | Committed? | Purpose |
+|---|---|---|
+| `.claude/settings.json` | Yes | Hook definitions. Shared across the team. |
+| `.claude/settings.local.json` | No (gitignored) | Personal permissions allowlist and local overrides like `plansDirectory`. |
+
+If a hook misbehaves, the fix is in `settings.json` — not in `settings.local.json`.
+
+## PostToolUse — advisory checks after `Write` or `Edit`
+
+These run after Claude writes or edits a file. They warn or fail loudly so issues are caught before commit.
+
+### 1. JSON validator
+
+| Field | Value |
+|---|---|
+| Matcher | `Write\|Edit` |
+| Status message | `Validating JSON...` |
+| Behaviour | If the touched file ends in `.json`, parses it with `python3 json.load`. Stderr surfaces the parse error, but does not exit non-zero. |
+| Why | Catches truncated edits in `plugin.json`, `marketplace.json`, `theme.tokens.json` before they propagate. |
+
+### 2. plugin.json schema check
+
+| Field | Value |
+|---|---|
+| Matcher | `Write\|Edit` |
+| Status message | `Checking plugin.json schema...` |
+| Behaviour | If the touched file matches `plugins/*/.claude-plugin/plugin.json`, runs `jq` to confirm `name`, `version`, and `description` are non-empty strings. **Exits 2 on failure**, blocking the operation. |
+| Why | Plugin manifests are silently authoritative for `/plugin update` — a broken manifest is a release-blocker. |
+
+### 3. Command front-matter check
+
+| Field | Value |
+|---|---|
+| Matcher | `Write\|Edit` |
+| Status message | `Checking command front-matter...` |
+| Behaviour | If the touched file matches `plugins/*/commands/*.md`, warns when `description:` or `allowed-tools:` is missing from the YAML front-matter. Warning only — no exit code. |
+| Why | These two fields drive how Claude surfaces and gates the command — easy to forget when scaffolding by hand. |
+
+### 4. SKILL.md front-matter check
+
+| Field | Value |
+|---|---|
+| Matcher | `Write\|Edit` |
+| Status message | `Checking SKILL.md front-matter...` |
+| Behaviour | If the touched file ends in `/SKILL.md`, warns when `name:` or `description:` is missing. Warning only — no exit code. |
+| Why | Same reason as the command check — front-matter is the contract Claude reads to decide when a skill applies. |
+
+## PreToolUse — gates before `Bash`
+
+These run before Claude executes a Bash command. They can block dangerous operations.
+
+### 5. Main-branch guard
+
+| Field | Value |
+|---|---|
+| Matcher | `Bash` |
+| Status message | `Checking branch guard...` |
+| Behaviour | If the command is `git commit` or `git push` (any form that targets `main`), and the current branch is `main`, **exits 2 to block** with `[main-guard] BLOCKED: direct commit/push to main is not allowed. Use a feature branch.` |
+| Why | Project policy is feature-branch + PR; this stops accidental direct commits to `main`. Includes both `git push origin main`-style and naked `git push` while on `main`. |
+
+### 6. Spec/kit-builder parity hook
+
+| Field | Value |
+|---|---|
+| Matcher | `Bash` |
+| Status message | `Checking spec/kit-builder parity...` |
+| Behaviour | On `git commit`, looks for staged files matching `acss-component-specs.*specs/`, then runs `python3 plugins/acss-component-specs/scripts/check_kitbuilder_parity.py` for each. |
+| Why | Originally enforced parity between the `acss-component-specs` plugin's specs and the `acss-kit-builder` plugin's references. |
+| **Status** | **Drift — never fires.** Both `acss-component-specs` and `acss-kit-builder` were consolidated into `acss-kit` at v0.3.0. Neither directory exists; the matcher condition is never true. Either delete this hook or rewrite it for the new structure. |
+
+## Adding a new hook
+
+1. Open `.claude/settings.json` and add an entry under `hooks.PostToolUse` or `hooks.PreToolUse`.
+2. `matcher` is a regex against the tool name (`Write|Edit`, `Bash`, etc.).
+3. `command` is shell that reads the tool input from stdin via `jq`. Exit `0` to pass, `2` to block (PreToolUse) or surface as an error (PostToolUse).
+4. Add a `statusMessage` so contributors see what's running.
+5. Document the hook in this file.
+
+For deeper guidance see the Claude Code docs on hooks.

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -1,0 +1,25 @@
+# Project Rules
+
+Advisory text auto-loaded into Claude's context whenever it touches a file matching the rule's `paths:` glob. Unlike [hooks](../hooks.md), rules **do not block or warn** — they're just reminders that ride along in the prompt.
+
+| Rule | Triggers on | Status |
+|---|---|---|
+| [`scss-conventions.md`](scss-conventions.md) | `**/*.scss`, `**/*.css` | Active — variable naming pattern, `var()` fallbacks, `[aria-disabled="true"]` for disabled state. |
+| [`python-scripts.md`](python-scripts.md) | `plugins/acss-app-builder/scripts/**` | **Drift** — references `acss-app-builder`, a predecessor plugin consolidated into `acss-kit` at v0.3.0. The path glob never matches a real file, so this rule never loads. Fix: rewrite the inventory for `plugins/acss-kit/scripts/**`, or delete the file. |
+
+## Rules vs. hooks vs. skills
+
+| Layer | Purpose | Where it lives | When it runs |
+|---|---|---|---|
+| Rule | Inject advisory context | `.claude/rules/<name>.md` with `paths:` front-matter | When Claude reads/writes a matching file |
+| [Hook](../hooks.md) | Validate or block tool calls | `.claude/settings.json` `hooks` block | Before/after a tool call |
+| [Skill](../skills/README.md) | Author or update artifacts | `.claude/skills/<name>/SKILL.md` | When Claude routes a request to it (or the maintainer slashes it) |
+
+Use **rules** to reinforce a convention you want present every time (naming, security boundaries). Use **hooks** to actually enforce or warn. Use **skills** for multi-step workflows.
+
+## Adding a new rule
+
+1. Create `.claude/rules/<rule-name>.md`.
+2. Front-matter must include a `paths:` array of glob patterns.
+3. Body is the advisory text — keep it short; it's loaded on every match.
+4. Add a row to the table above.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,42 @@
+# Maintainer Skills
+
+Project-local skills for working on the `acss-kit` plugin. These are distinct from the plugin's own end-user skills (which live under `plugins/acss-kit/skills/`) — these run **on this repo while you maintain it**.
+
+Each skill has a slash command of the same name. Claude can also invoke them automatically when the request matches the skill's `description` field.
+
+## Authoring — scaffold new artifacts
+
+| Skill | What it does |
+|---|---|
+| [`/add-command`](add-command/SKILL.md) | Scaffold a new slash command for a plugin — creates `commands/<name>.md` with front-matter and adds a stub section to the relevant `SKILL.md`. |
+| [`/component-author`](component-author/SKILL.md) | Scaffold a new component reference doc under `plugins/acss-kit/skills/components/references/components/<name>.md` in the canonical embedded-markdown shape, and add a placeholder row to the catalog. |
+| [`/style-author`](style-author/SKILL.md) | Scaffold a bundled brand preset, palette role, or theme-schema field for `acss-kit`. Three sub-flows; ends with a WCAG 2.2 AA contrast re-validation. |
+
+## Updating — refresh existing artifacts
+
+| Skill | What it does |
+|---|---|
+| [`/component-update`](component-update/SKILL.md) | Re-verify an existing component reference doc against its captured fpkit ref, surface drift in TSX/SCSS templates, and run the canonical-shape reviewer agent. |
+| [`/style-update`](style-update/SKILL.md) | Re-validate and roll forward theme assets after edits to `role-catalogue.md`, `palette-algorithm.md`, `theme.schema.json`, or a bundled brand preset. |
+
+## Validation — read-only audits
+
+| Skill | What it does |
+|---|---|
+| [`/plugin-health`](plugin-health/SKILL.md) | One-shot audit dashboard for `acss-kit`: structural validation + canonical-shape compliance + catalog parity + bundled theme validation. Read-only. |
+| [`/validate-plugin`](validate-plugin/SKILL.md) | Deep per-plugin structural validation (semver, command bodies, fpkit URL hygiene, Python syntax). Run before publishing a specific plugin. |
+| [`/verify-plugins`](verify-plugins/SKILL.md) | Repo-wide sweep — pass/fail per plugin with no argument needed. Use to spot-check the marketplace before tagging a release. |
+
+## Release — pre-PR paperwork
+
+| Skill | What it does |
+|---|---|
+| [`/release-plugin`](release-plugin/SKILL.md) | Bump a plugin's version in `plugin.json` and update `marketplace.json` description if needed. Run **before** committing a publishable change. |
+| [`/release-check`](release-check/SKILL.md) | Audit whether release paperwork is complete on the current branch — version bump, CHANGELOG, README all touched as needed. Run **after** `/release-plugin` and **before** opening a PR. |
+
+## Adding a new skill
+
+1. Create `.claude/skills/<skill-name>/SKILL.md` with at minimum a `name:` and `description:` in YAML front-matter.
+2. Body is instructions to Claude — explain when to use it and the steps to follow.
+3. If the skill should be invokable as a slash command, the folder name is the command name.
+4. Add a row to the matching table above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ The repo contains one plugin:
 
 - `plugins/acss-kit` - accessible React components and CSS themes for fpkit/acss projects.
 
+Maintainer tooling for working on this repo lives at `.claude/` (review agents, authoring/release skills, validation commands, advisory rules, hooks) — see [`.claude/README.md`](./.claude/README.md) for the index.
+
 Install from a Claude Code session:
 ```
 /plugin marketplace add shawn-sandy/acss-plugins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ The sibling layout is for **contributors** editing plugin skill docs: open the f
 
 ```
 acss-plugins/
+├── .claude/                # project-local maintainer tooling — see .claude/README.md
 ├── .claude-plugin/
 │   └── marketplace.json    # catalog listing acss-kit
 ├── plugins/
@@ -36,6 +37,10 @@ Each plugin directory follows the Claude Code plugin convention:
 - `skills/*/SKILL.md` — skill definitions invoked by Claude
 - `skills/*/references/` — knowledge base documents where applicable
 - `assets/` — templates and code snippets used by the plugin
+
+## Maintainer tooling
+
+The `.claude/` directory at the repo root holds project-local Claude Code definitions used while developing the plugin: review agents, authoring/release skills, validation slash commands, advisory rules, and `settings.json` hooks. See [`.claude/README.md`](./.claude/README.md) for the index — it includes an "I want to..." quick-reference table mapping common maintainer tasks to the right tool.
 
 ## Version bumps
 

--- a/docs/plans/document-claude-maintainer-tooling.md
+++ b/docs/plans/document-claude-maintainer-tooling.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The `acss-plugins` repo ships one plugin (`acss-kit`) but holds substantial **maintainer-only tooling** at the repo-root `.claude/` directory: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules files, and a `settings.json` enforcing 5 hooks. Only the agents are documented (`.claude/agents/README.md`). The rest is undocumented, so a contributor (or returning maintainer) browsing `.claude/skills/` cannot tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. exist or when to use them.
+The `acss-plugins` repo ships one plugin (`acss-kit`) but holds substantial **maintainer-only tooling** at the repo-root `.claude/` directory: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules files, and a `settings.json` enforcing 6 hooks (4 PostToolUse + 2 PreToolUse). Only the agents are documented (`.claude/agents/README.md`). The rest is undocumented, so a contributor (or returning maintainer) browsing `.claude/skills/` cannot tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. exist or when to use them.
 
 Goal: make the `.claude/` directory self-documenting so a developer landing in the repo can quickly run the right tool. Mirror the existing per-category README pattern (`agents/README.md`) rather than consolidating into a single file — depth-per-category × 16 items would produce a 500-line index, and contributors editing `.claude/skills/` look for a sibling README, not one a level up.
 
@@ -15,7 +15,7 @@ Add a contributor-facing index plus per-category READMEs under `.claude/`, link 
 **To create (5):**
 - `.claude/README.md` — top-level index ("I want to..." task table, links to category READMEs and `hooks.md`)
 - `.claude/skills/README.md` — table of 10 skills (name, one-line description, trigger phrase / slash command if any)
-- `.claude/commands/README.md` — table of 4 review commands (command, description, agent dispatched)
+- `.claude/commands.md` — table of 4 review commands (command, description, agent dispatched). Lives one level above `commands/` because the slash-command loader treats every `.md` in `commands/` as a command (even without front-matter) — a `commands/README.md` would have registered as `/README`. Discovered during implementation.
 - `.claude/rules/README.md` — table of 2 rules (filename, what it governs, who reads it)
 - `.claude/hooks.md` — what `settings.json` enforces; `settings.json` vs `settings.local.json`; flag the dead `acss-component-specs` parity hook
 
@@ -38,11 +38,11 @@ Add a contributor-facing index plus per-category READMEs under `.claude/`, link 
 
 3. **Write `.claude/skills/README.md`.** Single table: skill name | description | how to invoke (slash command if one exists; otherwise "Claude auto-invokes when ..."). Group rows by purpose (Authoring / Updating / Validation / Release) for scannability. Why: 10 alphabetical rows are noise; 4 grouped clusters of 2-3 rows are scannable.
 
-4. **Write `.claude/commands/README.md`.** Single table: command | description | dispatches to (agent name from `.claude/agents/README.md`). Add a one-line note that all four commands wrap an agent and write nothing. Why: contributors should know these are review-only before running them.
+4. **Write `.claude/commands.md`.** Single table: command | description | dispatches to (agent name from `.claude/agents/README.md`). Add a one-line note that all four commands wrap an agent and write nothing. Why: contributors should know these are review-only before running them. Note: this file lives at `.claude/commands.md` (one level above `commands/`), not `.claude/commands/README.md` — the slash-command loader registers every `.md` inside `commands/` as a command, so the doc would have leaked through as `/README`.
 
 5. **Write `.claude/rules/README.md`.** Two-row table: rule file | scope | when Claude reads it. Add a note that rules are advisory text loaded into Claude's context for matching files, not enforced hooks. Why: the distinction between rules (advisory) and hooks (enforced) is non-obvious and easy to confuse.
 
-6. **Write `.claude/hooks.md`.** Document each of the 5 hooks: matcher, what it does, exit behaviour, statusMessage. Group as "PostToolUse" (4 advisory) and "PreToolUse" (2 blocking). Add a "Files" section explaining `settings.json` (committed, hooks live here) vs `settings.local.json` (machine-local, permissions allowlist). Add a "Known drift" callout: the spec/kit-builder parity hook references `plugins/acss-component-specs/` and `plugins/acss-kit-builder/`, neither of which exist post-v0.3.0 consolidation — the hook will never fire. Why: contributors deserve an honest map of what's enforced; pretending the dead hook works is misleading.
+6. **Write `.claude/hooks.md`.** Document each of the 6 hooks: matcher, what it does, exit behaviour, statusMessage. Group as "PostToolUse" (4 advisory) and "PreToolUse" (2 blocking). Add a "Files" section explaining `settings.json` (committed, hooks live here) vs `settings.local.json` (machine-local, permissions allowlist). Add a "Known drift" callout: the spec/kit-builder parity hook references `plugins/acss-component-specs/` and `plugins/acss-kit-builder/`, neither of which exist post-v0.3.0 consolidation — the hook will never fire. Why: contributors deserve an honest map of what's enforced; pretending the dead hook works is misleading.
 
 7. **Write `.claude/README.md`.** Sections: header ("Maintainer tooling for working on acss-kit"); "I want to..." task table (rows for: add a component, update a component, add a brand preset, update a theme, run pre-PR validation, bump a plugin version, audit a SKILL.md, audit a Python script, add a slash command); links to each category README; pointer to `.claude/agents/README.md` (already canonical); pointer to `.claude/hooks.md`. Keep under 80 lines. Why: the top-level index must stay scannable; deep info lives in category files.
 
@@ -55,8 +55,8 @@ Add a contributor-facing index plus per-category READMEs under `.claude/`, link 
 ## Verification
 
 - `cat .claude/README.md` renders as a scannable index, all internal links resolve to files in this commit
-- `ls .claude/*/README.md .claude/hooks.md` shows 4 new READMEs + the hooks file present
-- For each category README, the count matches `ls .claude/<category>/ | grep -v README` — i.e. skills README has 10 rows, commands README has 4 rows, rules README has 2 rows
+- `ls .claude/README.md .claude/skills/README.md .claude/rules/README.md .claude/commands.md .claude/hooks.md` shows all 5 new doc files present
+- For each catalog, the count matches what's on disk: `.claude/skills/README.md` has 10 rows, `.claude/commands.md` has 4 rows, `.claude/rules/README.md` has 2 rows
 - Open the 5 new files locally and confirm every cross-link path is repo-relative (no `file://`, no absolute paths)
 - `tests/run.sh` exits 0
 - `git diff --stat` shows exactly 5 new files + 2 edited files (`CONTRIBUTING.md`, `AGENTS.md`); no other changes

--- a/docs/plans/document-claude-maintainer-tooling.md
+++ b/docs/plans/document-claude-maintainer-tooling.md
@@ -1,0 +1,75 @@
+# Document the local maintainer tooling under `.claude/`
+
+## Context
+
+The `acss-plugins` repo ships one plugin (`acss-kit`) but holds substantial **maintainer-only tooling** at the repo-root `.claude/` directory: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules files, and a `settings.json` enforcing 5 hooks. Only the agents are documented (`.claude/agents/README.md`). The rest is undocumented, so a contributor (or returning maintainer) browsing `.claude/skills/` cannot tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. exist or when to use them.
+
+Goal: make the `.claude/` directory self-documenting so a developer landing in the repo can quickly run the right tool. Mirror the existing per-category README pattern (`agents/README.md`) rather than consolidating into a single file — depth-per-category × 16 items would produce a 500-line index, and contributors editing `.claude/skills/` look for a sibling README, not one a level up.
+
+## Objective
+
+Add a contributor-facing index plus per-category READMEs under `.claude/`, link to them from `CONTRIBUTING.md` and `AGENTS.md`, and document the `settings.json` hooks (including the one dead reference). No source-code changes.
+
+## Critical files
+
+**To create (5):**
+- `.claude/README.md` — top-level index ("I want to..." task table, links to category READMEs and `hooks.md`)
+- `.claude/skills/README.md` — table of 10 skills (name, one-line description, trigger phrase / slash command if any)
+- `.claude/commands/README.md` — table of 4 review commands (command, description, agent dispatched)
+- `.claude/rules/README.md` — table of 2 rules (filename, what it governs, who reads it)
+- `.claude/hooks.md` — what `settings.json` enforces; `settings.json` vs `settings.local.json`; flag the dead `acss-component-specs` parity hook
+
+**To edit (2):**
+- `CONTRIBUTING.md` — add ~5-line "Maintainer tooling" subsection linking `.claude/README.md`
+- `AGENTS.md` — one-line pointer to `.claude/README.md` in the existing "What this repo is" block
+
+**To read while authoring (no edits):**
+- `.claude/agents/README.md` — canonical README pattern to mirror
+- `.claude/skills/<each>/SKILL.md` — pull `description` from front-matter for the skills table
+- `.claude/commands/<each>.md` — pull `description` and `argument-hint` for the commands table
+- `.claude/rules/python-scripts.md`, `.claude/rules/scss-conventions.md` — confirm scope of each rule
+- `.claude/settings.json` — source for `hooks.md`
+
+## Steps
+
+1. **Read source-of-truth front-matter for the skills table.** Open all 10 `.claude/skills/<name>/SKILL.md` files and pull the `description:` field. Why: the README must match what Claude actually loads, not a re-paraphrase.
+
+2. **Read source-of-truth front-matter for the commands table.** Open all 4 `.claude/commands/<name>.md` files and pull `description:` and `argument-hint:`. Why: same reason — the README is a derived view, not a fresh authoring of intent.
+
+3. **Write `.claude/skills/README.md`.** Single table: skill name | description | how to invoke (slash command if one exists; otherwise "Claude auto-invokes when ..."). Group rows by purpose (Authoring / Updating / Validation / Release) for scannability. Why: 10 alphabetical rows are noise; 4 grouped clusters of 2-3 rows are scannable.
+
+4. **Write `.claude/commands/README.md`.** Single table: command | description | dispatches to (agent name from `.claude/agents/README.md`). Add a one-line note that all four commands wrap an agent and write nothing. Why: contributors should know these are review-only before running them.
+
+5. **Write `.claude/rules/README.md`.** Two-row table: rule file | scope | when Claude reads it. Add a note that rules are advisory text loaded into Claude's context for matching files, not enforced hooks. Why: the distinction between rules (advisory) and hooks (enforced) is non-obvious and easy to confuse.
+
+6. **Write `.claude/hooks.md`.** Document each of the 5 hooks: matcher, what it does, exit behaviour, statusMessage. Group as "PostToolUse" (4 advisory) and "PreToolUse" (2 blocking). Add a "Files" section explaining `settings.json` (committed, hooks live here) vs `settings.local.json` (machine-local, permissions allowlist). Add a "Known drift" callout: the spec/kit-builder parity hook references `plugins/acss-component-specs/` and `plugins/acss-kit-builder/`, neither of which exist post-v0.3.0 consolidation — the hook will never fire. Why: contributors deserve an honest map of what's enforced; pretending the dead hook works is misleading.
+
+7. **Write `.claude/README.md`.** Sections: header ("Maintainer tooling for working on acss-kit"); "I want to..." task table (rows for: add a component, update a component, add a brand preset, update a theme, run pre-PR validation, bump a plugin version, audit a SKILL.md, audit a Python script, add a slash command); links to each category README; pointer to `.claude/agents/README.md` (already canonical); pointer to `.claude/hooks.md`. Keep under 80 lines. Why: the top-level index must stay scannable; deep info lives in category files.
+
+8. **Edit `CONTRIBUTING.md`.** Add a new subsection after "Repo structure" titled "Maintainer tooling" with 4-5 lines: one sentence explaining the `.claude/` directory contains review agents, authoring skills, validation commands, and release helpers; a link to `.claude/README.md`. Why: `CONTRIBUTING.md` is the human contributor entry point; without a link they may never find `.claude/README.md`.
+
+9. **Edit `AGENTS.md`.** Add one bullet to the existing "What this repo is" section: `Maintainer tooling for working on this repo lives at `.claude/` — see [.claude/README.md](.claude/README.md).` Why: `AGENTS.md` is the coding-agent entry point; the same link belongs there because Claude itself benefits from finding the index.
+
+10. **Run the pre-submit checklist.** Execute `tests/run.sh` to confirm no structural validation regresses. Why: `CONTRIBUTING.md` is one of the files validated; an inadvertent broken link or front-matter would surface here.
+
+## Verification
+
+- `cat .claude/README.md` renders as a scannable index, all internal links resolve to files in this commit
+- `ls .claude/*/README.md .claude/hooks.md` shows 4 new READMEs + the hooks file present
+- For each category README, the count matches `ls .claude/<category>/ | grep -v README` — i.e. skills README has 10 rows, commands README has 4 rows, rules README has 2 rows
+- Open the 5 new files locally and confirm every cross-link path is repo-relative (no `file://`, no absolute paths)
+- `tests/run.sh` exits 0
+- `git diff --stat` shows exactly 5 new files + 2 edited files (`CONTRIBUTING.md`, `AGENTS.md`); no other changes
+- Manually click through from `CONTRIBUTING.md` → `.claude/README.md` → each category README on GitHub once the PR is open, confirming GitHub auto-renders each `README.md` when navigating into the directory
+
+## Next Steps (out of scope)
+
+- **Fix the dead parity hook in `settings.json`** — references gone-since-v0.3.0 plugins. Either delete it or rewrite it for `acss-kit`. Worth a separate PR with its own decision (delete vs port).
+- **Fix stale paths in `settings.local.json` allowlist** — references `plugins/acss-app-builder/assets/themes/`. Personal/machine-local file, low priority, but worth pruning.
+- **Reconcile `AGENTS.md` ↔ `CLAUDE.md` overlap** — both files restate the same repo overview. Either consolidate into one canonical source with a stub in the other, or leave the duplication as a deliberate choice for the two audiences. Out of scope for documentation work; raise as a separate question.
+- **Inline per-skill docs in `.claude/skills/README.md`** — currently only one-line descriptions; could grow into per-skill sections like `.claude/agents/README.md` does (checks tables, sample output). Defer until contributors actually ask for that depth.
+
+## Unresolved Questions
+
+- Should `.claude/README.md` group skills by **purpose** (Authoring / Updating / Validation / Release) or alphabetically? The plan above proposes by-purpose; alphabetical is easier to author but harder to scan.
+- Should `CONTRIBUTING.md`'s new subsection be under "Repo structure" (current proposal) or after "Testing locally"? Either is defensible.


### PR DESCRIPTION
## Summary

- Adds a contributor-facing index for the repo-local maintainer tooling under `.claude/` so a developer landing in the repo can quickly find the right skill, command, agent, rule, or hook.
- Mirrors the existing `.claude/agents/README.md` pattern with per-category catalogs for skills, commands, rules, and hooks. Cross-linked from `CONTRIBUTING.md` and `AGENTS.md`.
- Honestly flags two pieces of drift left behind by the v0.3.0 consolidation (a dead `settings.json` hook and a dead `rules/python-scripts.md` path) without fixing them — that cleanup is filed as out-of-scope follow-ups in the plan file.

## Why

The repo-root `.claude/` directory holds substantial maintainer-only tooling: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules, and 6 hooks. Only the agents were documented (`.claude/agents/README.md`). A contributor browsing `.claude/skills/` couldn't tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. existed or when to use each.

## What changed

**New files (5)**
- `.claude/README.md` — top-level index with an "I want to..." task table (15 rows mapping tasks to tools) and a catalog table linking each per-category reference.
- `.claude/skills/README.md` — 10 skills grouped by purpose (Authoring / Updating / Validation / Release) for scannability.
- `.claude/commands.md` — 4 review commands with the agent each dispatches to. Lives one level above `commands/` (not inside it) because the slash-command loader registers every `.md` in `commands/` as a slash command, even without front-matter — a `commands/README.md` would have leaked through as a `/README` command.
- `.claude/rules/README.md` — 2 rules + a Rules-vs-hooks-vs-skills primer.
- `.claude/hooks.md` — all 6 `settings.json` hooks documented (4 PostToolUse advisory + 2 PreToolUse blocking), with `settings.json` vs `settings.local.json` clarified.

**Edits (2)**
- `CONTRIBUTING.md` — added `.claude/` to the structure tree and a 3-line "Maintainer tooling" subsection linking the index.
- `AGENTS.md` — one-line pointer to `.claude/README.md` after the `plugins/acss-kit` bullet.

**Plan**
- `docs/plans/document-claude-maintainer-tooling.md` — full plan-mode workflow plan that drove this change, including the rejected "single consolidated `.claude/README.md`" alternative and the reasons against it.

## Drift documented (not fixed in this PR)

The plan calls these out as separate follow-ups:

- **Dead parity hook in `settings.json`** — references `plugins/acss-component-specs/` and `plugins/acss-kit-builder/`, both consolidated into `acss-kit` at v0.3.0. The matcher condition is never true; the hook silently never fires.
- **Stale `rules/python-scripts.md`** — `paths: plugins/acss-app-builder/scripts/**` (also gone). The rule never loads against any real file.

Each is documented at its catalog row in `hooks.md` / `rules/README.md` so the next maintainer touching them knows what to do.

## Test plan

- [x] `tests/run.sh` exits 0 — all 6 phases green (component reference extraction, SCSS contract, WCAG contrast skip, manifest, known-bad self-tests).
- [x] `git diff --stat` shows 2 modified files + 6 new files (5 docs + 1 plan); no other changes.
- [x] No `/README` slash command pollution — `.claude/commands/` contains only the 4 actual command files.
- [ ] Reviewer: confirm the "I want to..." table in `.claude/README.md` covers every maintainer task you'd reach for.
- [ ] Reviewer: confirm the cross-links from `CONTRIBUTING.md` and `AGENTS.md` resolve on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)