### PR TITLE
chore: rename marketplace repo references to agentic-acss-plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "acss-plugins",
+  "name": "agentic-acss-plugins",
   "description": "Claude Code plugin for building accessible React components and CSS themes for fpkit/acss projects",
   "owner": {
     "name": "Shawn Sandy",
-    "url": "https://github.com/shawn-sandy/acss-plugins"
+    "url": "https://github.com/shawn-sandy/agentic-acss-plugins"
   },
   "plugins": [
     {

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -1,6 +1,6 @@
 # Subagents
 
-Specialized review agents for the acss-plugins repo. Each agent is read-only — it reports findings but never modifies files.
+Specialized review agents for the agentic-acss-plugins repo. Each agent is read-only — it reports findings but never modifies files.
 
 Claude can invoke these automatically when context matches the agent's `description`. You can also invoke them explicitly by asking Claude to delegate to a named agent.
 

--- a/.claude/agents/component-reference-reviewer.md
+++ b/.claude/agents/component-reference-reviewer.md
@@ -3,7 +3,7 @@ name: component-reference-reviewer
 description: Reviews a single component reference doc (plugins/acss-kit/skills/components/references/components/<name>.md) against the canonical embedded-markdown shape and the catalog.md verification table. Use when authoring or editing a component reference doc.
 ---
 
-You are a component reference doc reviewer for the acss-plugins repository. When given a component reference doc path, read the file and the sibling `catalog.md`, then check all of the following. Report PASS or FAIL for each check with file:line citations on failures.
+You are a component reference doc reviewer for the agentic-acss-plugins repository. When given a component reference doc path, read the file and the sibling `catalog.md`, then check all of the following. Report PASS or FAIL for each check with file:line citations on failures.
 
 ## Canonical shape
 

--- a/.claude/agents/python-script-reviewer.md
+++ b/.claude/agents/python-script-reviewer.md
@@ -3,7 +3,7 @@ name: python-script-reviewer
 description: Reviews Python scripts in this plugin repo against the project contract — stdlib only, JSON to stdout, exit 0/1, reasons array present. Invoke when adding or significantly modifying a script under plugins/*/scripts/.
 ---
 
-You are a Python script reviewer for the acss-plugins repository. When given a script path, read the file and check all of the following. Report PASS or FAIL for each check.
+You are a Python script reviewer for the agentic-acss-plugins repository. When given a script path, read the file and check all of the following. Report PASS or FAIL for each check.
 
 ## Contract
 

--- a/.claude/agents/skill-quality-reviewer.md
+++ b/.claude/agents/skill-quality-reviewer.md
@@ -3,7 +3,7 @@ name: skill-quality-reviewer
 description: Reviews SKILL.md files for structural completeness, front-matter correctness, step quality, and GitHub URL hygiene. Use when authoring or editing a plugin skill before committing.
 ---
 
-You are a Claude Code plugin skill reviewer for the acss-plugins repository. When given a SKILL.md file path, perform these checks and report PASS or FAIL for each.
+You are a Claude Code plugin skill reviewer for the agentic-acss-plugins repository. When given a SKILL.md file path, perform these checks and report PASS or FAIL for each.
 
 ## Checks
 

--- a/.claude/agents/theme-reference-reviewer.md
+++ b/.claude/agents/theme-reference-reviewer.md
@@ -3,7 +3,7 @@ name: theme-reference-reviewer
 description: Reviews theme references (role-catalogue, palette-algorithm, theme-schema) for internal consistency and parity with the Python scripts (generate_palette.py, tokens_to_css.py, validate_theme.py) and the JSON schema. Use when authoring or editing files under plugins/acss-kit/skills/styles/references/ or plugins/acss-kit/assets/theme.schema.json.
 ---
 
-You are a theme reference reviewer for the acss-plugins repository. When invoked, read each of the following files and check for cross-source parity. Report PASS or FAIL for each check with file:line citations on failures.
+You are a theme reference reviewer for the agentic-acss-plugins repository. When invoked, read each of the following files and check for cross-source parity. Report PASS or FAIL for each check with file:line citations on failures.
 
 ## Source files to read
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,8 @@ Maintainer tooling for working on this repo lives at `.claude/` (review agents, 
 
 Install from a Claude Code session:
 ```
-/plugin marketplace add shawn-sandy/acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Plugin structure
@@ -78,7 +78,7 @@ Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direc
 
 ```bash
 # In a disposable project or Claude Code test session:
-/plugin marketplace add /absolute/path/to/acss-plugins
+/plugin marketplace add /absolute/path/to/agentic-acss-plugins
 /plugin install acss-kit@<local-marketplace-name>
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ The repo contains a single plugin:
 Install from a Claude Code session:
 
 ```text
-/plugin marketplace add shawn-sandy/acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Plugin structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to acss-plugins
+# Contributing to agentic-acss-plugins
 
 This repo hosts the Claude Code plugins for `@fpkit/acss`. The live fpkit source lives in a separate repo: [`shawn-sandy/acss`](https://github.com/shawn-sandy/acss).
 
@@ -9,7 +9,7 @@ Plugin work often needs to reference the fpkit source — either to check what's
 ```
 ~/work/
 ├── acss/               # shawn-sandy/acss — live fpkit library
-└── acss-plugins/       # this repo
+└── agentic-acss-plugins/       # this repo
 ```
 
 The plugins do not assume this layout at runtime. All references to fpkit source in `SKILL.md` files and generated-code comments use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts`) so plugin users need only this repo to be installed.
@@ -19,7 +19,7 @@ The sibling layout is for **contributors** editing plugin skill docs: open the f
 ## Repo structure
 
 ```
-acss-plugins/
+agentic-acss-plugins/
 ├── .claude/                # project-local maintainer tooling — see .claude/README.md
 ├── .claude-plugin/
 │   └── marketplace.json    # catalog listing acss-kit
@@ -74,7 +74,7 @@ See [`tests/README.md`](./tests/README.md) for the full workflow:
 - Reset and custom-recipe guidance
 - Troubleshooting
 
-Local-path marketplaces work the same as git-hosted ones. When satisfied, push to GitHub and let users install from `shawn-sandy/acss-plugins`.
+Local-path marketplaces work the same as git-hosted ones. When satisfied, push to GitHub and let users install from `shawn-sandy/agentic-acss-plugins`.
 
 ## Before submitting a change
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,7 +1,7 @@
 
-# acss-plugins User Guide
+# agentic-acss-plugins User Guide
 
-`acss-plugins` is a Claude Code plugin marketplace for building accessible React components and CSS themes for fpkit/acss projects.
+`agentic-acss-plugins` is a Claude Code plugin marketplace for building accessible React components and CSS themes for fpkit/acss projects.
 
 As of `0.3.0`, the marketplace ships one plugin: `acss-kit`.
 
@@ -10,15 +10,15 @@ As of `0.3.0`, the marketplace ships one plugin: `acss-kit`.
 Run these commands inside a Claude Code session:
 
 ```text
-/plugin marketplace add shawn-sandy/acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 For local testing from this repo:
 
 ```text
-/plugin marketplace add /absolute/path/to/acss-plugins
-/plugin install acss-kit@acss-plugins
+/plugin marketplace add /absolute/path/to/agentic-acss-plugins
+/plugin install acss-kit@agentic-acss-plugins
 ```
 
 Use `/plugin list` to confirm the plugin is installed and to see available slash commands.
@@ -110,11 +110,11 @@ It vendors required form dependencies through `/kit-add` when needed, then write
 Uninstall old plugins if they are present:
 
 ```text
-/plugin uninstall acss-kit-builder@shawn-sandy-acss-plugins
-/plugin uninstall acss-theme-builder@shawn-sandy-acss-plugins
-/plugin uninstall acss-app-builder@shawn-sandy-acss-plugins
-/plugin uninstall acss-component-specs@shawn-sandy-acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin uninstall acss-kit-builder@shawn-sandy-agentic-acss-plugins
+/plugin uninstall acss-theme-builder@shawn-sandy-agentic-acss-plugins
+/plugin uninstall acss-app-builder@shawn-sandy-agentic-acss-plugins
+/plugin uninstall acss-component-specs@shawn-sandy-agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 Existing `.acss-target.json` files remain compatible.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# acss-plugins
+# agentic-acss-plugins
 
 A Claude Code plugin marketplace for building accessible React applications with the [fpkit/acss](https://github.com/shawn-sandy/acss) design system.
 
@@ -11,8 +11,8 @@ A Claude Code plugin marketplace for building accessible React applications with
 ## Install
 
 ```shell
-/plugin marketplace add shawn-sandy/acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Migration

--- a/docs/plans/document-claude-maintainer-tooling.md
+++ b/docs/plans/document-claude-maintainer-tooling.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The `acss-plugins` repo ships one plugin (`acss-kit`) but holds substantial **maintainer-only tooling** at the repo-root `.claude/` directory: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules files, and a `settings.json` enforcing 6 hooks (4 PostToolUse + 2 PreToolUse). Only the agents are documented (`.claude/agents/README.md`). The rest is undocumented, so a contributor (or returning maintainer) browsing `.claude/skills/` cannot tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. exist or when to use them.
+The `agentic-acss-plugins` repo ships one plugin (`acss-kit`) but holds substantial **maintainer-only tooling** at the repo-root `.claude/` directory: 4 review agents, 4 review commands, 10 authoring/release skills, 2 rules files, and a `settings.json` enforcing 6 hooks (4 PostToolUse + 2 PreToolUse). Only the agents are documented (`.claude/agents/README.md`). The rest is undocumented, so a contributor (or returning maintainer) browsing `.claude/skills/` cannot tell that `/release-plugin`, `/component-author`, `/plugin-health`, etc. exist or when to use them.
 
 Goal: make the `.claude/` directory self-documenting so a developer landing in the repo can quickly run the right tool. Mirror the existing per-category README pattern (`agents/README.md`) rather than consolidating into a single file — depth-per-category × 16 items would produce a 500-line index, and contributors editing `.claude/skills/` look for a sibling README, not one a level up.
 

--- a/docs/plans/repo-rename-references.md
+++ b/docs/plans/repo-rename-references.md
@@ -1,0 +1,105 @@
+# Update repo references for `shawn-sandy/acss-plugins` → `shawn-sandy/agentic-acss-plugins`
+
+## Context
+
+The GitHub repository was renamed from `shawn-sandy/acss-plugins` to `shawn-sandy/agentic-acss-plugins`. The git remote in this worktree already points at the new URL (`origin → https://github.com/shawn-sandy/agentic-acss-plugins.git`), but in-repo install instructions, marketplace metadata, and prose still reference the old slug. Users following any current install command would have to rely on GitHub's redirect, which is brittle for the Claude Code marketplace resolver.
+
+Claude Code derives the install suffix from `<owner>-<repo>`, so it changes from `@shawn-sandy-acss-plugins` → `@shawn-sandy-agentic-acss-plugins`.
+
+## Objective
+
+Refresh every in-repo reference to the marketplace path so the README/install snippets, marketplace manifest, contributor docs, and migration notes all point to the new repo. No plugin behavior changes.
+
+## Steps
+
+1. **Marketplace manifest** — `.claude-plugin/marketplace.json`
+   - `"name": "acss-plugins"` → `"name": "agentic-acss-plugins"` (line 3)
+   - `"owner.url"` → `https://github.com/shawn-sandy/agentic-acss-plugins` (line 7)
+
+2. **Root README** — `README.md`
+   - Title `# acss-plugins` → `# agentic-acss-plugins` (line 1)
+   - Install snippet `marketplace add` and `install` lines (lines 14–15)
+
+3. **CLAUDE.md** (lines 18–19)
+   - Update both install lines.
+
+4. **GUIDE.md** (lines 13–14, 113–117)
+   - Install snippet (lines 13–14)
+   - Migration uninstall/install block — 4 plugins each carrying the `@shawn-sandy-acss-plugins` suffix (lines 113–117)
+   - Description prose at line 4 mentioning `acss-plugins`
+
+5. **AGENTS.md** (lines 19–20, 81)
+   - Install snippet
+   - Local-path fallback example mentioning the absolute path
+
+6. **Plugin README** — `plugins/acss-kit/README.md` (lines 43, 60–61)
+   - All install snippets
+
+7. **Plugin CHANGELOG** — `plugins/acss-kit/CHANGELOG.md`
+   - Update the install command at line 57 inside the v0.3.0 migration block (still actionable today — broken commands here would mislead users mid-migration)
+   - Add an `[Unreleased]` entry: `- Marketplace repo renamed from \`shawn-sandy/acss-plugins\` to \`shawn-sandy/agentic-acss-plugins\`. Install commands now use \`@shawn-sandy-agentic-acss-plugins\`.`
+
+8. **Plugin tutorial** — `plugins/acss-kit/docs/tutorial.md` (line 15)
+   - Install snippet
+
+9. **CONTRIBUTING.md** (line 77)
+   - Prose reference `shawn-sandy/acss-plugins` → new slug
+
+10. **Test harness package**
+    - `tests/package.json`: `name` (`acss-plugins-tests` → `agentic-acss-plugins-tests`) and the description string
+    - `tests/package-lock.json`: regenerate after the package.json edit via `npm --prefix tests install --package-lock-only` so the lock's `name` and root `packages.""` entries stay consistent
+    - `tests/run.sh` line 2: update header comment if it references the repo name
+    - `tests/README.md` lines 136, 139, 185, 193: install/marketplace snippets
+
+11. **Plan archive prose** — `docs/plans/document-claude-maintainer-tooling.md` (line 5)
+    - Update current-state prose that names the repo (the file describes ongoing tooling, not a frozen snapshot)
+    - In `docs/plans/test-docs-harness-alignment.md`, **leave the commit URL** at line 5 unchanged — the commit SHA is immutable and GitHub redirects renamed-repo commit URLs reliably.
+
+## Critical files
+
+- `.claude-plugin/marketplace.json` — marketplace identifier, user-visible
+- `README.md`, `plugins/acss-kit/README.md`, `GUIDE.md` — primary install entry points
+- `plugins/acss-kit/CHANGELOG.md` — referenced by users following the migration path
+- `tests/package.json` + `tests/package-lock.json` — must move together to keep `npm --prefix tests ci` deterministic
+
+## Out of scope
+
+- **Sibling repo `shawn-sandy/acss`** — that's the separate fpkit library and is unaffected by this rename
+- **No plugin version bump for `acss-kit`** — see "Alternative considered" below
+- **Git remote** — already updated by the user
+- **Historical CHANGELOG version headers and prose body** — only the embedded install snippet in the v0.3.0 migration block is touched; dated entries are not rewritten
+- **Plan-archive commit URL** — preserved as a stable historical reference
+
+## Alternative considered
+
+Bump `plugins/acss-kit/.claude-plugin/plugin.json` (e.g. patch bump for the rename). **Rejected** because the plugin contract — commands, skills, components, generated CSS — is byte-identical. `/plugin update` would pull no functional change. The pre-submit checklist's version-bump rule exists for behavioral changes; a marketplace path rename is documented in CHANGELOG `[Unreleased]` and ships with the next real release.
+
+## Verification
+
+After edits, run from the repo root:
+
+```sh
+# 1. No remaining references to the old slug or old install suffix
+rg 'shawn-sandy/acss-plugins' -g '!.git' -g '!node_modules' -g '!.claude/worktrees'
+rg '@shawn-sandy-acss-plugins' -g '!.git' -g '!node_modules' -g '!.claude/worktrees'
+# Expected: only the preserved commit URL in docs/plans/test-docs-harness-alignment.md
+
+# 2. marketplace.json is still valid JSON
+python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
+
+# 3. Plugin manifest is untouched (no accidental version bump)
+git diff plugins/acss-kit/.claude-plugin/plugin.json
+# Expected: empty
+
+# 4. Lockfile and package.json agree
+node -e "const a=require('./tests/package.json').name, b=require('./tests/package-lock.json').name; if(a!==b) {console.error('mismatch', a, b); process.exit(1)}"
+
+# 5. Structural test pass
+tests/run.sh
+```
+
+End-to-end smoke (optional, requires a fresh Claude Code session): run `/plugin marketplace add shawn-sandy/agentic-acss-plugins` then `/plugin install acss-kit@shawn-sandy-agentic-acss-plugins` and confirm the new identifier resolves and `/kit-add button` still works.
+
+## Next Steps
+
+- After merge: open a follow-up PR that bumps `acss-kit` for its next real change and folds the `[Unreleased]` rename note into the release entry.

--- a/docs/plans/repo-rename-references.md
+++ b/docs/plans/repo-rename-references.md
@@ -55,6 +55,10 @@ Refresh every in-repo reference to the marketplace path so the README/install sn
     - Update current-state prose that names the repo (the file describes ongoing tooling, not a frozen snapshot)
     - In `docs/plans/test-docs-harness-alignment.md`, **leave the commit URL** at line 5 unchanged — the commit SHA is immutable and GitHub redirects renamed-repo commit URLs reliably.
 
+12. **Maintainer review agents** — `.claude/agents/README.md` and `.claude/agents/{component-reference,python-script,skill-quality,theme-reference}-reviewer.md`
+    - Each agent system prompt opens with "You are a {role} for the acss-plugins repo[sitory]" — update the repo name. Five files, one occurrence each.
+    - **Found late** because this worktree lives at `.claude/worktrees/<name>/` inside the parent checkout, and the parent repo's `.gitignore` has `.claude/worktrees/`. Default ripgrep walks up to the parent gitignore and applies its rules — so it skipped these tracked-but-superficially-ignored files. Run verification grep with `--no-ignore` (or scope to the worktree's `.claude/`) to avoid the trap.
+
 ## Critical files
 
 - `.claude-plugin/marketplace.json` — marketplace identifier, user-visible
@@ -79,10 +83,12 @@ Bump `plugins/acss-kit/.claude-plugin/plugin.json` (e.g. patch bump for the rena
 After edits, run from the repo root:
 
 ```sh
-# 1. No remaining references to the old slug or old install suffix
-rg 'shawn-sandy/acss-plugins' -g '!.git' -g '!node_modules' -g '!.claude/worktrees'
-rg '@shawn-sandy-acss-plugins' -g '!.git' -g '!node_modules' -g '!.claude/worktrees'
-# Expected: only the preserved commit URL in docs/plans/test-docs-harness-alignment.md
+# 1. No remaining references to the old slug or old install suffix.
+#    Use --no-ignore because this worktree lives under the parent's
+#    ignored .claude/worktrees/ path and ripgrep would otherwise skip it.
+rg --pcre2 --no-ignore '(?<!agentic-)acss-plugins' -g '!.git' -g '!node_modules' -g '!tests/node_modules'
+# Expected: only the preserved commit URL in docs/plans/test-docs-harness-alignment.md,
+# the [Unreleased] CHANGELOG entry that documents the rename, and this plan file itself.
 
 # 2. marketplace.json is still valid JSON
 python3 -m json.tool .claude-plugin/marketplace.json > /dev/null

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `acss-kit` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the plugin adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Marketplace repo renamed** from `shawn-sandy/acss-plugins` to `shawn-sandy/agentic-acss-plugins`. Install commands now use `@shawn-sandy-agentic-acss-plugins` (the marketplace alias is derived from `<owner>-<repo>`). The marketplace `name` field in `.claude-plugin/marketplace.json` also moved from `acss-plugins` to `agentic-acss-plugins` to match. No plugin behavior changed; this is metadata-only.
+
 ## [0.3.1] - 2026-04-26
 
 ### Fixed
@@ -54,7 +60,7 @@ Users on any of the predecessor plugins should:
 2. Install `acss-kit`:
 
    ```shell
-   /plugin install acss-kit@shawn-sandy-acss-plugins
+   /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
    ```
 
 3. Existing `.acss-target.json` files at project roots remain compatible — the schema (`{ "componentsDir": "..." }`) is unchanged.

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -40,7 +40,7 @@ If you have any of the old plugins installed:
 /plugin uninstall acss-theme-builder
 /plugin uninstall acss-app-builder
 /plugin uninstall acss-component-specs
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 Existing `.acss-target.json` files at project roots remain compatible — `/kit-add` reads the same shape.
@@ -57,8 +57,8 @@ npm install -D sass
 ## Installation
 
 ```shell
-/plugin marketplace add shawn-sandy/acss-plugins
-/plugin install acss-kit@shawn-sandy-acss-plugins
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Component commands

--- a/plugins/acss-kit/docs/tutorial.md
+++ b/plugins/acss-kit/docs/tutorial.md
@@ -12,7 +12,7 @@ Prerequisites:
 
 - React + TypeScript project with a `package.json`
 - `sass` or `sass-embedded` in `devDependencies`
-- `acss-kit` installed via `/plugin install acss-kit@shawn-sandy-acss-plugins`
+- `acss-kit` installed via `/plugin install acss-kit@shawn-sandy-agentic-acss-plugins`
 
 If sass is not installed:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -133,10 +133,10 @@ Inside the Claude Code session, paste the block from `RECIPE.md`:
 
 ```text
 /plugin marketplace add <absolute path printed by the script>
-/plugin install acss-kit@acss-plugins
+/plugin install acss-kit@agentic-acss-plugins
 ```
 
-The local marketplace suffix is `acss-plugins`, from the `name` field in `.claude-plugin/marketplace.json`.
+The local marketplace suffix is `agentic-acss-plugins`, from the `name` field in `.claude-plugin/marketplace.json`.
 
 ### Smoke flow
 
@@ -182,7 +182,7 @@ Run `npm --prefix tests ci` from the repo root.
 
 Run `pip3 install --user tinycss2`.
 
-**`Run this script from inside the acss-plugins repo` (setup.sh)**
+**`Run this script from inside the agentic-acss-plugins repo` (setup.sh)**
 
 The script cannot find `.claude-plugin/marketplace.json`. `cd` to the repo root and re-run.
 
@@ -190,7 +190,7 @@ The script cannot find `.claude-plugin/marketplace.json`. `cd` to the repo root 
 
 Expected on a second run. Pass `--reset` if you want a clean rebuild.
 
-**`/plugin install acss-kit@acss-plugins` says "not found"**
+**`/plugin install acss-kit@agentic-acss-plugins` says "not found"**
 
 Confirm the marketplace was added from the printed absolute repo path. Then run `/plugin marketplace list` and use the listed suffix if your Claude Code version normalizes it differently.
 

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "acss-plugins-tests",
+  "name": "agentic-acss-plugins-tests",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "acss-plugins-tests",
+      "name": "agentic-acss-plugins-tests",
       "version": "0.0.0",
       "devDependencies": {
         "@types/react": "^18.3.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "acss-plugins-tests",
+  "name": "agentic-acss-plugins-tests",
   "version": "0.0.0",
   "private": true,
-  "description": "Local test harness for the acss-plugins marketplace. Not published.",
+  "description": "Local test harness for the agentic-acss-plugins marketplace. Not published.",
   "type": "module",
   "scripts": {
     "tsc": "tsc"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Phase 1 test harness for acss-plugins.
+# Phase 1 test harness for agentic-acss-plugins.
 #
 # Runs the full structural validation gate. SERIAL ONLY — concurrent
 # runs in the same checkout will collide on tests/.tmp/. If you need

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Scaffold a disposable Vite + React + TypeScript sandbox at tests/sandbox/
-# for end-to-end demo and smoke-testing of the acss-plugins marketplace.
+# for end-to-end demo and smoke-testing of the agentic-acss-plugins marketplace.
 #
 # This is the DEMO path. For automated test verification, run:
 #
@@ -62,7 +62,7 @@ fi
 
 if [[ ! -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
   echo "Error: marketplace.json not found at $REPO_ROOT/.claude-plugin/" >&2
-  echo "Run this script from inside the acss-plugins repo." >&2
+  echo "Run this script from inside the agentic-acss-plugins repo." >&2
   exit 1
 fi
 
@@ -115,7 +115,7 @@ Inside the Claude Code session, paste these commands (the path is quoted so it w
 
 \`\`\`
 /plugin marketplace add "$REPO_ROOT"
-/plugin install acss-kit@acss-plugins
+/plugin install acss-kit@agentic-acss-plugins
 \`\`\`
 
 Then exercise the plugin. Suggested smoke flow:
@@ -154,8 +154,8 @@ git add -A
 # The .invalid TLD is reserved by RFC 2606 to signal a non-real address.
 # Subsequent commits the contributor makes inside tests/sandbox/ use their
 # normal git config — the overrides only affect this one invocation.
-git -c user.name="acss-plugins sandbox" \
-    -c user.email="sandbox@acss-plugins.invalid" \
+git -c user.name="agentic-acss-plugins sandbox" \
+    -c user.email="sandbox@agentic-acss-plugins.invalid" \
     -c commit.gpgsign=false \
     commit --no-verify -q -m "initial sandbox"
 


### PR DESCRIPTION
## Summary

- Refresh every in-repo reference from `shawn-sandy/acss-plugins` to `shawn-sandy/agentic-acss-plugins` (the GitHub repo was renamed; the git remote was already updated, this brings the docs and metadata in line)
- Marketplace install suffix moves from `@shawn-sandy-acss-plugins` to `@shawn-sandy-agentic-acss-plugins`; the `name` field in `.claude-plugin/marketplace.json` also moves to `agentic-acss-plugins`
- Add a CHANGELOG `[Unreleased]` entry under `acss-kit` documenting the marketplace rename — no plugin version bump (the plugin contract is byte-identical)

## Why

Existing install commands in the README, GUIDE, AGENTS, CONTRIBUTING, plugin tutorial, and CHANGELOG migration block all pointed at the old slug. Users following them would rely on GitHub's redirect, which is brittle for the Claude Code marketplace resolver. This change makes every documented install path resolve directly without a redirect.

## What did NOT change

- **Plugin name** stays `acss-kit` — same plugin, same skills, same commands
- **Plugin version** stays `0.3.1` — `plugins/acss-kit/.claude-plugin/plugin.json` is byte-identical (verified)
- **Author URL** at `plugins/acss-kit/.claude-plugin/plugin.json` line 7 still points to `shawn-sandy/acss` — that's the sibling fpkit library repo, not the marketplace repo
- **Three references intentionally preserved** (verified via `rg --pcre2 '(?<!agentic-)acss-plugins'`):
  1. Historical commit URL in `docs/plans/test-docs-harness-alignment.md` — commit SHAs are immutable and GitHub redirects renamed-repo commit URLs reliably
  2. The planning doc `docs/plans/repo-rename-references.md` itself naturally references both the old and new names
  3. The new CHANGELOG `[Unreleased]` entry quotes the prior name as part of describing the rename

## Test plan

- [x] `tests/run.sh` green (Phase 1 structural validation: extract+TSC, SCSS contract, manifest, known-bad self-tests)
- [x] `python3 -m json.tool` clean on `marketplace.json`, `tests/package.json`, `tests/package-lock.json`
- [x] `tests/package.json` `name` field matches `tests/package-lock.json` `name` field (both `agentic-acss-plugins-tests`)
- [x] `git diff --stat plugins/acss-kit/.claude-plugin/plugin.json` empty (no accidental version bump)
- [ ] (Optional, post-merge) End-to-end smoke from a fresh Claude Code session: `/plugin marketplace add shawn-sandy/agentic-acss-plugins` then `/plugin install acss-kit@shawn-sandy-agentic-acss-plugins` and run `/kit-add button` to confirm the new identifier resolves end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)