### PR TITLE
fix(acss-kit): address Copilot review findings on style-tune (#29 follow-up)

### DIFF
--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -24,17 +24,19 @@ For scripts whose output is parsed by slash commands or skills.
 - Exit 0 on success, 1 on logical failure (e.g. nothing detected)
 - Always include a `"reasons"` array in the JSON — empty `[]` on success, populated on failure
 
-Detectors: `detect_target.py`, `detect_package_manager.py`, `oklch_shift.py`.
+Detectors: `detect_target.py`, `detect_package_manager.py`.
 
 ## Generator / validator contract (pipeline-friendly, human-readable)
 
 For scripts that emit data or human-readable validation results.
 
-- Data on stdout (JSON for `generate_palette.py` / `css_to_tokens.py`; CSS files for `tokens_to_css.py`; text for `validate_theme.py`)
+- Data on stdout (JSON for `generate_palette.py` / `css_to_tokens.py` / `oklch_shift.py`; CSS files for `tokens_to_css.py`; text for `validate_theme.py`)
 - Errors on stderr
 - Exit 0 on success, 1 on logical failure, 2 on usage / IO errors
 
-Generators / validators: `generate_palette.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`.
+Generators / validators: `generate_palette.py`, `oklch_shift.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`.
+
+`oklch_shift.py` follows this contract — it transforms an input hex into a shifted hex and emits structured JSON. It exits 0 whenever a usable hex was produced (even when chroma or lightness was clamped to stay in sRGB gamut — `clamped: true` and a populated `reasons` array surface the warning), reserves exit 1 for hard failures where no hex can be produced, and exits 2 on usage / IO errors.
 
 ## Internal module contract
 

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 ### Added
 
 - **Pilot `style-tune` skill and `/style-tune` command** — natural-language adjustment of acss-kit components and theme roles. Routes "warmer button", "softer card", "tone down the primary", "more spacious cards", "more elevated dialog", "smaller buttons", "narrower dialog", "taller dialog" between theme-role edits (delegated to `/theme-update` with WCAG pre-validation) and component SCSS token edits. Six v1 token families (color, radius, spacing, elevation, size, height) across six components (button, card, alert, dialog, input, nav). Atomic batch pre-validation guarantees paired roles and light/dark mirrors never desync. `references/intent-vocabulary.md` documents the full modifier → token-family table.
-- **`scripts/oklch_shift.py`** — new CLI helper that takes a hex color plus per-channel OKLCH offsets (`--hue`, `--chroma`, `--lightness`) and emits the shifted hex. Detector contract; stdlib only. Powers `style-tune`'s color deltas.
-- **`scripts/_oklch.py`** — internal shared module exposing `hex_to_oklch`, `oklch_to_hex`, `in_gamut`. Extracted from `generate_palette.py` so both palette generation and `oklch_shift.py` use the same conversion math.
-- **`tests/setup.sh --with-style-tune`** — opt-in fixture build that vendors the six v1 components and seeds a `light.css` / `dark.css` baseline so end-to-end style-tune prompts have a populated project to edit.
+- **`scripts/oklch_shift.py`** — new CLI helper that takes a hex color plus per-channel OKLCH offsets (`--hue`, `--chroma`, `--lightness`) and emits the shifted hex. Generator/validator contract; stdlib only. Exits 0 whenever a usable hex was produced (with `clamped: true` and a populated `reasons` array when the math hit a gamut boundary). Powers `style-tune`'s color deltas.
+- **`scripts/_oklch.py`** — internal shared module exposing `hex_to_oklch`, `oklch_to_hex`, `in_gamut`. Extracted from `generate_palette.py` so both palette generation and `oklch_shift.py` use the same conversion math. `oklch_to_hex` defensively clamps `L` to `[0, 1]` upfront and falls back to a directly-synthesized achromatic hex on gamut failure (no recursion).
+- **`tests/setup.sh --with-style-tune`** — opt-in fixture flag that seeds `light.css` and `dark.css` from a baseline palette so end-to-end style-tune prompts have a populated theme to edit. Component vendoring (`/kit-add`) still requires an interactive Claude session — `RECIPE.md` walks through that step.
 
 ### Changed
 

--- a/plugins/acss-kit/scripts/_oklch.py
+++ b/plugins/acss-kit/scripts/_oklch.py
@@ -47,7 +47,19 @@ def hex_to_oklch(hex_str: str) -> tuple[float, float, float]:
 
 
 def oklch_to_hex(L: float, C: float, H: float) -> str:
-    """Convert OKLCH to hex, clamping chroma to stay in sRGB gamut."""
+    """Convert OKLCH to hex, clamping chroma to stay in sRGB gamut.
+
+    Defensive clamps:
+    - ``L`` is clamped to ``[0.0, 1.0]`` up front, so the iterative
+      chroma-reduction loop always operates on a valid lightness.
+    - ``C`` is clamped to ``>= 0``.
+    - When all 100 reduction steps fail to find an in-gamut color, we
+      return an achromatic hex at the requested lightness directly
+      instead of recursing — preventing infinite recursion if numeric
+      issues somehow leave even ``C=0`` out of gamut.
+    """
+    L = max(0.0, min(1.0, L))
+    C = max(0.0, C)
     for _ in range(100):
         a = C * math.cos(math.radians(H))
         b = C * math.sin(math.radians(H))
@@ -70,9 +82,18 @@ def oklch_to_hex(L: float, C: float, H: float) -> str:
             gi = round(_gamma(g) * 255)
             bi = round(_gamma(b_) * 255)
             return f"#{ri:02x}{gi:02x}{bi:02x}"
+        if C == 0.0:
+            # Already achromatic and still failing the gamut check —
+            # synthesize a neutral gray at the requested lightness
+            # directly so we never recurse into the same code path.
+            v = max(0.0, min(1.0, L))
+            gv = round(_gamma(v) * 255)
+            return f"#{gv:02x}{gv:02x}{gv:02x}"
         C = max(0.0, C - 0.01)
-    # Fallback: achromatic at target lightness
-    return oklch_to_hex(L, 0.0, H)
+    # Final fallback: achromatic at the (clamped) target lightness.
+    v = max(0.0, min(1.0, L))
+    gv = round(_gamma(v) * 255)
+    return f"#{gv:02x}{gv:02x}{gv:02x}"
 
 
 def in_gamut(L: float, C: float, H: float) -> bool:

--- a/plugins/acss-kit/scripts/_oklch.py
+++ b/plugins/acss-kit/scripts/_oklch.py
@@ -60,6 +60,15 @@ def oklch_to_hex(L: float, C: float, H: float) -> str:
     """
     L = max(0.0, min(1.0, L))
     C = max(0.0, C)
+
+    def _achromatic_hex(L_clamped: float) -> str:
+        # OKLab → linear sRGB on the neutral axis (a = b = 0): the M2
+        # inverse gives l_ = m_ = s_ = L, then cubing yields linear-light
+        # r = g = b = L ** 3. Apply gamma encoding to get the sRGB byte.
+        lv = max(0.0, min(1.0, L_clamped ** 3))
+        gv = round(_gamma(lv) * 255)
+        return f"#{gv:02x}{gv:02x}{gv:02x}"
+
     for _ in range(100):
         a = C * math.cos(math.radians(H))
         b = C * math.sin(math.radians(H))
@@ -86,14 +95,10 @@ def oklch_to_hex(L: float, C: float, H: float) -> str:
             # Already achromatic and still failing the gamut check —
             # synthesize a neutral gray at the requested lightness
             # directly so we never recurse into the same code path.
-            v = max(0.0, min(1.0, L))
-            gv = round(_gamma(v) * 255)
-            return f"#{gv:02x}{gv:02x}{gv:02x}"
+            return _achromatic_hex(L)
         C = max(0.0, C - 0.01)
     # Final fallback: achromatic at the (clamped) target lightness.
-    v = max(0.0, min(1.0, L))
-    gv = round(_gamma(v) * 255)
-    return f"#{gv:02x}{gv:02x}{gv:02x}"
+    return _achromatic_hex(L)
 
 
 def in_gamut(L: float, C: float, H: float) -> bool:

--- a/plugins/acss-kit/scripts/oklch_shift.py
+++ b/plugins/acss-kit/scripts/oklch_shift.py
@@ -10,8 +10,10 @@ Examples:
     oklch_shift.py "#2563eb" --chroma=0.75     # multiply chroma by 0.75
     oklch_shift.py "#2563eb" --lightness=-0.06 # subtract 0.06 from L
 
-Output: JSON to stdout — { "hex", "oklch": [L, C, H], "shifted": [L, C, H], "reasons": [] }
-Exit codes: 0 = success, 1 = logical failure (post-shift out of gamut, etc.), 2 = usage / IO error.
+Output: JSON to stdout — { "hex", "oklch": [L, C, H], "shifted": [L, C, H], "clamped": bool, "reasons": [] }
+Exit codes: 0 = success (a usable hex was produced — `reasons` may still be populated as warnings;
+            check `clamped` to detect gamut clamping), 1 = no usable hex (reserved for future hard
+            failures — currently unreachable), 2 = usage / IO error.
 
 Stdlib only — no external dependencies.
 """
@@ -76,6 +78,7 @@ def main() -> int:
         return 2
 
     reasons: list[str] = []
+    clamped = False
 
     L0, C0, H0 = hex_to_oklch(seed)
 
@@ -83,23 +86,27 @@ def main() -> int:
     C1 = C0 * chroma_factor
     H1 = (H0 + hue_delta) % 360
 
-    # Lightness clamp [0.0, 1.0] is a hard gamut floor/ceiling; surface it.
+    # Lightness clamp [0.0, 1.0] — note as a warning, not a hard failure.
     if L1 < 0.0:
-        reasons.append(f"lightness out of gamut: {L1:.4f} < 0.0 (clamped to 0.0)")
+        reasons.append(f"lightness clamped: {L1:.4f} < 0.0 (using 0.0)")
         L1 = 0.0
+        clamped = True
     if L1 > 1.0:
-        reasons.append(f"lightness out of gamut: {L1:.4f} > 1.0 (clamped to 1.0)")
+        reasons.append(f"lightness clamped: {L1:.4f} > 1.0 (using 1.0)")
         L1 = 1.0
+        clamped = True
     # Chroma must stay non-negative.
     if C1 < 0.0:
-        reasons.append(f"chroma negative after shift: {C1:.4f} (clamped to 0.0)")
+        reasons.append(f"chroma clamped: {C1:.4f} < 0.0 (using 0.0)")
         C1 = 0.0
+        clamped = True
 
     if not in_gamut(L1, C1, H1):
         reasons.append(
-            f"shifted color out of sRGB gamut at (L={L1:.4f}, C={C1:.4f}, H={H1:.2f}); "
-            f"oklch_to_hex will reduce chroma to fit"
+            f"requested OKLCH (L={L1:.4f}, C={C1:.4f}, H={H1:.2f}) is out of sRGB gamut; "
+            f"oklch_to_hex reduced chroma to fit"
         )
+        clamped = True
 
     new_hex = oklch_to_hex(L1, C1, H1)
     Lp, Cp, Hp = hex_to_oklch(new_hex)
@@ -114,10 +121,14 @@ def main() -> int:
             "chroma": chroma_factor,
             "lightness": lightness_delta,
         },
+        "clamped": clamped,
         "reasons": reasons,
     }
     print(json.dumps(result, indent=2))
-    return 1 if reasons else 0
+    # A usable hex was always produced — `reasons` is informational
+    # (clamping warnings). Reserve exit 1 for future hard failures
+    # (currently no path reaches it from valid input).
+    return 0
 
 
 if __name__ == "__main__":

--- a/plugins/acss-kit/skills/style-tune/SKILL.md
+++ b/plugins/acss-kit/skills/style-tune/SKILL.md
@@ -144,10 +144,18 @@ For each `(role, delta)` from Step A:
    `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/css_to_tokens.py <theme-file>`.
 2. Compute the new hex via
    `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/oklch_shift.py <currentHex>
-   --hue=±deg --chroma=×float --lightness=±float`. Capture `hex` from
-   the JSON output. If `oklch_shift.py` exits 1 (out-of-gamut),
-   surface its `reasons` in Step F's summary and skip that role for
-   that file.
+   --hue=±deg --chroma=×float --lightness=±float`. The script always
+   produces a usable hex when the input is valid:
+   - **Exit 0** (always when a hex is produced): use the returned `hex`
+     value. Inspect `clamped` — if `true`, the OKLCH math hit a gamut
+     boundary; surface the entries from `reasons` in Step F as
+     informational warnings but still apply the edit (the clamped hex
+     is what the user asked for, expressed in valid sRGB).
+   - **Exit 2**: usage / IO error (e.g. invalid hex argument). Surface
+     the stderr message and skip that role.
+   The skill does not currently see exit 1 from this script;
+   `oklch_shift.py` reserves it for future hard failures where no
+   usable hex can be produced.
 3. **Paired-role rule:** when shifting `--color-primary`, always shift
    `--color-primary-hover` by the same OKLCH delta. Treat the pair as
    a single batch entry — both values must apply, or both must revert.


### PR DESCRIPTION
## Summary

Follow-up PR addressing the five review comments Copilot left on #29 (which was merged before the fixes could be pushed). All five fixes are in a single commit (`cca0bb5`).

## Fixes

### 1. `_oklch.py` — defensive correctness in `oklch_to_hex` (real bug)

The previous fallback path called `return oklch_to_hex(L, 0.0, H)` after 100 chroma-reduction steps. If numeric edge cases left even `C=0` failing the gamut check (e.g. `L` outside `[0, 1]`), the function would re-enter the same branch and never terminate.

Now: clamp `L` to `[0, 1]` and `C` to `>= 0` upfront; on gamut failure, synthesize an achromatic hex directly at the (clamped) target lightness — no recursion. **Byte-identity** of `generate_palette.py` output verified against the same five canonical seeds used in #29 (`#2563eb`, `#7c3aed`, `#16a34a`, `#dc2626`, `#0f766e`).

### 2. `oklch_shift.py` — exit-code semantics

Previously exited 1 whenever `reasons` was non-empty, even when a usable hex was produced (gamut-clamped warmer/cooler/calmer shifts). That made common clamped cases look like failures to `set -e` shells and to the skill's "skip on exit 1" rule.

Now: exit `0` whenever a usable hex was produced, with a new `clamped: bool` field and `reasons[]` array surfacing warnings; reserve exit `1` for future hard failures where no hex can be produced; exit `2` is unchanged for usage / IO errors.

Smoke-tested across warmer / clamped-lightness / clamped-chroma / invalid-hex inputs.

### 3. `style-tune` SKILL.md — Step C1 wording

Updated to match the new exit semantics: use the returned hex on exit 0 even when `clamped: true`, surface `reasons` as informational warnings in Step F, and skip a role only on exit 2 (usage / IO error).

### 4. `.claude/rules/python-scripts.md` — contract reclassification

Moved `oklch_shift.py` from the **detector** contract (exit 0/1 only) to the **generator/validator** contract (exit 0/1/2; data on stdout, errors on stderr), matching its actual transformer behavior. Inline note documents the exit-code contract.

### 5. `CHANGELOG.md` — `--with-style-tune` wording

Corrected the entry to match what the script actually does: it seeds `light.css` + `dark.css` from a baseline palette only. Component vendoring (`/kit-add`) still requires an interactive Claude Code session, as the script itself notes in `RECIPE.md`.

## Test plan

- [x] `tests/run.sh` — all seven steps green.
- [x] `generate_palette.py` byte-identity verified against five canonical seeds (`#2563eb`, `#7c3aed`, `#16a34a`, `#dc2626`, `#0f766e`).
- [x] `oklch_shift.py` smoke-tested for warmer (clean), clamped lightness (`#000000 --lightness=-0.5`), clamped chroma (`--chroma=-0.5`), and invalid hex (still exit 2).

https://claude.ai/code/session_01Nr6Gi1QdEAqY6PChA3RtwS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr6Gi1QdEAqY6PChA3RtwS)_