### PR TITLE
feat(acss-kit): add /setup command for first-run project bootstrap (0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "acss-kit",
       "source": "./plugins/acss-kit",
-      "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Markdown-as-source component templates plus OKLCH theme generation with WCAG 2.2 AA validation. No @fpkit/acss npm package required.",
+      "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Run /setup to bootstrap a new project (sass check, ui.tsx copy, starter theme). Then use /kit-add for components and /theme-create for themes. No @fpkit/acss npm package required.",
       "category": "development",
       "tags": [
         "fpkit",

--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -8,6 +8,7 @@ paths:
 Current scripts in `plugins/acss-kit/scripts/`:
 
 - `detect_target.py` — detects the target project type (Vite, etc.) for skill routing
+- `detect_package_manager.py` — detects the active package manager (pnpm/yarn/bun/npm) via lockfile inspection; outputs install command
 - `generate_palette.py` — OKLCH palette math; outputs palette JSON
 - `css_to_tokens.py` — converts CSS custom properties to palette JSON
 - `tokens_to_css.py` — converts palette JSON to CSS custom property files
@@ -21,7 +22,7 @@ For scripts whose output is parsed by slash commands or skills.
 - Exit 0 on success, 1 on logical failure (e.g. nothing detected)
 - Always include a `"reasons"` array in the JSON — empty `[]` on success, populated on failure
 
-Detectors: `detect_target.py`.
+Detectors: `detect_target.py`, `detect_package_manager.py`.
 
 ## Generator / validator contract (pipeline-friendly, human-readable)
 

--- a/plugins/acss-kit/.claude-plugin/plugin.json
+++ b/plugins/acss-kit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit",
   "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Markdown-as-source component templates plus OKLCH theme generation with WCAG 2.2 AA validation.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 
 - **Marketplace repo renamed** from `shawn-sandy/acss-plugins` to `shawn-sandy/agentic-acss-plugins`. Install commands now use `@shawn-sandy-agentic-acss-plugins` (the marketplace alias is derived from `<owner>-<repo>`). The marketplace `name` field in `.claude-plugin/marketplace.json` also moved from `acss-plugins` to `agentic-acss-plugins` to match. No plugin behavior changed; this is metadata-only.
 
+## [0.4.0] - 2026-04-26
+
+### Added
+
+- **`/setup` command** — first-run project bootstrap for acss-kit. Detects package manager via lockfile inspection, prints the exact `<pm> add -D sass` command (does not execute), writes `.acss-target.json`, copies `ui.tsx` verbatim, and optionally seeds `src/styles/theme/light.css` + `dark.css` via the OKLCH pipeline. Per-step idempotency: re-running `/setup` skips artifacts that already exist and tabulates `created` vs `kept` in the final summary.
+- **`detect_package_manager.py`** — new detector script. Inspects lockfiles in priority order (`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`) then falls back to `package.json#packageManager` field. Outputs `{ manager, lockfile, installCommand, projectRoot, reasons }`. Includes `--self-test` mode for `tests/run.sh` smoke check.
+- **`skills/setup/SKILL.md`** — cross-domain setup skill. Deliberately not nested under `components` or `styles`; documents the placement rationale inline for future maintainers.
+
 ## [0.3.1] - 2026-04-26
 
 ### Fixed

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -48,11 +48,7 @@ Existing `.acss-target.json` files at project roots remain compatible — `/kit-
 ## Prerequisites
 
 - React + TypeScript project
-- `sass` or `sass-embedded` in devDependencies
-
-```bash
-npm install -D sass
-```
+- `sass` or `sass-embedded` in devDependencies (acss-kit will tell you the exact command if missing)
 
 ## Installation
 
@@ -60,6 +56,28 @@ npm install -D sass
 /plugin marketplace add shawn-sandy/agentic-acss-plugins
 /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
+
+## First-run setup
+
+**Run `/setup` once after installing the plugin.** It front-loads the one-time configuration so subsequent `/kit-add` and `/theme-create` calls are pure generation.
+
+```
+/setup
+```
+
+What it does:
+
+1. Detects your package manager from the lockfile (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `package-lock.json`).
+2. Checks for `sass`/`sass-embedded` in `devDependencies`. If missing, prints the exact install command and stops — no side effects.
+3. Writes `.acss-target.json` at your project root (or reuses existing).
+4. Copies `ui.tsx` (the polymorphic foundation component) verbatim to your target directory.
+5. Seeds `src/styles/theme/light.css` and `dark.css` from a prompt for a seed hex color.
+
+Pass `--no-theme` to skip theme generation, or `--target=<dir>` to override the component output directory.
+
+**Generated artifacts are committed — developer owns the code.** `.acss-target.json`, `src/components/fpkit/`, and `src/styles/theme/` should be in version control, not `.gitignore`.
+
+`/setup` is idempotent: re-running it checks each artifact and skips anything already present.
 
 ## Component commands
 
@@ -276,6 +294,7 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
     brand-template.css                     # Brand preset placeholder (theme-brand)
     theme.schema.json                      # Internal contract for round-trip scripts
   commands/
+    setup.md                               # /setup  ← start here after install
     kit-list.md                            # /kit-list
     kit-add.md                             # /kit-add
     theme-create.md                        # /theme-create
@@ -284,6 +303,7 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
     theme-extract.md                       # /theme-extract
   scripts/
     detect_target.py                       # Manages .acss-target.json
+    detect_package_manager.py             # Detects pnpm/yarn/bun/npm from lockfile
     generate_palette.py                    # OKLCH palette math
     tokens_to_css.py                       # Palette JSON → CSS theme
     css_to_tokens.py                       # CSS theme → palette JSON (round-trip)
@@ -305,6 +325,8 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
         theme-schema.md                    # Internal JSON schema reference
     component-form/
       SKILL.md                             # Form pilot — auto-triggers on natural language
+    setup/
+      SKILL.md                             # Cross-domain setup skill (/setup command)
   docs/                                    # Developer guides (architecture, recipes, troubleshooting)
 ```
 

--- a/plugins/acss-kit/commands/setup.md
+++ b/plugins/acss-kit/commands/setup.md
@@ -1,0 +1,43 @@
+---
+description: Bootstrap a React project for acss-kit — installs sass, copies ui.tsx, writes .acss-target.json, optionally seeds a starter theme
+argument-hint: [--no-theme] [--target=<dir>]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+
+# /setup
+
+First-run bootstrap for acss-kit. Run once after `/plugin install acss-kit` to prepare your project before generating components or themes.
+
+## Usage
+
+```
+/setup
+/setup --no-theme
+/setup --target=src/ui/fpkit/
+```
+
+## Workflow
+
+When this command is invoked, follow the full bootstrap workflow documented in the `setup` skill at `${CLAUDE_PLUGIN_ROOT}/skills/setup/SKILL.md`.
+
+### Quick Reference
+
+1. **Verify project** — confirm React + TypeScript project is present
+2. **React version** — detect React 19+ and warn if ui.tsx adaptation may be needed
+3. **Package manager** — auto-detect from lockfile or `package.json#packageManager` field
+4. **sass check** — if missing, print the exact install command and stop (no side effects)
+5. **Target directory** — read `.acss-target.json` or prompt for target dir and write the file
+6. **ui.tsx** — copy `${CLAUDE_PLUGIN_ROOT}/assets/foundation/ui.tsx` to target dir (verbatim)
+7. **Starter theme** — seed `src/styles/theme/light.css` and `dark.css` via OKLCH pipeline (skip with `--no-theme`)
+8. **Summary** — tabulate `created` vs `kept` artifacts and print next steps
+
+### After Setup
+
+Once `/setup` completes:
+
+```
+/kit-add button card      # generate your first components
+/theme-create "#4f46e5"   # re-generate or tune the theme
+```
+
+Generated files (`src/components/fpkit/`, `src/styles/theme/`, `.acss-target.json`) are owned by your project — commit them.

--- a/plugins/acss-kit/scripts/detect_package_manager.py
+++ b/plugins/acss-kit/scripts/detect_package_manager.py
@@ -2,14 +2,18 @@
 """
 Detect the package manager for a JavaScript project.
 
-Inspection priority (first match wins):
+Inspection priority (first match wins, walking from package root upward):
   1. pnpm-lock.yaml          → pnpm
   2. yarn.lock               → yarn
   3. bun.lock (text, 1.2+)   → bun
   4. bun.lockb (binary)      → bun
   5. package-lock.json       → npm
-  6. package.json#packageManager field (name@version spec)
+  6. package.json#packageManager field (name@version spec, walks ancestors)
   7. npm (final fallback)
+
+Lockfile search walks ancestor directories so monorepo/workspace setups
+are handled correctly — workspace lockfiles live at the workspace root,
+not inside each package.
 
 Usage:
     python detect_package_manager.py [project_root]
@@ -62,6 +66,7 @@ INSTALL_COMMANDS = {
 
 
 def find_project_root(start: Path) -> Optional[Path]:
+    """Walk from start upward; return first directory containing package.json."""
     cur = start.resolve()
     while True:
         if (cur / "package.json").is_file():
@@ -71,26 +76,51 @@ def find_project_root(start: Path) -> Optional[Path]:
         cur = cur.parent
 
 
-def detect_manager(root: Path) -> dict:
-    lockfile_name: Optional[str] = None
-    manager = "npm"
+def find_lockfile(start: Path) -> tuple[Optional[str], Optional[str]]:
+    """Walk from start upward; return (filename, manager) for first lockfile found.
 
-    for filename, pm in LOCKFILE_PRIORITY:
-        if (root / filename).is_file():
-            lockfile_name = filename
-            manager = pm
-            break
+    Walks ancestors so monorepo workspace lockfiles (at the workspace root)
+    are found even when start is a nested package directory.
+    """
+    cur = start.resolve()
+    while True:
+        for filename, pm in LOCKFILE_PRIORITY:
+            if (cur / filename).is_file():
+                return filename, pm
+        if cur.parent == cur:
+            return None, None
+        cur = cur.parent
+
+
+def find_packagemanager_field(start: Path) -> Optional[str]:
+    """Walk from start upward; return manager from first packageManager field found.
+
+    Handles workspace roots that carry the packageManager field on the root
+    package.json rather than on nested package package.json files.
+    """
+    cur = start.resolve()
+    while True:
+        pkg_path = cur / "package.json"
+        if pkg_path.is_file():
+            try:
+                pkg = json.loads(pkg_path.read_text(encoding="utf-8"))
+                pm_field = pkg.get("packageManager", "")
+                if pm_field:
+                    m = re.match(r"^([a-z]+)@", pm_field)
+                    if m and m.group(1) in INSTALL_COMMANDS:
+                        return m.group(1)
+            except Exception:
+                pass
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def detect_manager(root: Path) -> dict:
+    lockfile_name, manager = find_lockfile(root)
 
     if lockfile_name is None:
-        try:
-            pkg = json.loads((root / "package.json").read_text(encoding="utf-8"))
-            pm_field = pkg.get("packageManager", "")
-            if pm_field:
-                m = re.match(r"^([a-z]+)@", pm_field)
-                if m and m.group(1) in INSTALL_COMMANDS:
-                    manager = m.group(1)
-        except Exception:
-            pass
+        manager = find_packagemanager_field(root) or "npm"
 
     return {
         "manager": manager,

--- a/plugins/acss-kit/scripts/detect_package_manager.py
+++ b/plugins/acss-kit/scripts/detect_package_manager.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Detect the package manager for a JavaScript project.
+
+Inspection priority (first match wins):
+  1. pnpm-lock.yaml          → pnpm
+  2. yarn.lock               → yarn
+  3. bun.lock (text, 1.2+)   → bun
+  4. bun.lockb (binary)      → bun
+  5. package-lock.json       → npm
+  6. package.json#packageManager field (name@version spec)
+  7. npm (final fallback)
+
+Usage:
+    python detect_package_manager.py [project_root]
+    python detect_package_manager.py --self-test
+
+Output (JSON to stdout):
+
+    Success:
+    {
+      "manager": "pnpm",
+      "lockfile": "pnpm-lock.yaml",
+      "installCommand": "pnpm add -D",
+      "projectRoot": "/abs/path",
+      "reasons": []
+    }
+
+    Failure (no project root found):
+    {
+      "manager": null,
+      "lockfile": null,
+      "installCommand": null,
+      "projectRoot": null,
+      "reasons": ["No package.json found in any ancestor directory."]
+    }
+
+Exit code 0 = manager detected, 1 = no project root found.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+LOCKFILE_PRIORITY = [
+    ("pnpm-lock.yaml", "pnpm"),
+    ("yarn.lock", "yarn"),
+    ("bun.lock", "bun"),
+    ("bun.lockb", "bun"),
+    ("package-lock.json", "npm"),
+]
+
+INSTALL_COMMANDS = {
+    "npm": "npm install -D",
+    "pnpm": "pnpm add -D",
+    "yarn": "yarn add -D",
+    "bun": "bun add -d",
+}
+
+
+def find_project_root(start: Path) -> Optional[Path]:
+    cur = start.resolve()
+    while True:
+        if (cur / "package.json").is_file():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def detect_manager(root: Path) -> dict:
+    lockfile_name: Optional[str] = None
+    manager = "npm"
+
+    for filename, pm in LOCKFILE_PRIORITY:
+        if (root / filename).is_file():
+            lockfile_name = filename
+            manager = pm
+            break
+
+    if lockfile_name is None:
+        try:
+            pkg = json.loads((root / "package.json").read_text(encoding="utf-8"))
+            pm_field = pkg.get("packageManager", "")
+            if pm_field:
+                m = re.match(r"^([a-z]+)@", pm_field)
+                if m and m.group(1) in INSTALL_COMMANDS:
+                    manager = m.group(1)
+        except Exception:
+            pass
+
+    return {
+        "manager": manager,
+        "lockfile": lockfile_name,
+        "installCommand": INSTALL_COMMANDS[manager],
+        "projectRoot": str(root),
+        "reasons": [],
+    }
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if args and args[0] == "--self-test":
+        return self_test()
+
+    start = Path(args[0]).resolve() if args else Path.cwd()
+    root = find_project_root(start)
+    if root is None:
+        print(json.dumps({
+            "manager": None,
+            "lockfile": None,
+            "installCommand": None,
+            "projectRoot": None,
+            "reasons": ["No package.json found in any ancestor directory."],
+        }))
+        return 1
+
+    print(json.dumps(detect_manager(root)))
+    return 0
+
+
+def self_test() -> int:
+    import tempfile
+
+    passed = 0
+    failed = 0
+
+    def run(
+        name: str,
+        files: dict,
+        expected_manager: str,
+        expected_lockfile: Optional[str] = None,
+    ) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for filename, content in files.items():
+                (root / filename).write_text(content, encoding="utf-8")
+            result = detect_manager(root)
+            manager_ok = result["manager"] == expected_manager
+            lockfile_ok = expected_lockfile is None or result["lockfile"] == expected_lockfile
+            if manager_ok and lockfile_ok:
+                print(f"PASS: {name}")
+                passed += 1
+            else:
+                detail = f"manager={result['manager']!r}, lockfile={result['lockfile']!r}"
+                print(f"FAIL: {name} — got {detail}")
+                failed += 1
+
+    run(
+        "pnpm-lock.yaml → pnpm",
+        {"package.json": '{"name":"test"}', "pnpm-lock.yaml": ""},
+        "pnpm",
+        "pnpm-lock.yaml",
+    )
+    run(
+        "package-lock.json → npm",
+        {"package.json": '{"name":"test"}', "package-lock.json": "{}"},
+        "npm",
+        "package-lock.json",
+    )
+    run(
+        "packageManager field → yarn (no lockfile)",
+        {"package.json": '{"name":"test","packageManager":"yarn@3.6.0"}'},
+        "yarn",
+        None,
+    )
+
+    total = passed + failed
+    if failed:
+        print(f"\n{failed}/{total} self-test(s) FAILED")
+        return 1
+    print(f"\nAll {total} self-tests PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-kit/skills/setup/SKILL.md
+++ b/plugins/acss-kit/skills/setup/SKILL.md
@@ -42,7 +42,14 @@ Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_target.py <cwd>`.
 
 Parse the JSON output. If `projectRoot` is `null`, halt with the script's `reasons[0]` message. Do not proceed.
 
-Checkpoint: `Detected React project at <projectRoot>`.
+Then confirm TypeScript is configured: check that `<projectRoot>/tsconfig.json` exists. If not, halt with:
+
+```
+TypeScript not configured. /setup requires a React + TypeScript project.
+Add tsconfig.json and re-run /setup.
+```
+
+Checkpoint: `Detected React + TypeScript project at <projectRoot>`.
 
 ---
 
@@ -100,9 +107,15 @@ Halt. Record `paused=true` for the Step 8 summary. Do not proceed to Step 5.
 
 ## Step 5 — Determine target directory
 
-Honor the `--target=<dir>` flag if provided; use that value as `componentsDir`.
+**If `--target=<dir>` was passed:**
+Set `componentsDir` to the specified value. Always write `.acss-target.json` at `projectRoot` so subsequent `/kit-add` calls use the same directory:
+```json
+{ "componentsDir": "<dir>" }
+```
+Add `.acss-target.json` to `created[]`.
 
-Otherwise, read `.acss-target.json` at `projectRoot`:
+**Otherwise:**
+Read `.acss-target.json` at `projectRoot`:
 
 - **If it exists:** Use the `componentsDir` value. Add `.acss-target.json` to `kept[]`. Skip the prompt.
 - **If it does not exist:** Ask:
@@ -138,11 +151,21 @@ Checkpoint: `Copied ui.tsx to <componentsDir>/` or `ui.tsx already present, skip
 
 If `--no-theme` was passed, skip this step entirely.
 
-Check if `<projectRoot>/src/styles/theme/light.css` exists.
+Let `themeDir = <projectRoot>/src/styles/theme/`. Check `light.css` and `dark.css` in `themeDir` independently:
 
-**If it exists:** Add `src/styles/theme/light.css` and `src/styles/theme/dark.css` to `kept[]`. Skip.
+- If `<themeDir>/light.css` exists, add it to `kept[]`.
+- If `<themeDir>/dark.css` exists, add it to `kept[]`.
 
-**If it does not exist:**
+Determine generation mode from what is missing:
+
+| light.css | dark.css | Action |
+|-----------|----------|--------|
+| present   | present  | skip — both already kept |
+| present   | missing  | `--mode=dark` |
+| missing   | present  | `--mode=light` |
+| missing   | missing  | `--mode=both` |
+
+**If generation is needed:**
 1. Ask the developer for a seed hex color:
    ```
    Enter a seed hex color for your theme (default: #4f46e5):
@@ -150,27 +173,27 @@ Check if `<projectRoot>/src/styles/theme/light.css` exists.
 2. Validate the input is a 3- or 6-digit hex color (e.g. `#4f46e5` or `#fff`). If invalid, use `#4f46e5` and note the substitution.
 3. Run:
    ```
-   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_palette.py <hex> --mode=both
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_palette.py <hex> --mode=<mode>
    ```
    Capture JSON stdout. If exit code is non-zero, print the error output, skip to Step 8 (keep component init intact; record theme as not generated).
 4. Run:
    ```
-   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/tokens_to_css.py --stdin --out-dir=src/styles/theme/
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/tokens_to_css.py --stdin --out-dir=<projectRoot>/src/styles/theme/
    ```
-   piping the palette JSON to stdin. This writes `src/styles/theme/light.css` and `dark.css`.
+   piping the palette JSON to stdin.
 5. Run:
    ```
-   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_theme.py src/styles/theme/
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_theme.py <projectRoot>/src/styles/theme/
    ```
-   **On validation failure:** Print the contrast errors. Add `light.css` and `dark.css` to `created[]` with a `(contrast warning)` flag. Print:
+   **On validation failure:** Print the contrast errors. Add the generated files to `created[]` with a `(contrast warning)` flag. Print:
    ```
    Theme validation failed — fix the seed color and re-run /theme-create.
    ```
    Do not roll back `ui.tsx` or `.acss-target.json`. Continue to Step 8.
 
-   **On validation success:** Add `src/styles/theme/light.css` and `src/styles/theme/dark.css` to `created[]`.
+   **On validation success:** Add the generated files to `created[]`.
 
-Checkpoint: `Wrote light.css and dark.css` or `Theme files already present, skipped`.
+Checkpoint: `Wrote <generated files>` or `Theme files already present, skipped`.
 
 ---
 

--- a/plugins/acss-kit/skills/setup/SKILL.md
+++ b/plugins/acss-kit/skills/setup/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: setup
+description: Use when the user runs /setup or asks to "set up", "bootstrap", "initialize", or "prepare" a project for acss-kit components and themes. One-time first-run init — detects package manager, prints the sass install command, writes .acss-target.json, copies ui.tsx, optionally seeds a starter theme. Cross-domain skill (touches both components and styles concerns) — deliberately not nested under either domain skill.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+metadata:
+  version: "0.4.0"
+---
+
+# SKILL: setup
+
+Bootstrap a React project for acss-kit. Run once after `/plugin install acss-kit` to front-load the one-time setup so subsequent `/kit-add` and `/theme-create` calls are pure generation.
+
+**Skill placement rationale:** `/setup` spans both the `components` and `styles` domains — it initializes `ui.tsx` (component foundation) and seeds a starter theme (styles). It lives as its own skill rather than as a section of either domain skill. This is the only cross-domain skill in the plugin; future maintainers should not merge it into `components/SKILL.md` or `styles/SKILL.md`.
+
+## Purpose
+
+Front-load the one-time project configuration that would otherwise run piecemeal at the start of each `/kit-add` invocation. After `/setup` succeeds:
+
+- `sass` is confirmed in `devDependencies` (or the user has the exact install command to run)
+- `.acss-target.json` exists at the project root
+- `<componentsDir>/ui.tsx` is present
+- `src/styles/theme/light.css` and `dark.css` exist (unless `--no-theme` was passed)
+
+## Prerequisites
+
+- React + TypeScript project
+
+## Idempotency contract
+
+Every step checks for its artifact before acting. If the artifact already exists, the step is skipped and added to `kept[]`. If the artifact is created, it is added to `created[]`. The final summary tabulates both lists. There is no `--force` flag — re-running `/setup` is safe.
+
+## Flags
+
+- `--no-theme` — skip Step 7 (theme generation). Only initializes the component foundation.
+- `--target=<dir>` — override the default target directory (default: `src/components/fpkit/`).
+
+---
+
+## Step 1 — Verify React project
+
+Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_target.py <cwd>`.
+
+Parse the JSON output. If `projectRoot` is `null`, halt with the script's `reasons[0]` message. Do not proceed.
+
+Checkpoint: `Detected React project at <projectRoot>`.
+
+---
+
+## Step 2 — Detect React version
+
+Read `package.json` at the detected `projectRoot`. Extract `dependencies.react`.
+
+Apply the regex `/^[~^>=]*(\d+)/` to the version string. If the first captured group is `19` or higher, print:
+
+```
+Warning: React 19+ detected. ui.tsx is copied verbatim from the plugin asset.
+It may need the ElementInstance<C> adaptation for React 19 + TS compatibility.
+See the acss-kit first-run transcript for the patch pattern.
+```
+
+Continue regardless — the warning is advisory only.
+
+Checkpoint: `React 19+ detected — see warning above` or `React <major> detected`.
+
+---
+
+## Step 3 — Detect package manager
+
+Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_package_manager.py <projectRoot>`.
+
+Parse the JSON output. Capture `manager`, `lockfile`, and `installCommand` for use in Steps 4 and 8.
+
+Checkpoint: `Detected <manager> (<lockfile if present, else "packageManager field">)`.
+
+---
+
+## Step 4 — Print sass install command (does not execute)
+
+Read `package.json` `devDependencies` at `projectRoot`. Check for `sass` or `sass-embedded`.
+
+**If `sass` or `sass-embedded` is present:** Skip. Add `sass` (or `sass-embedded`) to `kept[]`. Continue to Step 5.
+
+**If `node-sass` only:** Print:
+```
+Warning: node-sass found in devDependencies.
+Vite prefers sass or sass-embedded. Consider replacing it:
+  <installCommand> sass
+```
+Continue to Step 5 — do not halt.
+
+**If neither is present:** Print:
+```
+sass not found in devDependencies.
+Run: <installCommand> sass
+Then re-run: /setup
+```
+Halt. Record `paused=true` for the Step 8 summary. Do not proceed to Step 5.
+
+---
+
+## Step 5 — Determine target directory
+
+Honor the `--target=<dir>` flag if provided; use that value as `componentsDir`.
+
+Otherwise, read `.acss-target.json` at `projectRoot`:
+
+- **If it exists:** Use the `componentsDir` value. Add `.acss-target.json` to `kept[]`. Skip the prompt.
+- **If it does not exist:** Ask:
+  ```
+  Where should components be generated? (default: src/components/fpkit/)
+  ```
+  Write `.acss-target.json` at `projectRoot`:
+  ```json
+  { "componentsDir": "src/components/fpkit" }
+  ```
+  Add `.acss-target.json` to `created[]`.
+
+Checkpoint: `Wrote .acss-target.json (componentsDir=<dir>)` or `Reusing existing .acss-target.json (componentsDir=<dir>)`.
+
+---
+
+## Step 6 — Copy ui.tsx foundation
+
+Check if `<projectRoot>/<componentsDir>/ui.tsx` exists.
+
+**If it exists:** Skip. Add `<componentsDir>/ui.tsx` to `kept[]`.
+
+**If it does not exist:**
+1. Create the directory `<projectRoot>/<componentsDir>/` if it does not exist.
+2. Read `${CLAUDE_PLUGIN_ROOT}/assets/foundation/ui.tsx` and write it verbatim to `<projectRoot>/<componentsDir>/ui.tsx`. Do not edit or adapt the content.
+3. Add `<componentsDir>/ui.tsx` to `created[]`.
+
+Checkpoint: `Copied ui.tsx to <componentsDir>/` or `ui.tsx already present, skipped`.
+
+---
+
+## Step 7 — Seed starter theme (skip if --no-theme)
+
+If `--no-theme` was passed, skip this step entirely.
+
+Check if `<projectRoot>/src/styles/theme/light.css` exists.
+
+**If it exists:** Add `src/styles/theme/light.css` and `src/styles/theme/dark.css` to `kept[]`. Skip.
+
+**If it does not exist:**
+1. Ask the developer for a seed hex color:
+   ```
+   Enter a seed hex color for your theme (default: #4f46e5):
+   ```
+2. Validate the input is a 3- or 6-digit hex color (e.g. `#4f46e5` or `#fff`). If invalid, use `#4f46e5` and note the substitution.
+3. Run:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_palette.py <hex> --mode=both
+   ```
+   Capture JSON stdout. If exit code is non-zero, print the error output, skip to Step 8 (keep component init intact; record theme as not generated).
+4. Run:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/tokens_to_css.py --stdin --out-dir=src/styles/theme/
+   ```
+   piping the palette JSON to stdin. This writes `src/styles/theme/light.css` and `dark.css`.
+5. Run:
+   ```
+   python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_theme.py src/styles/theme/
+   ```
+   **On validation failure:** Print the contrast errors. Add `light.css` and `dark.css` to `created[]` with a `(contrast warning)` flag. Print:
+   ```
+   Theme validation failed — fix the seed color and re-run /theme-create.
+   ```
+   Do not roll back `ui.tsx` or `.acss-target.json`. Continue to Step 8.
+
+   **On validation success:** Add `src/styles/theme/light.css` and `src/styles/theme/dark.css` to `created[]`.
+
+Checkpoint: `Wrote light.css and dark.css` or `Theme files already present, skipped`.
+
+---
+
+## Step 8 — Print summary
+
+If `paused=true` (Step 4 halted), print:
+```
+Setup paused at Step 4.
+Run: <installCommand> sass
+Then re-run: /setup
+```
+
+Otherwise, print a structured summary:
+
+```
+Setup complete.
+
+Created:
+  - <componentsDir>/ui.tsx
+  - .acss-target.json
+  - src/styles/theme/light.css
+  - src/styles/theme/dark.css
+
+Kept (already present):
+  - sass in devDependencies
+
+Next steps:
+  - Commit these files (developer owns the code)
+  - /kit-add button card    # generate your first components
+```
+
+If theme validation failed, append to next steps:
+```
+  - Fix the seed color and re-run /theme-create
+```
+
+Omit any section (`Created` or `Kept`) that is empty.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -142,5 +142,16 @@ console.log('known-bad: TSX validator caught', failures.length, 'failure(s)');
 
 green "TSX validator caught known-bad.tsx"
 
+# Step 7
+section "7. detect_package_manager.py --self-test"
+DPM_LOG="$TMP_ROOT/detect-pm.log"
+if python3 "$REPO_ROOT/plugins/acss-kit/scripts/detect_package_manager.py" --self-test >"$DPM_LOG"; then
+  green "detect_package_manager self-test OK"
+else
+  red "detect_package_manager self-test FAILED:"
+  cat "$DPM_LOG"
+  exit 1
+fi
+
 section "ALL STEPS GREEN"
 green "Phase 1 harness passed."

--- a/~/devbox/agent-plans/review-this-file-and-ticklish-newt.md
+++ b/~/devbox/agent-plans/review-this-file-and-ticklish-newt.md
@@ -1,0 +1,242 @@
+# Plan: `/setup` skill for acss-kit — first-run project bootstrap
+
+## Context
+
+The transcript at `tests/2026-04-26-214810-implement-the-following-plan.txt` captures a real `/kit-add button card` first-run inside `tests/sandbox/`. Before any component could be generated, the user had to manually:
+
+1. Install `sass` as a dev dep (Vite needs it to compile `*.scss` imports)
+2. Create `src/components/fpkit/`
+3. Copy `assets/foundation/ui.tsx` verbatim
+4. Hand-patch `ui.tsx` for React 19 + TS 6 (`React.ElementRef<C>` → custom `ElementInstance<C>`)
+
+Today this prerequisite plumbing is wedged into Step A of `plugins/acss-kit/skills/components/SKILL.md` (lines 24–74), which runs at the start of *every* `/kit-add` invocation. There is no dedicated entry point users can run once after `/plugin install acss-kit` to prepare a project.
+
+This plan adds a `/setup` slash command + `setup` skill that front-loads the one-time bootstrap so subsequent `/kit-add` and `/theme-create` calls become pure generation. `/kit-add`'s inline Step A is left untouched as a safety net (per user decision — lower-risk than slimming it).
+
+## Decisions (locked in via AskUserQuestion + plan-interview)
+
+| Question | Decision |
+|---|---|
+| Sass install execution | **Print command only** — detect PM, print the exact `<pm> add -D sass` command, stop. User runs it. (Mirrors current `components` SKILL Step A2.) |
+| Package manager detection | Auto-detect via lockfile (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`/`bun.lockb`, `package-lock.json`) + `package.json#packageManager` field. |
+| Scope | Components init **+ starter theme** (inline the `/theme-create` script pipeline; no cross-command call). |
+| Modify `/kit-add` Step A? | No — keep as-is, `/setup` is purely additive. |
+| React 19 ui.tsx patch | Detect React 19+ via simple regex on `dependencies.react` and **warn**; do not auto-patch (preserves "verbatim copy" contract from `components` SKILL.md A4). |
+| Idempotency | Per-step skip; final summary tabulates `kept` vs `created`. No `--force` flag. |
+| Sass variants | Accept `sass` \| `sass-embedded`; warn on `node-sass` but don't block. |
+| Theme failure handling | Keep components init; print `validate_theme.py` errors; point user to `/theme-create` to retry. Bootstrap remains usable. |
+| Output verbosity | One-line checkpoint per step + structured final summary. |
+| Git tree check | None — keep friction low. |
+| Generated artifacts | **Committed** (developer owns the code). Not added to `.gitignore`. |
+| `marketplace.json` description | **Will be updated** — adding a top-level command is materially user-facing. |
+
+## Files to create
+
+### 1. `plugins/acss-kit/commands/setup.md`
+
+Slash command, delegates to the new skill. Front-matter follows existing convention (`description`, `argument-hint`, `allowed-tools`):
+
+```yaml
+---
+description: Bootstrap a React project for acss-kit — installs sass, copies ui.tsx, writes .acss-target.json, optionally seeds a starter theme
+argument-hint: [--no-theme] [--target=<dir>]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+```
+
+Body: H1 `# /setup`, `## Usage`, `## Workflow` pointing to `${CLAUDE_PLUGIN_ROOT}/skills/setup/SKILL.md`, plus a `### Quick Reference` checklist (mirrors `kit-add.md` shape).
+
+### 2. `plugins/acss-kit/skills/setup/SKILL.md`
+
+The orchestration skill. Front-matter:
+
+```yaml
+---
+name: setup
+description: Use when the user runs /setup or asks to "set up", "bootstrap", "initialize", or "prepare" a project for acss-kit components and themes. One-time first-run init — detects package manager, prints the sass install command, writes .acss-target.json, copies ui.tsx, optionally seeds a starter theme. Cross-domain skill (touches both components and styles concerns) — deliberately not nested under either domain skill.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+metadata:
+  version: "0.4.0"
+---
+```
+
+**Skill placement rationale (in skill body):** /setup spans both the `components` and `styles` domains, so it lives as its own skill rather than as a section of either. This is the only skill in the plugin that crosses domains; document this explicitly so future maintainers don't try to merge it.
+
+Sections (follows existing skill heading pattern):
+
+- `## Purpose`
+- `## Prerequisites` — React + TypeScript project
+- `## Idempotency contract` — every step checks for its artifact and skips if present. Track `kept[]` and `created[]` for the final summary.
+- `## Step 1 — Verify React project` — call `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_target.py`. If `projectRoot: null`, refuse with the script's `reasons[0]`. Print one-line checkpoint: `Detected React project at <path>`.
+- `## Step 2 — Detect React version` — read `package.json` `dependencies.react` with a simple regex (`/^[~^>=]*(\d+)/`). If first major ≥ 19, print warning that `ui.tsx` may need the `ElementInstance<C>` adaptation seen in the first-run transcript. Continue regardless. Checkpoint: `React 19+ detected — see warning above` or `React 18 detected`.
+- `## Step 3 — Detect package manager` — call new `detect_package_manager.py` (see file 3). Checkpoint: `Detected pnpm (pnpm-lock.yaml)`.
+- `## Step 4 — Print sass install command (does not execute)` — read `package.json` `devDependencies`. If `sass` or `sass-embedded` is present, skip and add to `kept[]`. If `node-sass` only, print warning that Vite prefers `sass`/`sass-embedded` and proceed without erroring. Otherwise, print:
+
+  ```text
+  sass not found in devDependencies.
+  Run: <detected-pm> add -D sass
+  Then re-run: /setup
+  ```
+
+  Stop the skill (do not proceed to Step 5). Same UX as today's `components` SKILL Step A2 — no install side effect from the skill.
+- `## Step 5 — Determine target directory` — same logic as `components` SKILL Step A3. Honors `--target=<dir>` flag. If `.acss-target.json` exists, reuse and add to `kept[]`; else prompt with default `src/components/fpkit/` and write file → add to `created[]`. Checkpoint: `Wrote .acss-target.json` or `Reusing existing .acss-target.json (componentsDir=<dir>)`.
+- `## Step 6 — Copy ui.tsx foundation` — if `<target>/ui.tsx` exists, skip → `kept[]`. Else `cp ${CLAUDE_PLUGIN_ROOT}/assets/foundation/ui.tsx <target>/ui.tsx` (verbatim, per A4 contract) → `created[]`. Checkpoint: `Copied ui.tsx` or `ui.tsx already present, skipped`.
+- `## Step 7 — Seed starter theme` — unless `--no-theme` passed:
+  1. If `src/styles/theme/light.css` already exists, skip → `kept[]`.
+  2. Otherwise prompt for seed hex (default `#4f46e5`).
+  3. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_palette.py <hex> --mode=both` → capture JSON.
+  4. Pipe into `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/tokens_to_css.py` to write `src/styles/theme/{light,dark}.css`.
+  5. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_theme.py src/styles/theme/`.
+  6. **On failure**: print the contrast errors. Add `light.css` / `dark.css` to `created[]` with a warning flag. Print: `Theme validation failed — fix the seed color and re-run /theme-create`. Do **not** roll back ui.tsx or `.acss-target.json`. Continue to Step 8.
+  7. On success: checkpoint `Wrote light.css and dark.css (top contrast: <ratio>)`.
+- `## Step 8 — Print summary + next steps` — structured table:
+
+  ```text
+  Setup complete.
+
+  Created:
+    - src/components/fpkit/ui.tsx
+    - .acss-target.json
+    - src/styles/theme/light.css
+    - src/styles/theme/dark.css
+
+  Kept (already present):
+    - sass in devDependencies
+
+  Next steps:
+    - Commit these files (developer owns the code)
+    - /kit-add button card    # generate your first components
+  ```
+
+  If sass install was needed (Step 4 stopped early), summary instead says: `Setup paused at Step 4. Run: <pm> add -D sass, then re-run /setup.`
+
+### 3. `plugins/acss-kit/scripts/detect_package_manager.py`
+
+New Python 3 stdlib script. Follows the **detector contract** (`.claude/rules/python-scripts.md`): JSON to stdout, exit 0/1, `reasons` array.
+
+- Walks parent dirs from `argv[1]` (or cwd) to find a project root containing `package.json`
+- Inspects lockfiles in priority order: `pnpm-lock.yaml` → `yarn.lock` → `bun.lock` (Bun 1.2+ text format) → `bun.lockb` (legacy binary) → `package-lock.json`
+- Falls back to `package.json#packageManager` field (parse `name@version` spec) if no lockfile
+- Final fallback: `npm`
+
+Output shape (success):
+
+```json
+{
+  "manager": "pnpm",
+  "lockfile": "pnpm-lock.yaml",
+  "installCommand": "pnpm add -D",
+  "projectRoot": "/abs/path",
+  "reasons": []
+}
+```
+
+Install command map:
+
+| Manager | Install command |
+|---|---|
+| `npm` | `npm install -D` |
+| `pnpm` | `pnpm add -D` |
+| `yarn` | `yarn add -D` |
+| `bun` | `bun add -d` |
+
+On failure (no project root): `manager: null`, populated `reasons`, exit 1.
+
+**Self-test (`if __name__ == "__main__"`)** — when invoked with `--self-test`, run against three in-memory fixtures (pnpm-lock present, package-lock present, no lockfile + packageManager field) and print pass/fail. This gives `tests/run.sh` a smoke check without external fixtures.
+
+## Files to modify
+
+| Path | Change |
+|---|---|
+| `plugins/acss-kit/.claude-plugin/plugin.json` | Bump `version` `0.3.1` → `0.4.0` via the explicit release step below — do **not** hand-edit. |
+| `plugins/acss-kit/CHANGELOG.md` | Add `0.4.0` entry: "Added `/setup` command for first-run project bootstrap (PM detection, sass install instructions, ui.tsx copy, starter theme). New `detect_package_manager.py` detector script." |
+| `plugins/acss-kit/README.md` | Document `/setup` in the commands section as the **recommended first command after install**. Note that generated artifacts (`src/components/fpkit/`, `src/styles/theme/`) are meant to be committed — developer owns the code. |
+| `.claude/rules/python-scripts.md` | Add `detect_package_manager.py` to the script inventory under "Detectors". |
+| `.claude-plugin/marketplace.json` | **Update** the `acss-kit` plugin entry `description` to mention the new `/setup` bootstrap. **Do not add a `version` field** (per CLAUDE.md). |
+| `tests/run.sh` | Add a smoke step: `python3 plugins/acss-kit/scripts/detect_package_manager.py --self-test` (exit 0 expected). |
+
+## Release step
+
+After all files above are written, run `/release-plugin acss-kit` (interactive). It bumps `plugin.json#version` to `0.4.0`, scaffolds the CHANGELOG entry consistent with prior releases, and runs `tests/run.sh` as a final gate. Do **not** hand-edit `plugin.json` — the release skill keeps version semantics consistent.
+
+## Existing functions / utilities to reuse (no duplication)
+
+- `plugins/acss-kit/scripts/detect_target.py` — already detects React project root and reads/writes `.acss-target.json`. Use unchanged for Steps 1, 5.
+- `plugins/acss-kit/assets/foundation/ui.tsx` — verbatim source for Step 6.
+- `plugins/acss-kit/skills/styles/SKILL.md` `/theme-create` section — Step 7 delegates here rather than reimplementing palette math. Pipeline: `generate_palette.py` → `tokens_to_css.py` → `validate_theme.py`.
+- `plugins/acss-kit/skills/components/SKILL.md` Step A — left as-is; serves as a fallback if a user runs `/kit-add` without `/setup` first.
+
+## Verification
+
+Run from the repo root:
+
+1. **Structural validator** — `tests/run.sh` must pass. Specifically Step 5 (`tests/validate_manifest.py`) confirms:
+   - `commands/setup.md` exists
+   - `skills/setup/SKILL.md` exists
+   - `plugin.json` version `0.4.0` matches semver
+2. **Front-matter hooks** — the PostToolUse hook in `.claude/settings.json` will validate command + SKILL.md front-matter on Write. Both new files must have required keys.
+3. **End-to-end smoke test** in `tests/sandbox/`:
+   ```bash
+   tests/setup.sh                         # fresh sandbox
+   cd tests/sandbox
+   rm -rf src/components/fpkit src/styles .acss-target.json
+   # invoke /setup with default target, default seed color
+   npx tsc -b --noEmit                    # must pass
+   npm run dev                            # Vite must boot without sass errors
+   ```
+   Confirm:
+   - `package.json` has `sass` in `devDependencies` (correct PM was used)
+   - `.acss-target.json` written at sandbox root
+   - `src/components/fpkit/ui.tsx` is a byte-identical copy of the asset
+   - `src/styles/theme/light.css` + `dark.css` exist and pass `validate_theme.py`
+   - React 19 warning was printed (sandbox uses React 19 per the transcript)
+4. **Idempotency** — re-run `/setup` in the prepared sandbox; it should detect each artifact and skip without overwriting.
+5. **Follow-up** — `/kit-add button card` after `/setup` should now skip Step A's install/copy paths cleanly (Step A becomes verify-only).
+
+## Next Steps (out of scope)
+
+- Slim `components` SKILL.md Step A to "verify init artifacts present, else suggest `/setup`" — defer until `/setup` is proven in real use.
+- Auto-patch `ui.tsx` for React 19 — better solved upstream by updating `assets/foundation/ui.tsx` itself so the verbatim copy stays correct on React 19+.
+- Add `--theme-seed=<hex>` non-interactive flag to `/setup` for CI / scripted bootstrap.
+- Detect Vite-specific config (e.g. confirm `vite.config.ts` is present and warn on Webpack/CRA projects).
+- Add a `--yes` flag for fully non-interactive bootstrap (accepts all defaults).
+
+---
+
+## Interview Summary
+
+Stress-tested via `/plan-interview` on 2026-04-26. All amendments below have been folded into the plan above.
+
+### Key Decisions Confirmed
+
+- Sass install is **print-only** (no skill-side execution) — revises the original "auto-install with confirmation" decision and aligns with current `components` SKILL Step A2.
+- Per-step idempotency with `kept` vs `created` summary; no `--force` flag.
+- Theme generation runs the `generate_palette.py` → `tokens_to_css.py` → `validate_theme.py` pipeline directly inside the setup skill (no cross-command call).
+- React 19 detection uses a simple major-version regex on `dependencies.react`.
+- `sass`/`sass-embedded` are accepted; `node-sass` triggers a warning but does not block.
+- Theme failure keeps the components init intact; user is pointed to `/theme-create` to retry.
+- One-line checkpoint per step + structured final summary.
+- No git tree check.
+
+### Open Risks & Concerns
+
+- The new skill diverges from the one-skill-per-domain convention. Mitigation: explicit "skill placement rationale" in the SKILL.md description.
+- Bun ships both `bun.lock` (text, 1.2+) and `bun.lockb` (binary). Detector must handle both.
+- New Python script needs minimal test coverage — added via `--self-test` mode invoked from `tests/run.sh`.
+- Implementer might hand-edit `plugin.json` and skip changelog scaffolding — mitigated by making `/release-plugin` an explicit step.
+
+### Recommended Plan Amendments (applied)
+
+1. Step 4 changed from "install sass" to "print install command and stop" — matches `components` Step A2.
+2. Step 7 specifies failure handling (no rollback; print contrast errors; bootstrap remains usable).
+3. Step 8 rewritten to tabulate `kept` vs `created` and surface "paused at Step 4" branch when sass is missing.
+4. Skill placement rationale added to `setup` SKILL.md description.
+5. `detect_package_manager.py` updated to detect `bun.lock` + `bun.lockb` + `package.json#packageManager`. Install-command map added.
+6. `tests/run.sh` smoke step (`--self-test`) added to the "Files to modify" table.
+7. `/release-plugin acss-kit` made an explicit step after file writes.
+8. `marketplace.json` description update committed (not hedged); generated artifacts marked as committed (not gitignored) in the README update.
+
+### Simplification Opportunities (acknowledged, not adopted)
+
+- Could be a `## /setup` section in `components/SKILL.md` instead of a new skill. **Not adopted** — /setup is cross-domain (also seeds a theme); a dedicated skill is clearer. Documented in the SKILL.md rationale.
+- Could inline PM detection as a Bash chain instead of a Python script. **Not adopted** — script is testable via `--self-test`, reusable by future commands, and follows the established detector contract.


### PR DESCRIPTION
## Summary

- Adds `/setup` slash command and `skills/setup/SKILL.md` — a cross-domain skill that front-loads one-time project initialization (sass check, `.acss-target.json`, `ui.tsx` copy, starter theme seed) so subsequent `/kit-add` and `/theme-create` calls are pure generation
- Adds `detect_package_manager.py` detector script: inspects lockfiles in priority order (`pnpm-lock.yaml` → `yarn.lock` → `bun.lock` → `bun.lockb` → `package-lock.json`), falls back to `package.json#packageManager` field, final fallback to npm; includes `--self-test` mode
- Bumps plugin version `0.3.1` → `0.4.0`

## Changes

| File | Change |
|---|---|
| `commands/setup.md` | New slash command |
| `skills/setup/SKILL.md` | New cross-domain setup skill (8-step workflow, idempotent) |
| `scripts/detect_package_manager.py` | New detector script with `--self-test` |
| `plugin.json` | Version `0.3.1` → `0.4.0` |
| `CHANGELOG.md` | Added `[0.4.0]` entry |
| `README.md` | Added `/setup` first-run section + Plugin Structure diagram updates |
| `.claude/rules/python-scripts.md` | Added `detect_package_manager.py` to inventory |
| `.claude-plugin/marketplace.json` | Updated acss-kit description to surface `/setup` |
| `tests/run.sh` | Added Step 7: `detect_package_manager --self-test` |

## Test plan

- [x] `tests/run.sh` — all 7 steps green (including new Step 7)
- [x] `detect_package_manager.py --self-test` — 3/3 fixtures pass (pnpm, npm, yarn via packageManager field)
- [ ] End-to-end: `tests/setup.sh` → `rm -rf src/components/fpkit src/styles .acss-target.json` → `/setup` → confirm artifacts written, `npx tsc -b --noEmit` passes
- [ ] Idempotency: re-run `/setup` in prepared sandbox — all steps should report `kept`, nothing overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)