### PR TITLE
docs: mark python-scripts rule as Active in rules index

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -5,7 +5,7 @@ Advisory text auto-loaded into Claude's context whenever it touches a file match
 | Rule | Triggers on | Status |
 |---|---|---|
 | [`scss-conventions.md`](scss-conventions.md) | `**/*.scss`, `**/*.css` | Active — variable naming pattern, `var()` fallbacks, `[aria-disabled="true"]` for disabled state. |
-| [`python-scripts.md`](python-scripts.md) | `plugins/acss-app-builder/scripts/**` | **Drift** — references `acss-app-builder`, a predecessor plugin consolidated into `acss-kit` at v0.3.0. The path glob never matches a real file, so this rule never loads. Fix: rewrite the inventory for `plugins/acss-kit/scripts/**`, or delete the file. |
+| [`python-scripts.md`](python-scripts.md) | `plugins/acss-kit/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current 6-script inventory. |
 
 ## Rules vs. hooks vs. skills
 


### PR DESCRIPTION
## Summary

- Setup audit found no drift in `/setup`, test harness, hooks, or rule files — they are already aligned with v0.4.0.
- One stale entry remained: `.claude/rules/README.md` table row for `python-scripts.md` still described it as drifted against the removed `acss-app-builder` plugin, even though the rule file itself was already corrected to scope at `plugins/acss-kit/scripts/**` with the current 6-script inventory.
- Updated the row to **Active** with a one-line description of the contract (detector vs. generator/validator).

## Test plan

- [ ] `rg "acss-app-builder" .claude/rules/` returns zero matches
- [ ] `.claude/rules/README.md` shows both rules marked Active in the table
- [ ] No tests need to run — `.claude/rules/*.md` is not validated by the PostToolUse hooks in `.claude/settings.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbkvHwQ8njtq6TvyxYEqtM)_