### PR TITLE
Add style-tune pilot skill for natural-language component & theme tuning

### DIFF
--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -10,6 +10,8 @@ Current scripts in `plugins/acss-kit/scripts/`:
 - `detect_target.py` — detects the target project type (Vite, etc.) for skill routing
 - `detect_package_manager.py` — detects the active package manager (pnpm/yarn/bun/npm) via lockfile inspection; outputs install command
 - `generate_palette.py` — OKLCH palette math; outputs palette JSON
+- `oklch_shift.py` — shifts a hex color in OKLCH space (`--hue`, `--chroma`, `--lightness`); used by the `style-tune` skill for color deltas
+- `_oklch.py` — internal shared module exposing `hex_to_oklch`, `oklch_to_hex`, `in_gamut`. Imported by `generate_palette.py` and `oklch_shift.py`. Underscore prefix marks it as internal — no CLI, no detector contract.
 - `css_to_tokens.py` — converts CSS custom properties to palette JSON
 - `tokens_to_css.py` — converts palette JSON to CSS custom property files
 - `validate_theme.py` — checks theme CSS files for WCAG 2.2 AA contrast on semantic role pairs
@@ -22,7 +24,7 @@ For scripts whose output is parsed by slash commands or skills.
 - Exit 0 on success, 1 on logical failure (e.g. nothing detected)
 - Always include a `"reasons"` array in the JSON — empty `[]` on success, populated on failure
 
-Detectors: `detect_target.py`, `detect_package_manager.py`.
+Detectors: `detect_target.py`, `detect_package_manager.py`, `oklch_shift.py`.
 
 ## Generator / validator contract (pipeline-friendly, human-readable)
 
@@ -33,3 +35,7 @@ For scripts that emit data or human-readable validation results.
 - Exit 0 on success, 1 on logical failure, 2 on usage / IO errors
 
 Generators / validators: `generate_palette.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`.
+
+## Internal module contract
+
+`_oklch.py` is a private module — not callable from a slash command or shell. No exit codes, no stdout, no JSON. Test by importing into a sibling script and calling the helpers directly.

--- a/plugins/acss-kit/.claude-plugin/plugin.json
+++ b/plugins/acss-kit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit",
   "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Markdown-as-source component templates plus OKLCH theme generation with WCAG 2.2 AA validation.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Pilot `style-tune` skill and `/style-tune` command** — natural-language adjustment of acss-kit components and theme roles. Routes "warmer button", "softer card", "tone down the primary", "more spacious cards", "more elevated dialog", "smaller buttons", "narrower dialog", "taller dialog" between theme-role edits (delegated to `/theme-update` with WCAG pre-validation) and component SCSS token edits. Six v1 token families (color, radius, spacing, elevation, size, height) across six components (button, card, alert, dialog, input, nav). Atomic batch pre-validation guarantees paired roles and light/dark mirrors never desync. `references/intent-vocabulary.md` documents the full modifier → token-family table.
+- **`scripts/oklch_shift.py`** — new CLI helper that takes a hex color plus per-channel OKLCH offsets (`--hue`, `--chroma`, `--lightness`) and emits the shifted hex. Detector contract; stdlib only. Powers `style-tune`'s color deltas.
+- **`scripts/_oklch.py`** — internal shared module exposing `hex_to_oklch`, `oklch_to_hex`, `in_gamut`. Extracted from `generate_palette.py` so both palette generation and `oklch_shift.py` use the same conversion math.
+- **`tests/setup.sh --with-style-tune`** — opt-in fixture build that vendors the six v1 components and seeds a `light.css` / `dark.css` baseline so end-to-end style-tune prompts have a populated project to edit.
+
 ### Changed
 
+- **`scripts/generate_palette.py` refactored** — its inline OKLCH conversion helpers moved into the new shared `scripts/_oklch.py` module. Public CLI behavior is byte-identical against five canonical seeds (`#2563eb`, `#7c3aed`, `#16a34a`, `#dc2626`, `#0f766e`).
 - **Test harness simplified** — replaced the Vite + React + TypeScript demo sandbox (`tests/setup.sh`) with a minimal `package.json` + `tsconfig.json` fixture. No app framework, no `npm create`, no `npm run dev`. Replaced the Storybook + Playwright + axe-playwright deep check (`tests/storybook.sh`, `plugins/acss-kit/.harness/`, `scripts/generate_stories.mjs`) with a browserless `tests/e2e.sh` that runs `tsc --noEmit`, compiles SCSS, validates theme contrast, and runs jsdom + axe-core on rendered components. Faster install footprint, narrower a11y coverage (no real-pixel contrast or focus-indicator detection — see `tests/README.md` for the trade-off table). Plugin runtime behavior unchanged.
 - **Marketplace repo renamed** from `shawn-sandy/acss-plugins` to `shawn-sandy/agentic-acss-plugins`. Install commands now use `@shawn-sandy-agentic-acss-plugins` (the marketplace alias is derived from `<owner>-<repo>`). The marketplace `name` field in `.claude-plugin/marketplace.json` also moved from `acss-plugins` to `agentic-acss-plugins` to match. No plugin behavior changed; this is metadata-only.
 

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -4,11 +4,12 @@ A Claude Code plugin for building accessible React applications with the [fpkit/
 
 ## What you get
 
-Two top-level skills (plus one pilot per-component skill):
+Two top-level skills (plus two pilot skills):
 
 - **`components`** — accessible React components from markdown specs. `/kit-add <component>` walks the dependency tree and writes self-contained TSX + SCSS into your project.
 - **`styles`** — CSS theme generation. `/theme-create`, `/theme-brand`, `/theme-update`, `/theme-extract` for OKLCH palettes with WCAG 2.2 AA validation.
 - **`component-form`** — pilot per-component skill that auto-triggers on phrases like "create a signup form", "add a contact form".
+- **`style-tune`** — pilot per-feel skill that auto-triggers on phrases like "warmer button", "softer card", "tone down the primary", "more spacious cards", "more elevated dialog". `/style-tune` is the explicit fallback. Routes between theme-role and component-SCSS edits with atomic WCAG pre-validation.
 
 ## Why
 
@@ -156,6 +157,18 @@ Extract brand colors from an image or Figma design and generate full theme CSS.
 /theme-extract ~/Downloads/brand-moodboard.png
 /theme-extract https://figma.com/design/abc123/Brand-Guide
 ```
+
+### `/style-tune <natural-language description>`
+
+Adjust visual feel using natural language. Auto-triggers on phrases like "warmer button" / "softer card" / "more elevated dialog" — the slash form is the explicit fallback. Six v1 token families: color, radius, spacing, elevation, size, height.
+
+```shell
+/style-tune make the button feel softer and warmer
+/style-tune tone down the primary color a touch
+/style-tune more spacious cards
+```
+
+Theme-layer edits delegate to `/theme-update` after a pre-validation pass; component-layer edits write the targeted `--{component}-*` tokens in place. Paired roles and light/dark mirrors are atomic — either every role applies or none do.
 
 ## Available components
 
@@ -305,6 +318,8 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
     detect_target.py                       # Manages .acss-target.json
     detect_package_manager.py             # Detects pnpm/yarn/bun/npm from lockfile
     generate_palette.py                    # OKLCH palette math
+    oklch_shift.py                         # Hex + per-channel OKLCH offsets → hex
+    _oklch.py                              # Internal hex↔OKLCH helpers (shared by generate_palette + oklch_shift)
     tokens_to_css.py                       # Palette JSON → CSS theme
     css_to_tokens.py                       # CSS theme → palette JSON (round-trip)
     validate_theme.py                      # WCAG 2.2 AA contrast pair validator
@@ -325,6 +340,10 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
         theme-schema.md                    # Internal JSON schema reference
     component-form/
       SKILL.md                             # Form pilot — auto-triggers on natural language
+    style-tune/
+      SKILL.md                             # Style-feel pilot — auto-triggers on adjective + component
+      references/
+        intent-vocabulary.md               # Modifier → token-family table
     setup/
       SKILL.md                             # Cross-domain setup skill (/setup command)
   docs/                                    # Developer guides (architecture, recipes, troubleshooting)

--- a/plugins/acss-kit/commands/style-tune.md
+++ b/plugins/acss-kit/commands/style-tune.md
@@ -1,0 +1,53 @@
+---
+description: Adjust visual feel of theme roles or component tokens using natural language
+argument-hint: <natural-language description>
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+Tune acss-kit components or theme roles by describing how they should
+feel — softer, warmer, calmer, more spacious, more elevated, smaller,
+narrower. The skill routes between theme-role edits (delegated to
+`/theme-update` with WCAG pre-validation) and component SCSS token
+edits.
+
+Follow the workflow in `${CLAUDE_PLUGIN_ROOT}/skills/style-tune/SKILL.md`.
+
+**Arguments:**
+
+- `<natural-language description>` — one or more sentences naming a
+  component (button, card, alert, dialog, input, nav) or theme role
+  (primary, accent, danger, warning, info, success, brand) plus a
+  modifier from the intent vocabulary (softer, warmer, spacious,
+  elevated, smaller, etc.).
+
+**Quick steps:**
+
+1. Resolve the subject and modifiers; route to the theme or component
+   layer (Step A).
+2. Locate the in-scope theme files or component SCSS file (Step B).
+3. Compute deltas — for color modifiers call
+   `scripts/oklch_shift.py`; for radius/spacing/size apply the
+   canonical multiplier from `references/intent-vocabulary.md`
+   (Step C).
+4. **Theme batch:** stage edits, pre-validate via
+   `scripts/validate_theme.py`, halt the entire batch on any
+   contrast failure. **Component batch:** edit the SCSS atomically
+   in memory, preserving all `var()` wrappers (Step D).
+5. Validate structurally and surface drift hints when applicable
+   (Step E).
+6. Print a Modifier / Token / Old / New / Status table plus next-step
+   hints (Step F).
+
+**Example prompts:**
+
+- "Make the button feel softer and warmer."
+- "Tone down the primary color a touch."
+- "Give the alert a calmer look."
+- "More spacious cards."
+- "Style the dialog to feel more elevated."
+- "Narrower dialog."
+- "Smaller buttons."
+
+**Auto-trigger:** these phrases also route to `style-tune` directly
+without needing the slash command — see the SKILL.md front-matter
+description for the full trigger surface.

--- a/plugins/acss-kit/docs/commands.md
+++ b/plugins/acss-kit/docs/commands.md
@@ -115,3 +115,73 @@ Nothing is written to disk.
 /kit-list dialog               # Show Dialog's full dependency tree (button)
 /kit-list form                 # Show which sub-controls form.tsx contains
 ```
+
+---
+
+## /style-tune
+
+Adjust the visual feel of acss-kit components or theme roles using natural language. Routes between theme-role edits (delegated to `/theme-update` with WCAG pre-validation) and component SCSS token edits.
+
+**Signature**
+
+```
+/style-tune <natural-language description>
+```
+
+**Tools used:** `Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion`
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<natural-language description>` | Yes | One or more sentences naming a component (button, card, alert, dialog, input, nav) or theme role (primary, accent, danger, warning, info, success, brand) plus a modifier from the intent vocabulary (softer, warmer, calmer, spacious, elevated, smaller, narrower, etc.). |
+
+The skill also auto-triggers on the same phrases without the slash command — see the SKILL.md front-matter for the full trigger surface.
+
+### What happens step by step
+
+These steps correspond to Steps A–F in [`SKILL.md`](../skills/style-tune/SKILL.md).
+
+**Step A — Resolve intent**
+
+1. Read `references/intent-vocabulary.md` to load the modifier table.
+2. Tokenize the prompt; match modifiers to token families.
+3. Map subject nouns to a layer: theme-role names route to the theme layer, component names route to the component layer.
+4. AskUserQuestion when the prompt is ambiguous, contradictory, or missing a subject.
+
+**Step B — Locate files**
+
+1. Run `scripts/detect_target.py` to capture `componentsDir`.
+2. Theme layer: locate `light.css` + `dark.css`; auto-mirror when both exist.
+3. Component layer: probe `<componentsDir>/<component>/<component>.scss`; halt with a `/kit-add` hint if missing.
+
+**Step C — Compute deltas**
+
+1. Theme layer: read current hex via `scripts/css_to_tokens.py`; compute new hex via `scripts/oklch_shift.py`. Apply paired-role and dark-mirror rules.
+2. Component layer: apply scalar deltas (radius × 1.5, padding × 0.66, etc.). Var-only references auto-route to the underlying theme role.
+
+**Step D — Apply edits**
+
+1. Theme batch: stage proposed values into a tmp directory and run `scripts/validate_theme.py` against each staged file. Halt the entire batch on any contrast failure (atomic — paired roles never desync).
+2. Component batch: build the updated SCSS in memory; Edit atomically. Preserve all `var()` wrappers.
+
+**Step E — Validate**
+
+1. Theme: D's pre-validation guarantees no in-flight reverts.
+2. Component: structural integrity check (`var(` count unchanged; each token still appears exactly once on a declaration LHS).
+3. Drift hint when a tuned color's chroma drops below 0.05 or its hue diverges >30° from its palette-derived reference.
+
+**Step F — Summary**
+
+Print a `Modifier / Token / Old / New / Status` table plus next-step hints.
+
+### Examples
+
+```
+/style-tune make the button feel softer and warmer
+/style-tune tone down the primary color a touch
+/style-tune more spacious cards
+/style-tune style the dialog to feel more elevated
+/style-tune narrower dialog
+/style-tune smaller buttons
+```

--- a/plugins/acss-kit/scripts/_oklch.py
+++ b/plugins/acss-kit/scripts/_oklch.py
@@ -1,0 +1,96 @@
+"""
+Shared OKLCH ↔ sRGB conversion helpers (CSS Color 4 matrices).
+
+Used by ``generate_palette.py`` and ``oklch_shift.py``. Stdlib only —
+no external dependencies. Underscore prefix marks this as internal:
+no CLI entry point, no detector contract.
+
+Public surface:
+- ``hex_to_oklch(hex_str) -> (L, C, H)``
+- ``oklch_to_hex(L, C, H) -> "#rrggbb"`` (clamps chroma to stay in sRGB gamut)
+- ``in_gamut(L, C, H) -> bool``
+"""
+from __future__ import annotations
+
+import math
+
+
+def _linear(c: float) -> float:
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _gamma(c: float) -> float:
+    return c * 12.92 if c <= 0.0031308 else 1.055 * (c ** (1.0 / 2.4)) - 0.055
+
+
+def hex_to_oklch(hex_str: str) -> tuple[float, float, float]:
+    """Return (L, C, H) in OKLCH from a hex color string."""
+    h = hex_str.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    r, g, b = int(h[0:2], 16) / 255.0, int(h[2:4], 16) / 255.0, int(h[4:6], 16) / 255.0
+    # Gamma decode
+    r, g, b = _linear(r), _linear(g), _linear(b)
+    # Linear sRGB → LMS (M1)
+    l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b
+    m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b
+    s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b
+    # Cube root
+    l_, m_, s_ = l ** (1.0 / 3.0), m ** (1.0 / 3.0), s ** (1.0 / 3.0)
+    # LMS^(1/3) → Oklab (M2)
+    L =  0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_
+    a =  1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_
+    b_ = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+    C = math.sqrt(a * a + b_ * b_)
+    H = math.degrees(math.atan2(b_, a)) % 360
+    return (L, C, H)
+
+
+def oklch_to_hex(L: float, C: float, H: float) -> str:
+    """Convert OKLCH to hex, clamping chroma to stay in sRGB gamut."""
+    for _ in range(100):
+        a = C * math.cos(math.radians(H))
+        b = C * math.sin(math.radians(H))
+        # Oklab → LMS^(1/3) (M2 inverse)
+        l_ = L + 0.3963377774 * a + 0.2158037573 * b
+        m_ = L - 0.1055613458 * a - 0.0638541728 * b
+        s_ = L - 0.0894841775 * a - 1.2914855480 * b
+        # Cube
+        lv, mv, sv = l_ ** 3, m_ ** 3, s_ ** 3
+        # LMS → linear sRGB (M1 inverse)
+        r =  4.0767416621 * lv - 3.3077115913 * mv + 0.2309699292 * sv
+        g = -1.2684380046 * lv + 2.6097574011 * mv - 0.3413193965 * sv
+        b_ = -0.0041960863 * lv - 0.7034186147 * mv + 1.7076147010 * sv
+        # Check gamut
+        if all(-0.0001 <= x <= 1.0001 for x in (r, g, b_)):
+            r = max(0.0, min(1.0, r))
+            g = max(0.0, min(1.0, g))
+            b_ = max(0.0, min(1.0, b_))
+            ri = round(_gamma(r) * 255)
+            gi = round(_gamma(g) * 255)
+            bi = round(_gamma(b_) * 255)
+            return f"#{ri:02x}{gi:02x}{bi:02x}"
+        C = max(0.0, C - 0.01)
+    # Fallback: achromatic at target lightness
+    return oklch_to_hex(L, 0.0, H)
+
+
+def in_gamut(L: float, C: float, H: float) -> bool:
+    """True iff (L, C, H) maps cleanly into sRGB without chroma clamping.
+
+    Uses the same matrix path as ``oklch_to_hex`` but skips the iterative
+    chroma reduction. Also enforces a sensible lightness range
+    [0.0, 1.0] — values outside that always fail.
+    """
+    if not (0.0 <= L <= 1.0):
+        return False
+    a = C * math.cos(math.radians(H))
+    b = C * math.sin(math.radians(H))
+    l_ = L + 0.3963377774 * a + 0.2158037573 * b
+    m_ = L - 0.1055613458 * a - 0.0638541728 * b
+    s_ = L - 0.0894841775 * a - 1.2914855480 * b
+    lv, mv, sv = l_ ** 3, m_ ** 3, s_ ** 3
+    r =  4.0767416621 * lv - 3.3077115913 * mv + 0.2309699292 * sv
+    g = -1.2684380046 * lv + 2.6097574011 * mv - 0.3413193965 * sv
+    bl = -0.0041960863 * lv - 0.7034186147 * mv + 1.7076147010 * sv
+    return all(-0.0001 <= x <= 1.0001 for x in (r, g, bl))

--- a/plugins/acss-kit/scripts/generate_palette.py
+++ b/plugins/acss-kit/scripts/generate_palette.py
@@ -11,75 +11,16 @@ Exit codes: 0 = success, 1 = palette failure (non-empty "reasons"), 2 = usage/IO
 from __future__ import annotations
 
 import json
-import math
 import re
 import sys
 from typing import Optional
 
+from _oklch import _linear, hex_to_oklch, oklch_to_hex
+
 
 # ---------------------------------------------------------------------------
-# OKLCH ↔ sRGB conversion (CSS Color 4 matrices — no external dependencies)
+# WCAG luminance helpers
 # ---------------------------------------------------------------------------
-
-def _linear(c: float) -> float:
-    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
-
-
-def _gamma(c: float) -> float:
-    return c * 12.92 if c <= 0.0031308 else 1.055 * (c ** (1.0 / 2.4)) - 0.055
-
-
-def hex_to_oklch(hex_str: str) -> tuple[float, float, float]:
-    """Return (L, C, H) in OKLCH from a hex color string."""
-    h = hex_str.lstrip("#")
-    if len(h) == 3:
-        h = "".join(c * 2 for c in h)
-    r, g, b = int(h[0:2], 16) / 255.0, int(h[2:4], 16) / 255.0, int(h[4:6], 16) / 255.0
-    # Gamma decode
-    r, g, b = _linear(r), _linear(g), _linear(b)
-    # Linear sRGB → LMS (M1)
-    l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b
-    m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b
-    s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b
-    # Cube root
-    l_, m_, s_ = l ** (1.0 / 3.0), m ** (1.0 / 3.0), s ** (1.0 / 3.0)
-    # LMS^(1/3) → Oklab (M2)
-    L =  0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_
-    a =  1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_
-    b_ = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
-    C = math.sqrt(a * a + b_ * b_)
-    H = math.degrees(math.atan2(b_, a)) % 360
-    return (L, C, H)
-
-
-def oklch_to_hex(L: float, C: float, H: float) -> str:
-    """Convert OKLCH to hex, clamping chroma to stay in sRGB gamut."""
-    for _ in range(100):
-        a = C * math.cos(math.radians(H))
-        b = C * math.sin(math.radians(H))
-        # Oklab → LMS^(1/3) (M2 inverse)
-        l_ = L + 0.3963377774 * a + 0.2158037573 * b
-        m_ = L - 0.1055613458 * a - 0.0638541728 * b
-        s_ = L - 0.0894841775 * a - 1.2914855480 * b
-        # Cube
-        lv, mv, sv = l_ ** 3, m_ ** 3, s_ ** 3
-        # LMS → linear sRGB (M1 inverse)
-        r =  4.0767416621 * lv - 3.3077115913 * mv + 0.2309699292 * sv
-        g = -1.2684380046 * lv + 2.6097574011 * mv - 0.3413193965 * sv
-        b_ = -0.0041960863 * lv - 0.7034186147 * mv + 1.7076147010 * sv
-        # Check gamut
-        if all(-0.0001 <= x <= 1.0001 for x in (r, g, b_)):
-            r = max(0.0, min(1.0, r))
-            g = max(0.0, min(1.0, g))
-            b_ = max(0.0, min(1.0, b_))
-            ri = round(_gamma(r) * 255)
-            gi = round(_gamma(g) * 255)
-            bi = round(_gamma(b_) * 255)
-            return f"#{ri:02x}{gi:02x}{bi:02x}"
-        C = max(0.0, C - 0.01)
-    # Fallback: achromatic at target lightness
-    return oklch_to_hex(L, 0.0, H)
-
 
 def _hex_luminance(hex_str: str) -> float:
     h = hex_str.lstrip("#")

--- a/plugins/acss-kit/scripts/oklch_shift.py
+++ b/plugins/acss-kit/scripts/oklch_shift.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Shift a hex color in OKLCH space and emit the new hex.
+
+Usage:
+    oklch_shift.py <hex> [--hue=±deg] [--chroma=×float] [--lightness=±float]
+
+Examples:
+    oklch_shift.py "#2563eb" --hue=8           # rotate hue +8°
+    oklch_shift.py "#2563eb" --chroma=0.75     # multiply chroma by 0.75
+    oklch_shift.py "#2563eb" --lightness=-0.06 # subtract 0.06 from L
+
+Output: JSON to stdout — { "hex", "oklch": [L, C, H], "shifted": [L, C, H], "reasons": [] }
+Exit codes: 0 = success, 1 = logical failure (post-shift out of gamut, etc.), 2 = usage / IO error.
+
+Stdlib only — no external dependencies.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+from _oklch import hex_to_oklch, in_gamut, oklch_to_hex
+
+
+HEX_RE = re.compile(r"^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+def _parse_arg(arg: str, prefix: str) -> float | None:
+    if not arg.startswith(prefix):
+        return None
+    raw = arg[len(prefix):].strip()
+    if not raw:
+        raise ValueError(f"missing value for {prefix.rstrip('=')}")
+    return float(raw)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print("usage: oklch_shift.py <hex> [--hue=±deg] [--chroma=×float] [--lightness=±float]", file=sys.stderr)
+        return 2
+
+    seed_raw = args[0]
+    if not HEX_RE.match(seed_raw):
+        print(f"invalid hex color: {seed_raw}", file=sys.stderr)
+        return 2
+
+    seed = seed_raw if seed_raw.startswith("#") else "#" + seed_raw
+    if len(seed) == 4:
+        seed = "#" + "".join(c * 2 for c in seed[1:])
+
+    hue_delta: float = 0.0
+    chroma_factor: float = 1.0
+    lightness_delta: float = 0.0
+
+    for a in args[1:]:
+        try:
+            v = _parse_arg(a, "--hue=")
+            if v is not None:
+                hue_delta = v
+                continue
+            v = _parse_arg(a, "--chroma=")
+            if v is not None:
+                chroma_factor = v
+                continue
+            v = _parse_arg(a, "--lightness=")
+            if v is not None:
+                lightness_delta = v
+                continue
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        print(f"unknown argument: {a}", file=sys.stderr)
+        return 2
+
+    reasons: list[str] = []
+
+    L0, C0, H0 = hex_to_oklch(seed)
+
+    L1 = L0 + lightness_delta
+    C1 = C0 * chroma_factor
+    H1 = (H0 + hue_delta) % 360
+
+    # Lightness clamp [0.0, 1.0] is a hard gamut floor/ceiling; surface it.
+    if L1 < 0.0:
+        reasons.append(f"lightness out of gamut: {L1:.4f} < 0.0 (clamped to 0.0)")
+        L1 = 0.0
+    if L1 > 1.0:
+        reasons.append(f"lightness out of gamut: {L1:.4f} > 1.0 (clamped to 1.0)")
+        L1 = 1.0
+    # Chroma must stay non-negative.
+    if C1 < 0.0:
+        reasons.append(f"chroma negative after shift: {C1:.4f} (clamped to 0.0)")
+        C1 = 0.0
+
+    if not in_gamut(L1, C1, H1):
+        reasons.append(
+            f"shifted color out of sRGB gamut at (L={L1:.4f}, C={C1:.4f}, H={H1:.2f}); "
+            f"oklch_to_hex will reduce chroma to fit"
+        )
+
+    new_hex = oklch_to_hex(L1, C1, H1)
+    Lp, Cp, Hp = hex_to_oklch(new_hex)
+
+    result = {
+        "input": seed,
+        "hex": new_hex,
+        "oklch": [round(Lp, 6), round(Cp, 6), round(Hp, 4)],
+        "shifted": [round(L1, 6), round(C1, 6), round(H1, 4)],
+        "delta": {
+            "hue": hue_delta,
+            "chroma": chroma_factor,
+            "lightness": lightness_delta,
+        },
+        "reasons": reasons,
+    }
+    print(json.dumps(result, indent=2))
+    return 1 if reasons else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-kit/skills/style-tune/SKILL.md
+++ b/plugins/acss-kit/skills/style-tune/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: style-tune
+description: Use when the user asks to adjust visual feel of a named acss-kit component or theme role using natural language. Triggers must reference a component (button, card, alert, dialog, input, nav) or a theme role (primary, accent, danger, warning, info, success, brand) — bare adjectives in prose contexts do NOT trigger. Phrases include "warmer button", "softer card", "calmer alert", "more spacious cards", "more elevated dialog", "tone down the primary", "deeper accent for primary", "make buttons feel sharper", "give the input a quieter look", "bolder primary", "smaller buttons", "bigger dialog", "narrower dialog", "wider input", "shorter dialog", "taller dialog". Routes between theme-role edits (delegated to /theme-update with WCAG pre-validation) and component SCSS token edits (--btn-*, --card-*, --alert-*, --dialog-*, --input-*, --nav-*). Pilot per-feel skill — promoted because feel-based iteration is high-touch and benefits from auto-discoverable triggering.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+metadata:
+  version: "0.4.1"
+  pilot: true
+---
+
+# SKILL: style-tune
+
+Adjust the visual feel of acss-kit components or theme roles using
+natural language. Routes a free-form prompt ("make the dialog feel
+more elevated") to either a theme-role edit (delegated to
+`/theme-update`) or a component SCSS token edit, applies the delta
+from the intent vocabulary, and atomically validates before writing.
+
+> **Verified against fpkit source:** `@fpkit/acss@6.5.0` (closest
+> tagged ref to npm `6.6.0`). The skill operates on the same token
+> surface as the components and styles skills — it does not introduce
+> new tokens, only adjusts existing ones.
+
+## Pilot status
+
+This is the second per-feel skill in `acss-kit` (after
+`component-form`). It exists to validate natural-language adjective
+triggering on a token surface. Vocabulary, trigger phrases, and
+component coverage may shift in 0.4.x point releases as real-world
+usage surfaces gaps.
+
+---
+
+## Two layers, one skill
+
+The kit exposes two parallel token surfaces:
+
+- **Theme-level roles** — 18 semantic `--color-*` properties in
+  `src/styles/theme/{light,dark}.css` (and `brand-*.css`), governed by
+  `/theme-update` and validated against WCAG 2.2 AA contrast pairs.
+- **Component-level tokens** — `--btn-*`, `--card-*`, `--alert-*`,
+  `--dialog-*`, `--input-*`, `--nav-*` declarations inside each
+  vendored component SCSS file at
+  `<componentsDir>/<component>/<component>.scss`.
+
+Step A resolves the named subject from the prompt and routes the edit
+to the appropriate layer.
+
+---
+
+## Step A — Resolve intent
+
+### A0. Load the intent vocabulary
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/style-tune/references/intent-vocabulary.md`.
+Each row maps a modifier (and synonyms) to a token family + canonical
+delta + "var-only fallback" route.
+
+### A1. Tokenize the prompt and match modifiers
+
+Parse the prompt for vocabulary matches. Each match yields a
+`(token-family, delta, layer-hint)` tuple. Record the matches; do not
+write yet.
+
+### A2. Resolve the subject
+
+Map subject nouns to a target layer:
+
+| Subject in prompt | Layer | Target |
+|---|---|---|
+| `primary`, `accent`, `danger`, `warning`, `info`, `success`, `brand`, `theme`, `app` | theme | named role (or `--color-primary` for "the theme") |
+| `button` / `btn`, `card`, `alert`, `dialog`, `input`, `nav`, `form` | component | named component, edit globally |
+| Bare `this` / `it` / `the component` / `everything` | ambiguous | AskUserQuestion to choose |
+
+"This button" / "the button" / "buttons" all map to a **global** edit
+of the component's SCSS file. The skill never emits inline `style={...}`
+props or scoped variant classes.
+
+### A3. Confirm low-confidence intents
+
+Use `AskUserQuestion` (one consolidated question, ≤ 4 options) when:
+
+- The prompt is a single bare adjective with no subject ("warmer").
+- A modifier has multiple plausible token families (e.g. "louder" →
+  border vs shadow vs both).
+- Modifiers contradict each other in one prompt ("calmer but bolder").
+- The subject is "alert" and the modifier is a color modifier — ask
+  whether to tune base tokens only (default) or to include the four
+  severity variants (`--alert-{info,success,warning,error}-*`).
+
+For unambiguous prompts, skip A3 and proceed.
+
+---
+
+## Step B — Verify dependencies and locate files
+
+### B1. Detect the target project
+
+Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/detect_target.py <project_root>`.
+Capture `source` and `componentsDir` from the JSON output.
+
+### B2. Branch on layer
+
+**Theme layer:**
+
+1. Locate `src/styles/theme/light.css` and `src/styles/theme/dark.css`.
+   When **both** exist, edit both with the same OKLCH delta
+   (auto-mirror — same perceptual shift, mode-appropriate hex per
+   file). When only one exists, edit that one.
+2. `brand-*.css` files are NOT edited unless the user names the brand
+   explicitly ("warmer acme brand", "tone down acme primary"). When
+   brand files are present and the user did not name them, surface a
+   hint in Step F: "Brand `acme` is present and unchanged. To tune
+   it, say 'tune the acme brand'."
+3. If no theme files are found, halt: "No theme files at
+   `src/styles/theme/`. Run `/theme-create #seedhex` first."
+
+**Component layer:**
+
+1. Require `source: "generated"` from B1.
+2. Probe `<componentsDir>/<component>/<component>.scss`. If missing,
+   halt: "Component `<name>` isn't vendored yet. Run
+   `/kit-add <name>` first." Do not auto-install — this is a styling
+   task, not a scaffolding task.
+3. Reject components outside the v1 coverage list (button, card,
+   alert, dialog, input, nav). Halt with:
+   "Component `<name>` doesn't have a token mapping in v1. Open an
+   issue to request coverage."
+
+---
+
+## Step C — Compute deltas
+
+### C0. Read current state
+
+Always re-read current values from disk — the skill is stateless
+across invocations. Iteration ("warmer" then "cooler") works because
+each pass starts from the just-written value.
+
+### C1. Theme layer
+
+For each `(role, delta)` from Step A:
+
+1. Read the current hex from each in-scope theme file via
+   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/css_to_tokens.py <theme-file>`.
+2. Compute the new hex via
+   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/oklch_shift.py <currentHex>
+   --hue=±deg --chroma=×float --lightness=±float`. Capture `hex` from
+   the JSON output. If `oklch_shift.py` exits 1 (out-of-gamut),
+   surface its `reasons` in Step F's summary and skip that role for
+   that file.
+3. **Paired-role rule:** when shifting `--color-primary`, always shift
+   `--color-primary-hover` by the same OKLCH delta. Treat the pair as
+   a single batch entry — both values must apply, or both must revert.
+4. **Dark-mirror rule:** when both `light.css` and `dark.css` are in
+   scope, run the same OKLCH delta against each file's starting hex.
+   The two files yield mode-appropriate hex values from a shared
+   perceptual shift.
+5. Build the full plan as a list of `(file, role, oldHex, newHex)`
+   tuples. Do **not** invoke `/theme-update` yet — Step D pre-validates.
+
+### C2. Component layer
+
+For each `(component, family, delta)` from Step A:
+
+1. `Grep` the component SCSS for the targeted token name(s) and read
+   the current value(s).
+2. **Scalar values** (rem, unitless, hex literals): apply the
+   canonical delta from intent-vocabulary directly. Respect clamp
+   ranges (radius `[0.125rem, 1rem]`; padding multipliers; etc.).
+3. **Var-only references** (`--alert-bg: var(--color-surface, …)`):
+   do NOT edit this declaration. Look up the vocabulary's "var-only
+   fallback" column and route the edit to the underlying theme role
+   instead. Add a note to Step F: "Tuning `<component-token>` requires
+   changing `<theme-role>`, which affects every component using it."
+4. **Shadow tokens:** the vocabulary lists explicit preset values for
+   `flat`, `stronger`, `inset`, etc. — no procedural arithmetic on
+   multi-stop shadows. See `references/intent-vocabulary.md` for the
+   full preset enumeration.
+5. **Compound presets** (rows flagged `preset: true` — inviting,
+   businesslike, playful): expand into the listed multi-family
+   deltas; apply each independently.
+6. Preserve `var(--x, fallback)` wrappers everywhere — only the
+   declaration's RHS may change.
+
+---
+
+## Step D — Apply edits
+
+Apply immediately. No preview round-trip. Users review via the Step
+F summary or `git diff`.
+
+### D0. Pre-validate the theme batch
+
+Before any `/theme-update` invocation, stage the entire theme batch:
+
+1. Create a tmp directory via `mktemp -d`.
+2. For each in-scope theme file, copy it into the tmp dir and apply
+   the proposed `--color-<role>` edits in place (preserve comments
+   and whitespace).
+3. Run
+   `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_theme.py <staged-file>`
+   on each staged copy.
+4. If **any** contrast pair fails on **any** file, halt the entire
+   batch — do not write anything to disk. Print the failure(s),
+   the offending role/file, and a hint: "Re-run with a smaller delta
+   (e.g. `chroma × 0.85` instead of `× 0.75`), or pick an explicit
+   hex via `/theme-update`."
+
+This guarantees atomicity: paired roles never desync, light/dark stay
+in sync, and a failed contrast pair never leaves the project in a
+half-applied state.
+
+### D1. Theme layer
+
+With the batch pre-validated, invoke `/theme-update <file>
+--color-<role>=#<hex> [...]` once per theme file. Existing command
+writes in place. `/theme-update` runs `validate_theme.py` again
+internally; given D0, that should always pass.
+
+If `/theme-update`'s post-write validation ever fires (rounding
+mismatch between `oklch_shift.py` and `validate_theme.py`), surface
+the discrepancy as a bug and roll back manually via `git`.
+
+### D2. Component layer
+
+Build the entire updated SCSS file in memory; `Edit` atomically.
+
+Critical safety rules:
+
+- Never strip a `var()` wrapper — only the declaration's RHS may
+  change.
+- Never rename a token.
+- Never inline a hex literal where a `var(--color-*, …)` reference
+  exists.
+- Never edit lines outside the targeted `--{c}-*` declarations.
+
+### D3. Multi-target edits
+
+When one modifier touches multiple tokens (e.g. "more elevated dialog"
+→ `--dialog-shadow` + `--dialog-radius`), batch into one Edit pass per
+file.
+
+---
+
+## Step E — Validate and revert
+
+### E1. Theme layer
+
+D0's pre-validation guarantees no in-flight reverts. `/theme-update`'s
+own validation is a safety net.
+
+### E2. Component layer
+
+Structural integrity check after each Edit:
+
+1. Re-`Grep` the file for `var(` occurrences — count must be unchanged
+   before and after.
+2. Re-`Grep` for each edited token name — must appear exactly once on
+   a declaration LHS.
+
+On failure, restore from the in-memory pre-edit copy and surface the
+diff. Halt the batch.
+
+### E3. Idempotency
+
+If the computed value equals the current value within tolerance (hex
+equality, or rem within 0.0001), skip the write and report "already
+at target" in Step F. This does NOT prevent cumulative drift across
+iterations — `× 0.75` then `× 1.25` lands at `× 0.9375`, not the
+original. Document this in the Step F "Next" hint when a chroma or
+scale modifier is applied.
+
+### E4. Drift detection
+
+After applying any theme-layer color shift, inspect the post-edit
+OKLCH of the tuned role. If `chroma < 0.05` OR
+`|hue − palette-derived hue| > 30°`, append a drift hint to Step F:
+"Note: `--color-<role>` has drifted from its palette-derived value.
+Consecutive tunes accumulate hex round-trip noise; if the result
+feels off, run `/theme-create #seedhex` to reset."
+
+The "palette-derived hue" reference is the seed used by the most
+recent `/theme-create` invocation. If unknown, derive an approximate
+reference by reading the current `--color-success` hex (which is hue
+145° by construction) and computing the implied seed-hue offset.
+
+---
+
+## Step F — Summary
+
+Print a structured table mirroring `/theme-update`'s output:
+
+```
+Layer:       <theme | component | both>
+Files:       <list>
+
+Modifier         Token / Role               Old           New           Status
+warmer           --color-primary            #2563eb       #3265ec       accepted
+warmer           --color-primary-hover      #1e4dc7       #294fc8       accepted
+softer           --btn-radius               0.375rem      0.5625rem     accepted
+calmer           --color-danger             #dc2626       #d8413b       reverted (contrast)
+
+Notes:
+  - Tuning --alert-bg routed to --color-surface (affects all components).
+  - Brand `acme` is present and unchanged. To tune it, say "tune the acme brand".
+
+Next:
+  - Try "now go a touch sharper" to dial back radius.
+  - Or use /theme-update for explicit hex values.
+```
+
+Always include the "Next" hint so users know iteration is cheap and
+bounded.
+
+---
+
+## Reference documents
+
+- `references/intent-vocabulary.md` — full modifier → token-family
+  table with deltas, clamp ranges, var-only fallbacks, and worked
+  examples.
+- `${CLAUDE_PLUGIN_ROOT}/skills/styles/references/role-catalogue.md`
+  — semantic role list and contrast pairings.
+- `${CLAUDE_PLUGIN_ROOT}/skills/styles/references/palette-algorithm.md`
+  — OKLCH lightness targets and state-color hue offsets.
+- `${CLAUDE_PLUGIN_ROOT}/skills/components/references/css-variables.md`
+  — full component-token surface.

--- a/plugins/acss-kit/skills/style-tune/references/intent-vocabulary.md
+++ b/plugins/acss-kit/skills/style-tune/references/intent-vocabulary.md
@@ -1,0 +1,253 @@
+# Intent vocabulary
+
+Modifier → token-family mapping for the `style-tune` skill. Every
+modifier listed here is a trigger phrase; bare adjectives in prose
+contexts must NOT trigger the skill (front-matter description is
+component- and role-anchored).
+
+`{c}` in token names stands for the resolved component prefix
+(`btn`, `card`, `alert`, `dialog`, `input`, `nav`).
+
+## v1 component coverage
+
+| Family | Button | Card | Alert | Dialog | Input | Nav |
+|---|---|---|---|---|---|---|
+| Color | yes | yes | yes | yes | yes | yes |
+| Radius | yes | yes | yes | yes | yes | — |
+| Spacing | yes | yes | yes | yes | yes | yes |
+| Elevation | — | yes | yes | yes | — | — |
+| Size (font) | yes | — | — | — | — | — |
+| Size (width) | — | — | — | yes | yes | — |
+| Height | — | — | — | yes | — | — |
+
+Components outside the v1 list (`field`, `checkbox`, `icon`, `link`,
+`list`, `popover`, `table`, `tag`, `badge`, `img`) halt with a v2
+hint.
+
+## Clamp ranges
+
+Applied after every delta:
+
+- `--{c}-radius`: `[0.125rem, 1rem]`
+- OKLCH lightness: `[0.15, 0.95]`
+- OKLCH chroma: clipped at sRGB gamut by `oklch_to_hex`
+- `--{c}-padding-*` / `--{c}-gap`: `[0.125rem, 4rem]`
+- `--{c}-max-height`: `[20vh, 95vh]`
+
+## Single-axis modifiers
+
+### Radius
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| softer, friendlier, rounded, smoother | component | `--{c}-radius` | × 1.5 (clamp ≤ 1rem) | none — radius is always scalar |
+| sharper, crisper, harder, geometric | component | `--{c}-radius` | × 0.5 (clamp ≥ 0.125rem) | none |
+
+Worked example: `--btn-radius: 0.375rem` + "softer" → `0.5625rem`.
+
+### Color (theme-layer hue / chroma / lightness)
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| warmer, cozier, sunnier | theme | `--color-primary` (and `-hover`) | OKLCH `hue` += +8° toward 60° | n/a (theme role) |
+| cooler, icier | theme | `--color-primary` (and `-hover`) | OKLCH `hue` += −8° toward 240° | n/a |
+| calmer, muted, gentler, restrained | theme | named role (default `--color-primary`) | OKLCH `chroma` × 0.75 | n/a |
+| bolder, punchier, more vibrant, livelier | theme | named role | OKLCH `chroma` × 1.25 (gamut clamp) | n/a |
+| deeper, richer, darker accent | theme | `--color-primary` (and `-hover`) | OKLCH `lightness` += −0.06 | n/a |
+| lighter, paler, washed-out | theme | `--color-primary` (and `-hover`) | OKLCH `lightness` += +0.06 | n/a |
+| tone down | theme | named role | OKLCH `chroma` × 0.75 (alias of "calmer") | n/a |
+
+Worked example: `--color-primary: #2563eb` + "warmer" → call
+`oklch_shift.py "#2563eb" --hue=8` → `#475ceb`. Apply the same
+delta to `--color-primary-hover` (paired-role rule).
+
+Hue blend rules:
+- "warmer" rotates toward hue 60° (yellow-orange) with a +8° step. If
+  the current hue is already within ±10° of 60°, skip with "already
+  warm".
+- "cooler" rotates toward hue 240° (blue) with a −8° step. Same
+  threshold.
+
+### Spacing
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| spacious, roomier, airier, breathing | component | `--{c}-padding`, `--{c}-padding-inline`, `--{c}-padding-block`, `--{c}-content-padding`, `--{c}-content-gap`, `--{c}-gap` | × 1.5 | none |
+| tighter, denser, compact | component | same as above | × 0.66 | none |
+
+Worked example: `--card-padding: 1rem; --card-content-gap: 1rem` +
+"spacious" → both become `1.5rem`.
+
+### Elevation (border + shadow)
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| elevated, lifted, floating | component | `--{c}-shadow`, `--{c}-radius` | shadow → `stronger` preset; radius += `+0.125rem` | none |
+| grounded, planted, weighted | component | `--{c}-shadow`, `--{c}-border-bottom` | shadow → `inset` preset; emphasize border-bottom | none |
+| quieter, subtler | component | `--{c}-border`, `--{c}-shadow` | border thinner; shadow → `none` | none |
+| louder, prominent, attention-grabbing | component | `--{c}-border`, `--{c}-shadow` | border × 2; shadow → `stronger` preset | none |
+| minimal, flat, clean | component | `--{c}-shadow`, `--{c}-border` | shadow → `none`; border → `1px solid` | none |
+
+Shadow preset enumeration (canonical values used by deltas above):
+
+| Preset | Value |
+|---|---|
+| `none` | `none` |
+| `flat` | `0 1px 2px rgba(0,0,0,0.06)` |
+| `default` | `0 1px 3px rgba(0,0,0,0.10)` |
+| `stronger` | `0 8px 16px rgba(0,0,0,0.12), 0 4px 6px rgba(0,0,0,0.08)` |
+| `inset` | `inset 0 1px 2px rgba(0,0,0,0.08)` |
+
+When a modifier maps to a preset, replace the existing
+`--{c}-shadow` declaration's RHS with the preset value verbatim. Do
+not attempt to interpolate between presets.
+
+### Size — font scale
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| smaller, tinier | component (button) | `--btn-fs` | swap to next-smaller `--btn-size-*` step | none |
+| bigger, larger | component (button) | `--btn-fs` | swap to next-larger `--btn-size-*` step | none |
+
+The button scale ladder is xs → sm → md → lg → xl. Default is `md`.
+"Smaller" from `md` → `sm`; from `xs` → halt with "already at
+smallest". "Bigger" from `xl` → halt with "already at largest".
+
+Worked example: `--btn-fs: var(--btn-size-md, 0.9375rem)` + "smaller"
+→ `--btn-fs: var(--btn-size-sm, 0.8125rem)`. Both the variable
+reference and the fallback move together to keep the component
+self-contained without a global tokens file.
+
+### Size — width
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| narrower | component (dialog/input) | `--{c}-width`, `--{c}-max-width` | × 0.75 | none |
+| wider | component (dialog/input) | `--{c}-width`, `--{c}-max-width` | × 1.25 | none |
+
+Worked example: `--dialog-width: 32rem` + "narrower" → `24rem`.
+
+### Height
+
+| Modifiers | Layer | Family | Delta | var-only fallback |
+|---|---|---|---|---|
+| shorter | component (dialog) | `--{c}-max-height` | × 0.75 (clamp ≥ 20vh) | none |
+| taller | component (dialog) | `--{c}-max-height` | × 1.25 (clamp ≤ 95vh) | none |
+
+Worked example: `--dialog-max-height: 85vh` + "shorter" → `64vh` (× 0.75 rounded).
+
+## Compound presets
+
+These rows are flagged `preset: true`. Each maps one modifier to
+multiple token families. Apply each family delta independently as a
+single batch.
+
+| Modifier | Layer | Token-family deltas |
+|---|---|---|
+| inviting, welcoming | component (button) | `--btn-radius` × 1.5; `--btn-padding-inline` × 1.25 |
+| businesslike, formal, conservative | component | `--{c}-radius` × 0.5; `--{c}-shadow` → `flat` preset |
+| playful, fun | component | `--{c}-radius` × 2 (clamp ≤ 1rem); `--{c}-padding` × 1.25 |
+
+Worked example: `inviting` button →
+`--btn-radius: 0.375rem` becomes `0.5625rem` AND
+`--btn-padding-inline: calc(var(--btn-fs, 0.9375rem) * 1.5)` becomes
+`calc(var(--btn-fs, 0.9375rem) * 1.875)`. Both edits batch into one
+`Edit` pass per the SKILL's D3 rule.
+
+## Var-only fallback table
+
+Some component tokens are pure `var(--color-*, …)` references — they
+have no scalar to multiply. When a color-targeting modifier hits one,
+the skill auto-routes to the underlying theme role per this table:
+
+| Component token | Routes to theme role |
+|---|---|
+| `--alert-bg` | `--color-surface` |
+| `--alert-color` | `--color-text` |
+| `--alert-border` | `--color-border` |
+| `--card-bg` | `--color-surface` |
+| `--card-color` | `--color-text` |
+| `--card-border` | `--color-border` (in border declaration) |
+| `--card-footer-bg` | `--color-surface-subtle` |
+| `--card-footer-border-top` | `--color-border` |
+| `--dialog-bg` | `--color-surface` |
+| `--dialog-color` | `--color-text` |
+| `--dialog-header-border-bottom` | `--color-border` |
+| `--dialog-footer-bg` | `--color-surface-subtle` |
+| `--dialog-footer-border-top` | `--color-border` |
+| `--input-bg` | `--color-surface` |
+| `--input-color` | `--color-text` |
+| `--input-border` | `--color-border` (in border declaration) |
+| `--input-outline` | `--color-primary` |
+| `--input-focus-border` | `--color-primary` |
+| `--input-disabled-bg` | `--color-surface-subtle` |
+| `--input-placeholder-color` | `--color-text-subtle` |
+| `--btn-primary-bg` | `--color-primary` |
+| `--btn-primary-color` | `--color-text-inverse` |
+| `--btn-hover-bg` | `--color-primary-hover` |
+| `--nav-link-color` | `--color-text` |
+| `--nav-link-hover-color` | `--color-primary` |
+| `--nav-link-active-color` | `--color-primary` |
+
+When auto-routing fires, Step F appends a note: "Tuning
+`<component-token>` requires changing `<theme-role>`, which affects
+every component using it." This makes the cascade impact explicit so
+users can opt out (re-run with explicit `--scope` once that flag
+ships in v2).
+
+## Alert severity variants
+
+By default, "calmer alert" / "warmer alert" / etc. tune only the base
+alert tokens (`--alert-bg`, `--alert-border`, `--alert-color`,
+`--alert-fs`, `--alert-padding`, `--alert-radius`).
+
+The four severity variants — `--alert-info-{bg,border,color}`,
+`--alert-success-{bg,border,color}`, `--alert-warning-{bg,border,color}`,
+`--alert-error-{bg,border,color}` — stay locked unless the user names
+them explicitly. Trigger phrases for variants:
+
+- "calmer success alert" / "warmer error alert" / "bolder warning
+  alert" → tune the named single variant.
+- "calmer alert variants" / "tune all alert states" → tune all four.
+
+This avoids meaning-loss: a "calm" danger state still needs to read
+as urgent.
+
+## Brand-*.css edits
+
+Theme-layer modifiers ("warmer primary", "tone down primary") edit
+`light.css` + `dark.css` only by default. Any `brand-*.css` files in
+the same directory are **not** touched.
+
+To tune a brand file, the user must name it explicitly:
+
+- "warmer acme brand" → tune `brand-acme.css`
+- "tone down acme primary" → tune `brand-acme.css` only
+- "deeper accent for acme" → tune `brand-acme.css` only
+
+When brand files are present and the user did not name them, Step F
+appends: "Brand `acme` is present and unchanged. To tune it, say
+'tune the acme brand'."
+
+## Hue blend constants
+
+The hue rotation modifiers reference these target hues (CSS Color 4
+OKLCH degrees):
+
+| Direction | Target hue | Rationale |
+|---|---|---|
+| warmer | 60° | yellow-orange (sun, fire) |
+| cooler | 240° | blue (sky, ice) |
+
+The +8° / −8° step is calibrated to feel perceptually distinct
+without overshooting. Three to four "warmer" tunes saturate the move
+to the target hue.
+
+## Idempotency tolerance
+
+Step E3 reports "already at target" when the computed value equals
+the current value within:
+
+- Hex equality for color values (case-insensitive).
+- `±0.0001rem` for rem values.
+- `±0.5px` for vh / vw / px values (after rounding to one decimal).

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -15,14 +15,17 @@
 # render a React app.
 #
 # Usage:
-#   tests/setup.sh           # first-time setup (errors if sandbox exists)
-#   tests/setup.sh --reset   # wipe and recreate the sandbox
+#   tests/setup.sh                       # first-time setup (errors if sandbox exists)
+#   tests/setup.sh --reset               # wipe and recreate the sandbox
+#   tests/setup.sh --with-style-tune     # also seed light.css + dark.css for style-tune verification
+#   tests/setup.sh --reset --with-style-tune
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SANDBOX="$REPO_ROOT/tests/sandbox"
 RESET=0
+WITH_STYLE_TUNE=0
 
 cat >&2 <<'BANNER'
 [tests/setup.sh] This scaffolds the manual demo fixture.
@@ -30,19 +33,16 @@ cat >&2 <<'BANNER'
 
 BANNER
 
-if [[ $# -gt 1 ]]; then
-  echo "Too many arguments: $*" >&2
-  echo "Usage: tests/setup.sh [--reset]" >&2
-  exit 1
-fi
-
-case "${1:-}" in
-  --reset) RESET=1 ;;
-  "")      ;;
-  *)       echo "Unknown argument: $1" >&2
-           echo "Usage: tests/setup.sh [--reset]" >&2
-           exit 1 ;;
-esac
+for arg in "$@"; do
+  case "$arg" in
+    --reset)            RESET=1 ;;
+    --with-style-tune)  WITH_STYLE_TUNE=1 ;;
+    "")                 ;;
+    *)                  echo "Unknown argument: $arg" >&2
+                        echo "Usage: tests/setup.sh [--reset] [--with-style-tune]" >&2
+                        exit 1 ;;
+  esac
+done
 
 # --- Preflight -----------------------------------------------------------
 
@@ -137,6 +137,24 @@ SCSS_DTS
 # Placeholder so /kit-add has a stable directory tree to write into.
 touch "$SANDBOX/src/.gitkeep"
 
+# --- Optional style-tune theme baseline ---------------------------------
+# When --with-style-tune is passed, seed light.css + dark.css so the user
+# can immediately try /style-tune prompts against a populated theme. The
+# skill needs an existing theme to edit; without this baseline its first
+# instruction is "run /theme-create #seedhex first".
+#
+# Component vendoring (/kit-add) still requires an interactive Claude
+# session — those slash commands aren't reachable from a shell script.
+# RECIPE.md (below) walks the user through the component step.
+
+if [[ "$WITH_STYLE_TUNE" -eq 1 ]]; then
+  echo "Seeding theme baseline for style-tune verification..."
+  THEME_DIR="$SANDBOX/src/styles/theme"
+  mkdir -p "$THEME_DIR"
+  python3 "$REPO_ROOT/plugins/acss-kit/scripts/generate_palette.py" "#2563eb" --mode=both \
+    | python3 "$REPO_ROOT/plugins/acss-kit/scripts/tokens_to_css.py" --stdin --out-dir="$THEME_DIR"
+fi
+
 cd "$SANDBOX"
 
 echo "Installing fixture devDependencies (typescript, sass, react)..."
@@ -147,6 +165,46 @@ npm install --silent
 # the initial commit. If we wrote it after, the sandbox would have an
 # untracked file from the start — defeating the "clean anchor" the bootstrap
 # commit provides for plugin dirty-tree guards.
+
+STYLE_TUNE_NOTE=""
+if [[ "$WITH_STYLE_TUNE" -eq 1 ]]; then
+  STYLE_TUNE_NOTE="
+## Style-tune verification
+
+This sandbox was built with \`--with-style-tune\`, so \`light.css\` and
+\`dark.css\` are pre-seeded from \`#2563eb\`. To exercise the
+\`style-tune\` skill end to end:
+
+1. Vendor the v1-supported components inside Claude Code:
+
+   \`\`\`
+   /kit-add button card alert dialog input nav
+   \`\`\`
+
+2. Try natural-language prompts (no slash command needed — these
+   auto-trigger):
+
+   - \"Make the button feel softer and warmer\"
+   - \"Tone down the primary color a touch\"
+   - \"More spacious cards\"
+   - \"Style the dialog to feel more elevated\"
+   - \"Narrower dialog\"
+   - \"Smaller buttons\"
+
+3. After each prompt, inspect \`git diff\` to confirm the targeted
+   tokens moved (and only those tokens). \`var(\` count in each
+   component SCSS file should be unchanged before/after.
+
+4. For atomicity, try a deliberately failing prompt — e.g. set the
+   primary too close to the background:
+
+   \`\`\`
+   /style-tune make the primary nearly the same color as the background
+   \`\`\`
+
+   Expect: pre-validation halts the entire batch; nothing is written.
+"
+fi
 
 cat > "$SANDBOX/RECIPE.md" <<EOF
 # Local plugin testing recipe
@@ -193,7 +251,7 @@ Compile a generated SCSS file to confirm it parses:
 \`\`\`
 npx sass --no-source-map src/components/fpkit/button/button.scss
 \`\`\`
-
+$STYLE_TUNE_NOTE
 Reset this sandbox with:
 \`\`\`
 "$REPO_ROOT/tests/setup.sh" --reset


### PR DESCRIPTION
## Summary

Introduces the `style-tune` pilot skill, a natural-language interface for adjusting the visual feel of acss-kit components and theme roles. Users can now describe desired changes (e.g., "make the button softer", "tone down the primary") and the skill routes edits to either theme-layer color roles or component-level SCSS tokens, with atomic validation and WCAG contrast pre-checking.

## Key Changes

- **New skill: `style-tune`** (`plugins/acss-kit/skills/style-tune/SKILL.md`)
  - 327-line specification covering two-layer routing (theme vs. component), intent resolution, delta computation, atomic validation, and summary output
  - Implements Steps A–F: resolve intent from natural language → locate files → compute OKLCH/scalar deltas → pre-validate theme batch → apply edits → validate structurally → print summary table

- **Intent vocabulary** (`plugins/acss-kit/skills/style-tune/references/intent-vocabulary.md`)
  - 253-line reference mapping modifiers (softer, warmer, calmer, spacious, elevated, etc.) to token families, deltas, clamp ranges, and var-only fallbacks
  - Covers v1 component coverage (button, card, alert, dialog, input, nav) and theme roles (primary, accent, danger, warning, info, success, brand)
  - Includes compound presets (inviting, businesslike, playful) and alert severity variant handling

- **OKLCH color shift utility** (`plugins/acss-kit/scripts/oklch_shift.py`)
  - Standalone CLI tool for shifting hex colors in OKLCH space (hue rotation, chroma scaling, lightness adjustment)
  - Outputs JSON with shifted OKLCH values, gamut warnings, and reasons for out-of-gamut clamps
  - Used by style-tune to compute perceptually consistent color deltas

- **Shared OKLCH conversion module** (`plugins/acss-kit/scripts/_oklch.py`)
  - Extracted hex ↔ OKLCH conversion logic (CSS Color 4 matrices) for reuse by `generate_palette.py` and `oklch_shift.py`
  - Provides `hex_to_oklch()`, `oklch_to_hex()` (with sRGB gamut clamping), and `in_gamut()` helpers

- **Command definition** (`plugins/acss-kit/commands/style-tune.md`)
  - Slash command entry point with argument hint and tool declarations
  - References the SKILL.md workflow and provides quick-start examples

- **Documentation updates**
  - `plugins/acss-kit/docs/commands.md`: added `/style-tune` command reference with step-by-step explanation and examples
  - `plugins/acss-kit/README.md`: noted style-tune as second pilot skill
  - `plugins/acss-kit/CHANGELOG.md`: documented pilot skill addition
  - `.claude/rules/python-scripts.md`: added oklch_shift.py and _oklch.py to script inventory

- **Test fixture enhancement** (`tests/setup.sh`)
  - Added `--with-style-tune` flag to optionally seed `light.css` + `dark.css` from a baseline palette
  - Allows immediate style-tune verification without requiring manual `/theme-create` first
  - Updated usage documentation and added style-tune verification walkthrough in RECIPE.md

- **Plugin metadata** (`plugins/acss-kit/.claude-plugin/plugin.json`)
  - Incremented version to reflect new skill addition

## Notable Implementation Details

- **Atomic theme batch validation**: proposed color edits are staged in a temp directory and pre-validated against WCAG 2.2 AA contrast pairs before any disk writes. The entire batch reverts if any pair fails, preventing desync of paired roles (e.g., `--color-primary` and `--color-primary-hover`).

- **Dark-mode mirroring**: when both `light.css` and `dark.css` exist, the same OKLCH delta is applied to each file's starting hex, yielding mode-appropriate hex values from a shared perceptual shift.

- **

https://claude.ai/code/session_01Nr6Gi1QdEAqY6PChA3RtwS