### PR TITLE
Add acss-utilities plugin for Tailwind-style atomic CSS

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "agentic-acss-plugins",
-  "description": "Claude Code plugin for building accessible React components and CSS themes for fpkit/acss projects",
+  "description": "Claude Code plugins for building accessible React components, CSS themes, and utility classes for fpkit/acss projects",
   "owner": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/agentic-acss-plugins"
@@ -24,6 +24,22 @@
         "oklch",
         "sass",
         "typescript"
+      ]
+    },
+    {
+      "name": "acss-utilities",
+      "source": "./plugins/acss-utilities",
+      "description": "Tailwind-style atomic CSS utility classes for fpkit/acss projects, mirroring @fpkit/acss@6.5.0 conventions (.bg-primary, .mt-4, .sm:hide, etc.). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH roles to fpkit-style names in both light and dark modes. Run /utility-add to drop the bundle into your project.",
+      "category": "development",
+      "tags": [
+        "utility-classes",
+        "atomic-css",
+        "tailwind-style",
+        "fpkit",
+        "acss",
+        "css",
+        "responsive",
+        "css-variables"
       ]
     }
   ]

--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "plugins/acss-kit/scripts/**"
+  - "plugins/*/scripts/**"
 ---
 
 # Python Script Contracts
@@ -16,6 +16,12 @@ Current scripts in `plugins/acss-kit/scripts/`:
 - `tokens_to_css.py` — converts palette JSON to CSS custom property files
 - `validate_theme.py` — checks theme CSS files for WCAG 2.2 AA contrast on semantic role pairs
 
+Current scripts in `plugins/acss-utilities/scripts/`:
+
+- `detect_utility_target.py` — detects the target React project + drop directory for `utilities.css`. Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and reads the same `.acss-target.json` (with an added `utilitiesDir` field)
+- `generate_utilities.py` — reads `utilities.tokens.json` and emits per-family CSS partials + a concatenated `utilities.css`. Generator/validator contract; either streams the bundle to stdout or writes to a directory via `--out-dir`
+- `validate_utilities.py` — validates utility CSS files: kebab-case selectors, `var()` fallbacks, no duplicate selectors, responsive parity across breakpoints, bundle-size budget, and `token-bridge.css` `:root` ↔ `[data-theme="dark"]` parity. Generator/validator contract (data + reasons array on stdout, exit 0/1/2)
+
 ## Detector contract (machine-callable, structured)
 
 For scripts whose output is parsed by slash commands or skills.
@@ -24,7 +30,7 @@ For scripts whose output is parsed by slash commands or skills.
 - Exit 0 on success, 1 on logical failure (e.g. nothing detected)
 - Always include a `"reasons"` array in the JSON — empty `[]` on success, populated on failure
 
-Detectors: `detect_target.py`, `detect_package_manager.py`.
+Detectors: `detect_target.py`, `detect_package_manager.py`, `detect_utility_target.py`.
 
 ## Generator / validator contract (pipeline-friendly, human-readable)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,17 @@
         "hooks": [
           {
             "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; if [[ \"$f\" =~ plugins/acss-utilities/assets/.*\\.css$ ]]; then python3 plugins/acss-utilities/scripts/validate_utilities.py \"$f\" 2>&1; fi; }",
+            "timeout": 15,
+            "statusMessage": "Validating utility CSS..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "jq -r '.tool_input.file_path // empty' | { read -r f; if [[ \"$f\" == *.json ]]; then python3 -c \"import json,sys; json.load(open(sys.argv[1]))\" \"$f\" 2>&1; fi; }",
             "timeout": 10,
             "statusMessage": "Validating JSON..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,17 @@ A Claude Code **plugin marketplace** — not a Node.js or Python package. There 
 
 **Stack:** Claude Code plugin format, Python 3 (scripts), SCSS/CSS custom properties (generated output).
 
-The repo contains a single plugin:
+The repo contains two plugins:
 
 - `plugins/acss-kit` — accessible React components and CSS themes for fpkit/acss projects. Two top-level skills (`components`, `styles`) plus the `component-form` pilot skill.
+- `plugins/acss-utilities` — Tailwind-style atomic CSS utility classes paired with `acss-kit`'s OKLCH theme tokens via a bridge file. Generator + validator + four `/utility-*` commands. See [`plugins/acss-utilities/docs/`](plugins/acss-utilities/docs/README.md) for the developer guide.
 
 Install from a Claude Code session:
 
 ```text
 /plugin marketplace add shawn-sandy/agentic-acss-plugins
 /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
+/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Plugin structure

--- a/plugins/acss-utilities/.claude-plugin/plugin.json
+++ b/plugins/acss-utilities/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "acss-utilities",
+  "description": "CSS utility-class plugin for fpkit/acss projects. Tailwind-style atomic classes (.bg-primary, .mt-4, .sm:hide) generated from a token source-of-truth, with a token-bridge that aliases acss-kit's OKLCH roles to fpkit-style names.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Shawn Sandy",
+    "url": "https://github.com/shawn-sandy/acss"
+  },
+  "license": "MIT"
+}

--- a/plugins/acss-utilities/ATTRIBUTION.md
+++ b/plugins/acss-utilities/ATTRIBUTION.md
@@ -1,0 +1,45 @@
+# Attribution
+
+This plugin's class-naming conventions, family inventory, and breakpoint values are patterned on the upstream [`fpkit/acss`](https://github.com/shawn-sandy/acss) project. fpkit ships under MIT, as does this plugin.
+
+## Upstream pin
+
+The plugin tracks **`@fpkit/acss@6.5.0`** (the same pin used by `acss-kit`'s component-author skill). Re-verification after upstream tag bumps is a maintainer responsibility — see the deferred `utility-sync` skill noted in the v1 plan.
+
+## What we mirror verbatim
+
+- **Class names** for color (`.bg-*`, `.text-*`, `.border-*`), display (`.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`), responsive variants (`.sm:hide`, `.md:show`, `.lg:invisible`, `.xl:hide`, `.print:hide`), and the `:` separator (escaped as `\:` in CSS).
+- **Breakpoints**: `sm: 30rem`, `md: 48rem`, `lg: 62rem`, `xl: 80rem`. Identical to `_display.scss` in upstream.
+- **`!important` policy** for display/visibility utilities (matches `_display.scss`).
+
+Per-family upstream sources (when applicable):
+
+| Family | Upstream file |
+|---|---|
+| `color-bg` | [`packages/fpkit/src/sass/utilities/_color-bg.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/utilities/_color-bg.scss) |
+| `color-text` | [`packages/fpkit/src/sass/utilities/_color-text.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/utilities/_color-text.scss) |
+| `color-border` | [`packages/fpkit/src/sass/utilities/_color-border.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/utilities/_color-border.scss) |
+| `display` | [`packages/fpkit/src/sass/utilities/_display.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/utilities/_display.scss) |
+| `flex` (sibling) | [`packages/fpkit/src/sass/_layout.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/_layout.scss) |
+| `grid` (sibling) | [`packages/fpkit/src/sass/_grid.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/_grid.scss) |
+| `type` (sibling) | [`packages/fpkit/src/sass/_type.scss`](https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/sass/_type.scss) |
+
+## What this plugin extends beyond fpkit
+
+These families are not yet present in fpkit upstream and are added by this plugin in line with conventional atomic-CSS naming. They follow the same kebab-case, no-prefix style and the same responsive-variant syntax.
+
+- `spacing` — `m`, `mt/mb/ml/mr/mx/my`, `p`, `pt/pb/pl/pr/px/py`, `gap`. Driven by `utilities.tokens.json#spacing.scale`.
+- `radius` — `rounded`, `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-full`.
+- `shadow` — `shadow-sm`, `shadow-md`, `shadow-lg`, `shadow-xl`, `shadow-none`.
+- `position` — `static`, `relative`, `absolute`, `fixed`, `sticky`.
+- `z-index` — `z-0`, `z-10`, `z-20`, `z-30`, `z-40`, `z-50`, `z-auto`.
+
+When fpkit upstream adds an equivalent family, this plugin's classes will be reconciled (the v1 deferred `utility-sync` skill will handle the diff).
+
+## Token-naming bridge
+
+fpkit upstream references token names that are not present in `acss-kit`'s role catalogue (e.g. `--color-error`, `--color-error-bg`, `--color-primary-light`). The plugin ships `assets/token-bridge.css` to alias `acss-kit`'s names (`--color-danger`, `--color-primary`, etc.) to the fpkit-style names that the utility classes reference, in both `:root` and `[data-theme="dark"]`. See [`skills/utilities/references/token-bridge.md`](skills/utilities/references/token-bridge.md) for the full mapping.
+
+## License
+
+MIT — same as `acss-kit` and fpkit upstream.

--- a/plugins/acss-utilities/CHANGELOG.md
+++ b/plugins/acss-utilities/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 
 ## [Unreleased]
 
+### Added
+
+- **`docs/`** — developer guide tree mirroring `acss-kit/docs/`: `README.md`, `tutorial.md`, `concepts.md`, `commands.md`, `recipes.md`, `troubleshooting.md`, `architecture.md`. `visual-guide.md` deferred.
+
+### Fixed
+
+- **README:** add hex fallbacks to the token-bridge snippet so it matches the shipped `assets/token-bridge.css` and the documented bridge contract.
+- **README:** replace the non-existent `color` family in `/utility-add --families=…` and `/utility-list` examples with real ids (`color-bg`, `color-text`, `color-border`).
+- **`utility-catalogue.md`:** correct the spacing class-count math (`210 base + 210 × 4 bps = 1050`) and the `display` responsive count (only `hide`/`show`/`invisible` get breakpoint variants); fix the `.px-6` example (padding, not margin).
+- **`detect_utility_target.py`:** only honor `.acss-target.json#utilitiesDir` when `(projectRoot / utilitiesDir)` actually exists; otherwise fall back to `src/styles`.
+- **`utilities.tokens.json`:** drop the dangling `$schema: "./utilities.tokens.schema.json"` pointer — the schema file does not ship in the plugin.
+- **`validate_utilities.py`:** read `bundleSizeBudgetKb` from a co-located `utilities.tokens.json` when `--max-kb` is not passed, so the token field is no longer dead. CLI flag still wins.
+
 ## [0.1.0] - 2026-04-28
 
 ### Added

--- a/plugins/acss-utilities/CHANGELOG.md
+++ b/plugins/acss-utilities/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 ### Added
 
 - **`docs/`** — developer guide tree mirroring `acss-kit/docs/`: `README.md`, `tutorial.md`, `concepts.md`, `commands.md`, `recipes.md`, `troubleshooting.md`, `architecture.md`. `visual-guide.md` deferred.
+- **`tests/run.sh` integration** — Step 8 runs `validate_utilities.py` over `plugins/acss-utilities/assets/`; Step 9 regenerates the bundle from `utilities.tokens.json` and diffs against the committed copy (idempotency check). Both steps no-op gracefully if the plugin tree is missing. Bad-fixture self-tests are still deferred.
 
 ### Fixed
 
@@ -16,6 +17,8 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 - **`detect_utility_target.py`:** only honor `.acss-target.json#utilitiesDir` when `(projectRoot / utilitiesDir)` actually exists; otherwise fall back to `src/styles`.
 - **`utilities.tokens.json`:** drop the dangling `$schema: "./utilities.tokens.schema.json"` pointer — the schema file does not ship in the plugin.
 - **`validate_utilities.py`:** read `bundleSizeBudgetKb` from a co-located `utilities.tokens.json` when `--max-kb` is not passed, so the token field is no longer dead. CLI flag still wins.
+- **`validate_utilities.py`:** distinct context per `@media` condition for the duplicate-selector check, so a class can legitimately appear under two different breakpoints; reject unrecognised single-file targets with a usage error (exit 2) instead of running the validator against an unrelated stylesheet; correct the `seen_selectors` type annotation to `Dict[Tuple[str, str], int]`.
+- **`generate_utilities.py`:** drop unused `os` import.
 
 ## [0.1.0] - 2026-04-28
 
@@ -32,4 +35,4 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 - **Token bridge** — `assets/token-bridge.css` aliases acss-kit's `--color-danger`, `--color-primary`, etc. to fpkit-style names (`--color-error`, `--color-error-bg`, `--color-primary-light`) in both `:root` and `[data-theme="dark"]`.
 - **Source-of-truth** — `assets/utilities.tokens.json` is the canonical input for the generator. Includes spacing scale, breakpoints, color role list, family-enable map, and bundle-size budget.
 - **Maintainer skills** — `.claude/skills/utility-author/` (scaffold a new family) and `.claude/skills/utility-update/` (re-validate after token-bridge or naming changes) live in the project, not the plugin.
-- **Tests** — `tests/run.sh` adds a CSS contract check, an idempotency check (regenerate + diff against committed bundle), and four bad-fixture self-tests (PascalCase selector, missing `var()` fallback, missing `[data-theme="dark"]` alias, oversize bundle).
+- **Validation tooling** — the initial release ships `scripts/validate_utilities.py` and `scripts/generate_utilities.py`. Wiring these into the shared `tests/run.sh` harness (CSS contract + idempotency check) and adding bad-fixture self-tests was deferred past `0.1.0`; see the `[Unreleased]` block.

--- a/plugins/acss-utilities/CHANGELOG.md
+++ b/plugins/acss-utilities/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the `acss-utilities` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the plugin adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-28
+
+### Added
+
+- **Initial release.** Sibling plugin to `acss-kit` providing a Tailwind-style atomic CSS layer for fpkit/acss projects. Mirrors fpkit upstream class conventions (kebab-case, no prefix, responsive `sm:`/`md:`/`lg:`/`xl:` variants via escaped colons).
+- **`/utility-add [--target=<dir>] [--families=<list>] [--no-bridge]`** — copy `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into a target React project. Defaults to the bundled full atomic suite; `--families=color,spacing` filters.
+- **`/utility-list [family]`** — read-only catalogue printer. No-arg lists every utility family; with a family argument prints every class and the CSS custom property it references.
+- **`/utility-tune <natural-language>`** — adjust the spacing baseline, breakpoints, or family list via natural language. Edits `assets/utilities.tokens.json`, regenerates the bundle, runs the validator.
+- **`/utility-bridge [--theme=<file>]`** — regenerate `token-bridge.css` aliases against the user's active acss-kit theme. Always emits both `:root` and `[data-theme="dark"]` blocks.
+- **`scripts/generate_utilities.py`** — generator that reads `utilities.tokens.json` and emits `utilities.css` + per-family partials. Stdlib only; data on stdout, errors on stderr; exit 0/1/2.
+- **`scripts/validate_utilities.py`** — validator for utility CSS. Enforces kebab-case selectors, mandatory `var()` fallbacks, dark-mode bridge parity, no duplicate selectors, and an 80&nbsp;KB bundle-size budget. Exit 0 on pass.
+- **`scripts/detect_utility_target.py`** — detector for the React target project. Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and `.acss-target.json` schema; suggests a default drop location at `src/styles/utilities.css`.
+- **Token bridge** — `assets/token-bridge.css` aliases acss-kit's `--color-danger`, `--color-primary`, etc. to fpkit-style names (`--color-error`, `--color-error-bg`, `--color-primary-light`) in both `:root` and `[data-theme="dark"]`.
+- **Source-of-truth** — `assets/utilities.tokens.json` is the canonical input for the generator. Includes spacing scale, breakpoints, color role list, family-enable map, and bundle-size budget.
+- **Maintainer skills** — `.claude/skills/utility-author/` (scaffold a new family) and `.claude/skills/utility-update/` (re-validate after token-bridge or naming changes) live in the project, not the plugin.
+- **Tests** — `tests/run.sh` adds a CSS contract check, an idempotency check (regenerate + diff against committed bundle), and four bad-fixture self-tests (PascalCase selector, missing `var()` fallback, missing `[data-theme="dark"]` alias, oversize bundle).

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -171,7 +171,7 @@ plugins/acss-utilities/
 tests/run.sh
 ```
 
-Runs the structural validation, CSS contract check, idempotency check (regenerate `utilities.css` and diff against the committed bundle), and four bad-fixture self-tests.
+Runs the shared structural-validation gate plus two `acss-utilities`-specific steps: the validator over `plugins/acss-utilities/assets/` (selector grammar, `var()` fallbacks, bridge dark-mode parity, bundle-size budget) and an idempotency check that regenerates the bundle from `utilities.tokens.json` and diffs against the committed copy. Bad-fixture self-tests are not yet wired in.
 
 ## License
 

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -1,0 +1,176 @@
+# acss-utilities
+
+A Claude Code plugin that adds a Tailwind-style atomic CSS layer to fpkit/acss projects. Generates a single `utilities.css` (committed bundle) and a `token-bridge.css` that aliases the [`acss-kit`](../acss-kit) plugin's OKLCH color roles to the fpkit-style names utility classes reference.
+
+## Pairs with `acss-kit`
+
+This plugin is designed to sit alongside `acss-kit`. `acss-kit` owns components and themes; `acss-utilities` owns the utility-class layer. They are decoupled — install one, both, or use `acss-utilities` standalone with a hand-written theme.
+
+| Plugin | Owns |
+|---|---|
+| [`acss-kit`](../acss-kit) | Components, themes (light/dark/brand), OKLCH role catalogue |
+| `acss-utilities` (this) | Utility classes (`.bg-primary`, `.mt-4`, `.sm:hide`), token-bridge |
+
+## Why utility classes
+
+Components in `acss-kit` already get scoped CSS variables and `data-*` variants. Utility classes complement that with **layout glue** (spacing between cards, responsive show/hide, quick color overrides) without authoring new SCSS files. The plugin's class names are patterned on fpkit upstream so behavior is portable to other fpkit projects without a runtime dependency.
+
+## Installation
+
+```shell
+/plugin marketplace add shawn-sandy/agentic-acss-plugins
+/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins
+```
+
+If you also want `acss-kit`:
+
+```shell
+/plugin install acss-kit@shawn-sandy-agentic-acss-plugins
+```
+
+## Quick start
+
+```shell
+/utility-add
+```
+
+Auto-detects your React project root, copies `utilities.css` into `src/styles/utilities.css`, and copies `token-bridge.css` alongside. Add the imports to your app entry:
+
+```ts
+import "./styles/token-bridge.css";   // first — defines fpkit-style aliases
+import "./styles/utilities.css";       // then — utility classes consume them
+```
+
+If `acss-kit` is also installed, the bridge will resolve `--color-error`, `--color-primary-light`, etc. against acss-kit's `--color-danger`, `--color-primary`, … in both light and dark modes.
+
+## Commands
+
+### `/utility-add [--target=<dir>] [--families=<list>] [--no-bridge]`
+
+Copy `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into the target. With `--families=color,spacing` only those family partials are copied (still concatenated into a single file).
+
+```shell
+/utility-add
+/utility-add --target=apps/web/src/styles
+/utility-add --families=color,spacing,display
+/utility-add --no-bridge   # using your own theme without acss-kit
+```
+
+### `/utility-list [family]`
+
+Read-only catalogue. No-arg lists every family; pass a family name to print every class in that family with the CSS custom property it references.
+
+```shell
+/utility-list
+/utility-list color
+/utility-list spacing
+```
+
+### `/utility-tune <natural-language>`
+
+Adjust the spacing baseline, breakpoints, or family list via natural language. Edits `assets/utilities.tokens.json`, regenerates the bundle, runs the validator.
+
+```shell
+/utility-tune use a 4px spacing baseline
+/utility-tune add an xs breakpoint at 20rem
+/utility-tune disable shadow utilities
+```
+
+### `/utility-bridge [--theme=<file>]`
+
+Regenerate `token-bridge.css` against your active acss-kit theme. Always emits both `:root` and `[data-theme="dark"]` blocks so utility colors resolve correctly in dark mode.
+
+```shell
+/utility-bridge                              # uses src/styles/theme/light.css + dark.css
+/utility-bridge --theme=apps/web/src/styles/theme/light.css
+```
+
+## Utility families (v1)
+
+Mirroring fpkit upstream where present, plus standard atomic-CSS additions (see [ATTRIBUTION.md](./ATTRIBUTION.md) for the upstream-vs-extended split):
+
+| Family | Class examples | Responsive |
+|---|---|---|
+| `color-bg` | `.bg-primary`, `.bg-success`, `.bg-error`, `.bg-surface`, `.bg-transparent` | no |
+| `color-text` | `.text-primary`, `.text-error`, `.text-muted` | no |
+| `color-border` | `.border-primary`, `.border-error`, `.border-muted` | no |
+| `display` | `.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`, `.print:hide` | yes |
+| `spacing` | `.m-4`, `.mt-2`, `.px-6`, `.gap-3` | yes |
+| `flex` | `.flex`, `.flex-col`, `.justify-center`, `.items-center` | yes |
+| `grid` | `.grid`, `.grid-cols-2`, `.grid-cols-12` | yes |
+| `type` | `.text-xs`, `.text-base`, `.text-lg`, `.font-bold` | no |
+| `radius` | `.rounded-sm`, `.rounded-md`, `.rounded-lg`, `.rounded-full` | no |
+| `shadow` | `.shadow-sm`, `.shadow-md`, `.shadow-lg` | no |
+| `position` | `.relative`, `.absolute`, `.fixed`, `.sticky` | no |
+| `z-index` | `.z-10`, `.z-20`, `.z-50`, `.z-auto` | no |
+
+Responsive variants use the `:` separator escaped to `\:` in CSS — e.g. `.sm:hide` is written as `.sm\:hide` in the stylesheet but used as `<div className="sm:hide">…` in JSX. Breakpoints: `sm: 30rem`, `md: 48rem`, `lg: 62rem`, `xl: 80rem`.
+
+## Token bridge
+
+`utilities.css` references fpkit-style token names (`--color-error`, `--color-primary-light`, `--color-success-bg`). `acss-kit`'s role catalogue uses different names (`--color-danger`, no `-light` or `-bg` variants). `token-bridge.css` aliases between them:
+
+```css
+:root {
+  --color-error: var(--color-danger, #dc2626);
+  --color-error-bg: color-mix(in oklch, var(--color-danger) 12%, var(--color-background));
+  --color-primary-light: color-mix(in oklch, var(--color-primary) 80%, white);
+}
+[data-theme="dark"] {
+  --color-error: var(--color-danger, #f87171);
+  --color-error-bg: color-mix(in oklch, var(--color-danger) 18%, var(--color-background));
+  --color-primary-light: color-mix(in oklch, var(--color-primary) 70%, black);
+}
+```
+
+The full mapping is in [`skills/utilities/references/token-bridge.md`](skills/utilities/references/token-bridge.md). The validator enforces that every alias defined in `:root` also appears in `[data-theme="dark"]`.
+
+## Plugin structure
+
+```
+plugins/acss-utilities/
+├── .claude-plugin/plugin.json
+├── README.md
+├── CHANGELOG.md
+├── ATTRIBUTION.md
+├── commands/
+│   ├── utility-add.md
+│   ├── utility-list.md
+│   ├── utility-tune.md
+│   └── utility-bridge.md
+├── skills/utilities/
+│   ├── SKILL.md
+│   └── references/
+│       ├── utility-catalogue.md
+│       ├── naming-convention.md
+│       ├── breakpoints.md
+│       └── token-bridge.md
+├── scripts/
+│   ├── generate_utilities.py
+│   ├── validate_utilities.py
+│   └── detect_utility_target.py
+└── assets/
+    ├── utilities.css                    # committed bundle
+    ├── utilities/                       # per-family partials
+    ├── token-bridge.css
+    └── utilities.tokens.json            # source-of-truth
+```
+
+## What this plugin is **not**
+
+- Not a component generator (`acss-kit` owns components).
+- Not a theme generator (`acss-kit` owns themes; this plugin only consumes them via the bridge).
+- Not a CSS framework with a JS runtime — it ships a CSS file and a bridge. No React components.
+- Not a JIT/purge tool. v1 emits the full bundle; scan-and-emit is deferred to v2.
+
+## Verification
+
+```sh
+tests/run.sh
+```
+
+Runs the structural validation, CSS contract check, idempotency check (regenerate `utilities.css` and diff against the committed bundle), and four bad-fixture self-tests.
+
+## License
+
+MIT. See [ATTRIBUTION.md](./ATTRIBUTION.md) for upstream credits.

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -47,12 +47,12 @@ If `acss-kit` is also installed, the bridge will resolve `--color-error`, `--col
 
 ### `/utility-add [--target=<dir>] [--families=<list>] [--no-bridge]`
 
-Copy `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into the target. With `--families=color,spacing` only those family partials are copied (still concatenated into a single file).
+Copy `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into the target. With `--families=color-bg,spacing` only those family partials are copied (still concatenated into a single file). Family names match `assets/utilities.tokens.json#families` (`color-bg`, `color-text`, `color-border`, `spacing`, `display`, `flex`, `grid`, `type`, `radius`, `shadow`, `position`, `z-index`).
 
 ```shell
 /utility-add
 /utility-add --target=apps/web/src/styles
-/utility-add --families=color,spacing,display
+/utility-add --families=color-bg,color-text,spacing,display
 /utility-add --no-bridge   # using your own theme without acss-kit
 ```
 
@@ -62,7 +62,7 @@ Read-only catalogue. No-arg lists every family; pass a family name to print ever
 
 ```shell
 /utility-list
-/utility-list color
+/utility-list color-bg
 /utility-list spacing
 ```
 
@@ -113,13 +113,13 @@ Responsive variants use the `:` separator escaped to `\:` in CSS — e.g. `.sm:h
 ```css
 :root {
   --color-error: var(--color-danger, #dc2626);
-  --color-error-bg: color-mix(in oklch, var(--color-danger) 12%, var(--color-background));
-  --color-primary-light: color-mix(in oklch, var(--color-primary) 80%, white);
+  --color-error-bg: color-mix(in oklch, var(--color-danger, #dc2626) 12%, var(--color-background, #ffffff));
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #2563eb) 80%, white);
 }
 [data-theme="dark"] {
   --color-error: var(--color-danger, #f87171);
-  --color-error-bg: color-mix(in oklch, var(--color-danger) 18%, var(--color-background));
-  --color-primary-light: color-mix(in oklch, var(--color-primary) 70%, black);
+  --color-error-bg: color-mix(in oklch, var(--color-danger, #f87171) 18%, var(--color-background, #0f172a));
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #7dd3fc) 70%, black);
 }
 ```
 

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -2,6 +2,8 @@
 
 A Claude Code plugin that adds a Tailwind-style atomic CSS layer to fpkit/acss projects. Generates a single `utilities.css` (committed bundle) and a `token-bridge.css` that aliases the [`acss-kit`](../acss-kit) plugin's OKLCH color roles to the fpkit-style names utility classes reference.
 
+For a guided walkthrough, mental model, command reference, recipes, troubleshooting, and maintainer architecture, see the [developer guide in `docs/`](docs/README.md).
+
 ## Pairs with `acss-kit`
 
 This plugin is designed to sit alongside `acss-kit`. `acss-kit` owns components and themes; `acss-utilities` owns the utility-class layer. They are decoupled — install one, both, or use `acss-utilities` standalone with a hand-written theme.

--- a/plugins/acss-utilities/assets/token-bridge.css
+++ b/plugins/acss-utilities/assets/token-bridge.css
@@ -1,0 +1,52 @@
+/*
+ * acss-utilities — token bridge
+ *
+ * Aliases acss-kit's role names (`--color-danger`, `--color-primary`, …) to
+ * the fpkit-style token names that the utility classes reference
+ * (`--color-error`, `--color-error-bg`, `--color-primary-light`, …).
+ *
+ * Both `:root` and `[data-theme="dark"]` blocks are mandatory — utility
+ * classes that consume these aliases would otherwise fall back to light
+ * values when the page is in dark mode. The validator enforces parity.
+ *
+ * If acss-kit is not installed, every fallback hex is the resolved value
+ * — so this file works standalone too.
+ */
+
+:root {
+  /* Brand */
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #2563eb) 80%, white);
+
+  /* Semantic state — fpkit-style aliases. */
+  --color-error:         var(--color-danger, #dc2626);
+  --color-error-bg:      color-mix(in oklch, var(--color-danger, #dc2626) 12%, var(--color-background, #ffffff));
+  --color-success-bg:    color-mix(in oklch, var(--color-success, #16a34a) 12%, var(--color-background, #ffffff));
+  --color-warning-bg:    color-mix(in oklch, var(--color-warning, #ca8a04) 12%, var(--color-background, #ffffff));
+  --color-info-bg:       color-mix(in oklch, var(--color-info, #0284c7) 12%, var(--color-background, #ffffff));
+
+  /* Surface family — fpkit uses `--color-surface-secondary`; acss-kit
+     uses `--color-surface-raised`. Alias either name to the other for
+     mutual compatibility. */
+  --color-surface-secondary: var(--color-surface-raised, var(--color-surface, #f5f5f5));
+
+  /* Secondary brand — acss-kit doesn't define one; fall back to primary. */
+  --color-secondary: var(--color-primary, #2563eb);
+}
+
+[data-theme="dark"] {
+  /* Brand */
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #7dd3fc) 70%, black);
+
+  /* Semantic state — adjusted mix ratios for dark mode. */
+  --color-error:         var(--color-danger, #f87171);
+  --color-error-bg:      color-mix(in oklch, var(--color-danger, #f87171) 18%, var(--color-background, #0f172a));
+  --color-success-bg:    color-mix(in oklch, var(--color-success, #4ade80) 18%, var(--color-background, #0f172a));
+  --color-warning-bg:    color-mix(in oklch, var(--color-warning, #fbbf24) 18%, var(--color-background, #0f172a));
+  --color-info-bg:       color-mix(in oklch, var(--color-info, #38bdf8) 18%, var(--color-background, #0f172a));
+
+  /* Surface family */
+  --color-surface-secondary: var(--color-surface-raised, var(--color-surface, #1e293b));
+
+  /* Secondary brand */
+  --color-secondary: var(--color-primary, #7dd3fc);
+}

--- a/plugins/acss-utilities/assets/utilities.css
+++ b/plugins/acss-utilities/assets/utilities.css
@@ -1,0 +1,1436 @@
+/*
+ * acss-utilities v0.1.0
+ * Generated from utilities.tokens.json
+ * Mirrors fpkit upstream: @fpkit/acss@6.5.0
+ *
+ * Do not edit by hand. Regenerate via `generate_utilities.py`.
+ */
+
+
+/* color-bg utilities */
+.bg-primary { background-color: var(--color-primary, transparent); }
+.bg-primary-light { background-color: var(--color-primary-light, transparent); }
+.bg-secondary { background-color: var(--color-secondary, transparent); }
+.bg-success { background-color: var(--color-success, transparent); }
+.bg-error { background-color: var(--color-error, transparent); }
+.bg-warning { background-color: var(--color-warning, transparent); }
+.bg-info { background-color: var(--color-info, transparent); }
+.bg-text { background-color: var(--color-text, transparent); }
+.bg-muted { background-color: var(--color-text-muted, transparent); }
+.bg-surface { background-color: var(--color-surface, transparent); }
+.bg-surface-secondary { background-color: var(--color-surface-secondary, transparent); }
+.bg-success-subtle { background-color: var(--color-success-bg, transparent); }
+.bg-error-subtle { background-color: var(--color-error-bg, transparent); }
+.bg-warning-subtle { background-color: var(--color-warning-bg, transparent); }
+.bg-info-subtle { background-color: var(--color-info-bg, transparent); }
+.bg-transparent { background-color: transparent; }
+
+/* color-text utilities */
+.text-primary { color: var(--color-primary, currentColor); }
+.text-primary-light { color: var(--color-primary-light, currentColor); }
+.text-secondary { color: var(--color-secondary, currentColor); }
+.text-success { color: var(--color-success, currentColor); }
+.text-error { color: var(--color-error, currentColor); }
+.text-warning { color: var(--color-warning, currentColor); }
+.text-info { color: var(--color-info, currentColor); }
+.text-text { color: var(--color-text, currentColor); }
+.text-muted { color: var(--color-text-muted, currentColor); }
+.text-surface { color: var(--color-surface, currentColor); }
+.text-surface-secondary { color: var(--color-surface-secondary, currentColor); }
+
+/* color-border utilities */
+.border-primary { border-color: var(--color-primary, currentColor); }
+.border-primary-light { border-color: var(--color-primary-light, currentColor); }
+.border-secondary { border-color: var(--color-secondary, currentColor); }
+.border-success { border-color: var(--color-success, currentColor); }
+.border-error { border-color: var(--color-error, currentColor); }
+.border-warning { border-color: var(--color-warning, currentColor); }
+.border-info { border-color: var(--color-info, currentColor); }
+.border-text { border-color: var(--color-text, currentColor); }
+.border-muted { border-color: var(--color-text-muted, currentColor); }
+.border-surface { border-color: var(--color-surface, currentColor); }
+.border-surface-secondary { border-color: var(--color-surface-secondary, currentColor); }
+
+/* spacing utilities */
+.m-0 { margin: 0; }
+.m-1 { margin: 0.25rem; }
+.m-2 { margin: 0.5rem; }
+.m-3 { margin: 0.75rem; }
+.m-4 { margin: 1rem; }
+.m-5 { margin: 1.25rem; }
+.m-6 { margin: 1.5rem; }
+.m-8 { margin: 2rem; }
+.m-10 { margin: 2.5rem; }
+.m-12 { margin: 3rem; }
+.m-16 { margin: 4rem; }
+.m-20 { margin: 5rem; }
+.m-24 { margin: 6rem; }
+.m-32 { margin: 8rem; }
+.mt-0 { margin-top: 0; }
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
+.mt-5 { margin-top: 1.25rem; }
+.mt-6 { margin-top: 1.5rem; }
+.mt-8 { margin-top: 2rem; }
+.mt-10 { margin-top: 2.5rem; }
+.mt-12 { margin-top: 3rem; }
+.mt-16 { margin-top: 4rem; }
+.mt-20 { margin-top: 5rem; }
+.mt-24 { margin-top: 6rem; }
+.mt-32 { margin-top: 8rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-5 { margin-bottom: 1.25rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+.mb-10 { margin-bottom: 2.5rem; }
+.mb-12 { margin-bottom: 3rem; }
+.mb-16 { margin-bottom: 4rem; }
+.mb-20 { margin-bottom: 5rem; }
+.mb-24 { margin-bottom: 6rem; }
+.mb-32 { margin-bottom: 8rem; }
+.ml-0 { margin-left: 0; }
+.ml-1 { margin-left: 0.25rem; }
+.ml-2 { margin-left: 0.5rem; }
+.ml-3 { margin-left: 0.75rem; }
+.ml-4 { margin-left: 1rem; }
+.ml-5 { margin-left: 1.25rem; }
+.ml-6 { margin-left: 1.5rem; }
+.ml-8 { margin-left: 2rem; }
+.ml-10 { margin-left: 2.5rem; }
+.ml-12 { margin-left: 3rem; }
+.ml-16 { margin-left: 4rem; }
+.ml-20 { margin-left: 5rem; }
+.ml-24 { margin-left: 6rem; }
+.ml-32 { margin-left: 8rem; }
+.mr-0 { margin-right: 0; }
+.mr-1 { margin-right: 0.25rem; }
+.mr-2 { margin-right: 0.5rem; }
+.mr-3 { margin-right: 0.75rem; }
+.mr-4 { margin-right: 1rem; }
+.mr-5 { margin-right: 1.25rem; }
+.mr-6 { margin-right: 1.5rem; }
+.mr-8 { margin-right: 2rem; }
+.mr-10 { margin-right: 2.5rem; }
+.mr-12 { margin-right: 3rem; }
+.mr-16 { margin-right: 4rem; }
+.mr-20 { margin-right: 5rem; }
+.mr-24 { margin-right: 6rem; }
+.mr-32 { margin-right: 8rem; }
+.mx-0 { margin-left: 0; margin-right: 0; }
+.mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.my-0 { margin-top: 0; margin-bottom: 0; }
+.my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.p-0 { padding: 0; }
+.p-1 { padding: 0.25rem; }
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 0.75rem; }
+.p-4 { padding: 1rem; }
+.p-5 { padding: 1.25rem; }
+.p-6 { padding: 1.5rem; }
+.p-8 { padding: 2rem; }
+.p-10 { padding: 2.5rem; }
+.p-12 { padding: 3rem; }
+.p-16 { padding: 4rem; }
+.p-20 { padding: 5rem; }
+.p-24 { padding: 6rem; }
+.p-32 { padding: 8rem; }
+.pt-0 { padding-top: 0; }
+.pt-1 { padding-top: 0.25rem; }
+.pt-2 { padding-top: 0.5rem; }
+.pt-3 { padding-top: 0.75rem; }
+.pt-4 { padding-top: 1rem; }
+.pt-5 { padding-top: 1.25rem; }
+.pt-6 { padding-top: 1.5rem; }
+.pt-8 { padding-top: 2rem; }
+.pt-10 { padding-top: 2.5rem; }
+.pt-12 { padding-top: 3rem; }
+.pt-16 { padding-top: 4rem; }
+.pt-20 { padding-top: 5rem; }
+.pt-24 { padding-top: 6rem; }
+.pt-32 { padding-top: 8rem; }
+.pb-0 { padding-bottom: 0; }
+.pb-1 { padding-bottom: 0.25rem; }
+.pb-2 { padding-bottom: 0.5rem; }
+.pb-3 { padding-bottom: 0.75rem; }
+.pb-4 { padding-bottom: 1rem; }
+.pb-5 { padding-bottom: 1.25rem; }
+.pb-6 { padding-bottom: 1.5rem; }
+.pb-8 { padding-bottom: 2rem; }
+.pb-10 { padding-bottom: 2.5rem; }
+.pb-12 { padding-bottom: 3rem; }
+.pb-16 { padding-bottom: 4rem; }
+.pb-20 { padding-bottom: 5rem; }
+.pb-24 { padding-bottom: 6rem; }
+.pb-32 { padding-bottom: 8rem; }
+.pl-0 { padding-left: 0; }
+.pl-1 { padding-left: 0.25rem; }
+.pl-2 { padding-left: 0.5rem; }
+.pl-3 { padding-left: 0.75rem; }
+.pl-4 { padding-left: 1rem; }
+.pl-5 { padding-left: 1.25rem; }
+.pl-6 { padding-left: 1.5rem; }
+.pl-8 { padding-left: 2rem; }
+.pl-10 { padding-left: 2.5rem; }
+.pl-12 { padding-left: 3rem; }
+.pl-16 { padding-left: 4rem; }
+.pl-20 { padding-left: 5rem; }
+.pl-24 { padding-left: 6rem; }
+.pl-32 { padding-left: 8rem; }
+.pr-0 { padding-right: 0; }
+.pr-1 { padding-right: 0.25rem; }
+.pr-2 { padding-right: 0.5rem; }
+.pr-3 { padding-right: 0.75rem; }
+.pr-4 { padding-right: 1rem; }
+.pr-5 { padding-right: 1.25rem; }
+.pr-6 { padding-right: 1.5rem; }
+.pr-8 { padding-right: 2rem; }
+.pr-10 { padding-right: 2.5rem; }
+.pr-12 { padding-right: 3rem; }
+.pr-16 { padding-right: 4rem; }
+.pr-20 { padding-right: 5rem; }
+.pr-24 { padding-right: 6rem; }
+.pr-32 { padding-right: 8rem; }
+.px-0 { padding-left: 0; padding-right: 0; }
+.px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+.px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.px-12 { padding-left: 3rem; padding-right: 3rem; }
+.px-16 { padding-left: 4rem; padding-right: 4rem; }
+.px-20 { padding-left: 5rem; padding-right: 5rem; }
+.px-24 { padding-left: 6rem; padding-right: 6rem; }
+.px-32 { padding-left: 8rem; padding-right: 8rem; }
+.py-0 { padding-top: 0; padding-bottom: 0; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.gap-0 { gap: 0; }
+.gap-1 { gap: 0.25rem; }
+.gap-2 { gap: 0.5rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-5 { gap: 1.25rem; }
+.gap-6 { gap: 1.5rem; }
+.gap-8 { gap: 2rem; }
+.gap-10 { gap: 2.5rem; }
+.gap-12 { gap: 3rem; }
+.gap-16 { gap: 4rem; }
+.gap-20 { gap: 5rem; }
+.gap-24 { gap: 6rem; }
+.gap-32 { gap: 8rem; }
+
+@media (width >= 30rem) {
+.sm\:m-0 { margin: 0; }
+.sm\:m-1 { margin: 0.25rem; }
+.sm\:m-2 { margin: 0.5rem; }
+.sm\:m-3 { margin: 0.75rem; }
+.sm\:m-4 { margin: 1rem; }
+.sm\:m-5 { margin: 1.25rem; }
+.sm\:m-6 { margin: 1.5rem; }
+.sm\:m-8 { margin: 2rem; }
+.sm\:m-10 { margin: 2.5rem; }
+.sm\:m-12 { margin: 3rem; }
+.sm\:m-16 { margin: 4rem; }
+.sm\:m-20 { margin: 5rem; }
+.sm\:m-24 { margin: 6rem; }
+.sm\:m-32 { margin: 8rem; }
+.sm\:mt-0 { margin-top: 0; }
+.sm\:mt-1 { margin-top: 0.25rem; }
+.sm\:mt-2 { margin-top: 0.5rem; }
+.sm\:mt-3 { margin-top: 0.75rem; }
+.sm\:mt-4 { margin-top: 1rem; }
+.sm\:mt-5 { margin-top: 1.25rem; }
+.sm\:mt-6 { margin-top: 1.5rem; }
+.sm\:mt-8 { margin-top: 2rem; }
+.sm\:mt-10 { margin-top: 2.5rem; }
+.sm\:mt-12 { margin-top: 3rem; }
+.sm\:mt-16 { margin-top: 4rem; }
+.sm\:mt-20 { margin-top: 5rem; }
+.sm\:mt-24 { margin-top: 6rem; }
+.sm\:mt-32 { margin-top: 8rem; }
+.sm\:mb-0 { margin-bottom: 0; }
+.sm\:mb-1 { margin-bottom: 0.25rem; }
+.sm\:mb-2 { margin-bottom: 0.5rem; }
+.sm\:mb-3 { margin-bottom: 0.75rem; }
+.sm\:mb-4 { margin-bottom: 1rem; }
+.sm\:mb-5 { margin-bottom: 1.25rem; }
+.sm\:mb-6 { margin-bottom: 1.5rem; }
+.sm\:mb-8 { margin-bottom: 2rem; }
+.sm\:mb-10 { margin-bottom: 2.5rem; }
+.sm\:mb-12 { margin-bottom: 3rem; }
+.sm\:mb-16 { margin-bottom: 4rem; }
+.sm\:mb-20 { margin-bottom: 5rem; }
+.sm\:mb-24 { margin-bottom: 6rem; }
+.sm\:mb-32 { margin-bottom: 8rem; }
+.sm\:ml-0 { margin-left: 0; }
+.sm\:ml-1 { margin-left: 0.25rem; }
+.sm\:ml-2 { margin-left: 0.5rem; }
+.sm\:ml-3 { margin-left: 0.75rem; }
+.sm\:ml-4 { margin-left: 1rem; }
+.sm\:ml-5 { margin-left: 1.25rem; }
+.sm\:ml-6 { margin-left: 1.5rem; }
+.sm\:ml-8 { margin-left: 2rem; }
+.sm\:ml-10 { margin-left: 2.5rem; }
+.sm\:ml-12 { margin-left: 3rem; }
+.sm\:ml-16 { margin-left: 4rem; }
+.sm\:ml-20 { margin-left: 5rem; }
+.sm\:ml-24 { margin-left: 6rem; }
+.sm\:ml-32 { margin-left: 8rem; }
+.sm\:mr-0 { margin-right: 0; }
+.sm\:mr-1 { margin-right: 0.25rem; }
+.sm\:mr-2 { margin-right: 0.5rem; }
+.sm\:mr-3 { margin-right: 0.75rem; }
+.sm\:mr-4 { margin-right: 1rem; }
+.sm\:mr-5 { margin-right: 1.25rem; }
+.sm\:mr-6 { margin-right: 1.5rem; }
+.sm\:mr-8 { margin-right: 2rem; }
+.sm\:mr-10 { margin-right: 2.5rem; }
+.sm\:mr-12 { margin-right: 3rem; }
+.sm\:mr-16 { margin-right: 4rem; }
+.sm\:mr-20 { margin-right: 5rem; }
+.sm\:mr-24 { margin-right: 6rem; }
+.sm\:mr-32 { margin-right: 8rem; }
+.sm\:mx-0 { margin-left: 0; margin-right: 0; }
+.sm\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.sm\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.sm\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.sm\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.sm\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.sm\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.sm\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.sm\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.sm\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.sm\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.sm\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.sm\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.sm\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.sm\:my-0 { margin-top: 0; margin-bottom: 0; }
+.sm\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.sm\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.sm\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.sm\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.sm\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.sm\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.sm\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.sm\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.sm\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.sm\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.sm\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.sm\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.sm\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.sm\:p-0 { padding: 0; }
+.sm\:p-1 { padding: 0.25rem; }
+.sm\:p-2 { padding: 0.5rem; }
+.sm\:p-3 { padding: 0.75rem; }
+.sm\:p-4 { padding: 1rem; }
+.sm\:p-5 { padding: 1.25rem; }
+.sm\:p-6 { padding: 1.5rem; }
+.sm\:p-8 { padding: 2rem; }
+.sm\:p-10 { padding: 2.5rem; }
+.sm\:p-12 { padding: 3rem; }
+.sm\:p-16 { padding: 4rem; }
+.sm\:p-20 { padding: 5rem; }
+.sm\:p-24 { padding: 6rem; }
+.sm\:p-32 { padding: 8rem; }
+.sm\:pt-0 { padding-top: 0; }
+.sm\:pt-1 { padding-top: 0.25rem; }
+.sm\:pt-2 { padding-top: 0.5rem; }
+.sm\:pt-3 { padding-top: 0.75rem; }
+.sm\:pt-4 { padding-top: 1rem; }
+.sm\:pt-5 { padding-top: 1.25rem; }
+.sm\:pt-6 { padding-top: 1.5rem; }
+.sm\:pt-8 { padding-top: 2rem; }
+.sm\:pt-10 { padding-top: 2.5rem; }
+.sm\:pt-12 { padding-top: 3rem; }
+.sm\:pt-16 { padding-top: 4rem; }
+.sm\:pt-20 { padding-top: 5rem; }
+.sm\:pt-24 { padding-top: 6rem; }
+.sm\:pt-32 { padding-top: 8rem; }
+.sm\:pb-0 { padding-bottom: 0; }
+.sm\:pb-1 { padding-bottom: 0.25rem; }
+.sm\:pb-2 { padding-bottom: 0.5rem; }
+.sm\:pb-3 { padding-bottom: 0.75rem; }
+.sm\:pb-4 { padding-bottom: 1rem; }
+.sm\:pb-5 { padding-bottom: 1.25rem; }
+.sm\:pb-6 { padding-bottom: 1.5rem; }
+.sm\:pb-8 { padding-bottom: 2rem; }
+.sm\:pb-10 { padding-bottom: 2.5rem; }
+.sm\:pb-12 { padding-bottom: 3rem; }
+.sm\:pb-16 { padding-bottom: 4rem; }
+.sm\:pb-20 { padding-bottom: 5rem; }
+.sm\:pb-24 { padding-bottom: 6rem; }
+.sm\:pb-32 { padding-bottom: 8rem; }
+.sm\:pl-0 { padding-left: 0; }
+.sm\:pl-1 { padding-left: 0.25rem; }
+.sm\:pl-2 { padding-left: 0.5rem; }
+.sm\:pl-3 { padding-left: 0.75rem; }
+.sm\:pl-4 { padding-left: 1rem; }
+.sm\:pl-5 { padding-left: 1.25rem; }
+.sm\:pl-6 { padding-left: 1.5rem; }
+.sm\:pl-8 { padding-left: 2rem; }
+.sm\:pl-10 { padding-left: 2.5rem; }
+.sm\:pl-12 { padding-left: 3rem; }
+.sm\:pl-16 { padding-left: 4rem; }
+.sm\:pl-20 { padding-left: 5rem; }
+.sm\:pl-24 { padding-left: 6rem; }
+.sm\:pl-32 { padding-left: 8rem; }
+.sm\:pr-0 { padding-right: 0; }
+.sm\:pr-1 { padding-right: 0.25rem; }
+.sm\:pr-2 { padding-right: 0.5rem; }
+.sm\:pr-3 { padding-right: 0.75rem; }
+.sm\:pr-4 { padding-right: 1rem; }
+.sm\:pr-5 { padding-right: 1.25rem; }
+.sm\:pr-6 { padding-right: 1.5rem; }
+.sm\:pr-8 { padding-right: 2rem; }
+.sm\:pr-10 { padding-right: 2.5rem; }
+.sm\:pr-12 { padding-right: 3rem; }
+.sm\:pr-16 { padding-right: 4rem; }
+.sm\:pr-20 { padding-right: 5rem; }
+.sm\:pr-24 { padding-right: 6rem; }
+.sm\:pr-32 { padding-right: 8rem; }
+.sm\:px-0 { padding-left: 0; padding-right: 0; }
+.sm\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.sm\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.sm\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.sm\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.sm\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.sm\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.sm\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.sm\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.sm\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.sm\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.sm\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.sm\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.sm\:py-0 { padding-top: 0; padding-bottom: 0; }
+.sm\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.sm\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.sm\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.sm\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.sm\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.sm\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.sm\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.sm\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.sm\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.sm\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.sm\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.sm\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.sm\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.sm\:gap-0 { gap: 0; }
+.sm\:gap-1 { gap: 0.25rem; }
+.sm\:gap-2 { gap: 0.5rem; }
+.sm\:gap-3 { gap: 0.75rem; }
+.sm\:gap-4 { gap: 1rem; }
+.sm\:gap-5 { gap: 1.25rem; }
+.sm\:gap-6 { gap: 1.5rem; }
+.sm\:gap-8 { gap: 2rem; }
+.sm\:gap-10 { gap: 2.5rem; }
+.sm\:gap-12 { gap: 3rem; }
+.sm\:gap-16 { gap: 4rem; }
+.sm\:gap-20 { gap: 5rem; }
+.sm\:gap-24 { gap: 6rem; }
+.sm\:gap-32 { gap: 8rem; }
+}
+@media (width >= 48rem) {
+.md\:m-0 { margin: 0; }
+.md\:m-1 { margin: 0.25rem; }
+.md\:m-2 { margin: 0.5rem; }
+.md\:m-3 { margin: 0.75rem; }
+.md\:m-4 { margin: 1rem; }
+.md\:m-5 { margin: 1.25rem; }
+.md\:m-6 { margin: 1.5rem; }
+.md\:m-8 { margin: 2rem; }
+.md\:m-10 { margin: 2.5rem; }
+.md\:m-12 { margin: 3rem; }
+.md\:m-16 { margin: 4rem; }
+.md\:m-20 { margin: 5rem; }
+.md\:m-24 { margin: 6rem; }
+.md\:m-32 { margin: 8rem; }
+.md\:mt-0 { margin-top: 0; }
+.md\:mt-1 { margin-top: 0.25rem; }
+.md\:mt-2 { margin-top: 0.5rem; }
+.md\:mt-3 { margin-top: 0.75rem; }
+.md\:mt-4 { margin-top: 1rem; }
+.md\:mt-5 { margin-top: 1.25rem; }
+.md\:mt-6 { margin-top: 1.5rem; }
+.md\:mt-8 { margin-top: 2rem; }
+.md\:mt-10 { margin-top: 2.5rem; }
+.md\:mt-12 { margin-top: 3rem; }
+.md\:mt-16 { margin-top: 4rem; }
+.md\:mt-20 { margin-top: 5rem; }
+.md\:mt-24 { margin-top: 6rem; }
+.md\:mt-32 { margin-top: 8rem; }
+.md\:mb-0 { margin-bottom: 0; }
+.md\:mb-1 { margin-bottom: 0.25rem; }
+.md\:mb-2 { margin-bottom: 0.5rem; }
+.md\:mb-3 { margin-bottom: 0.75rem; }
+.md\:mb-4 { margin-bottom: 1rem; }
+.md\:mb-5 { margin-bottom: 1.25rem; }
+.md\:mb-6 { margin-bottom: 1.5rem; }
+.md\:mb-8 { margin-bottom: 2rem; }
+.md\:mb-10 { margin-bottom: 2.5rem; }
+.md\:mb-12 { margin-bottom: 3rem; }
+.md\:mb-16 { margin-bottom: 4rem; }
+.md\:mb-20 { margin-bottom: 5rem; }
+.md\:mb-24 { margin-bottom: 6rem; }
+.md\:mb-32 { margin-bottom: 8rem; }
+.md\:ml-0 { margin-left: 0; }
+.md\:ml-1 { margin-left: 0.25rem; }
+.md\:ml-2 { margin-left: 0.5rem; }
+.md\:ml-3 { margin-left: 0.75rem; }
+.md\:ml-4 { margin-left: 1rem; }
+.md\:ml-5 { margin-left: 1.25rem; }
+.md\:ml-6 { margin-left: 1.5rem; }
+.md\:ml-8 { margin-left: 2rem; }
+.md\:ml-10 { margin-left: 2.5rem; }
+.md\:ml-12 { margin-left: 3rem; }
+.md\:ml-16 { margin-left: 4rem; }
+.md\:ml-20 { margin-left: 5rem; }
+.md\:ml-24 { margin-left: 6rem; }
+.md\:ml-32 { margin-left: 8rem; }
+.md\:mr-0 { margin-right: 0; }
+.md\:mr-1 { margin-right: 0.25rem; }
+.md\:mr-2 { margin-right: 0.5rem; }
+.md\:mr-3 { margin-right: 0.75rem; }
+.md\:mr-4 { margin-right: 1rem; }
+.md\:mr-5 { margin-right: 1.25rem; }
+.md\:mr-6 { margin-right: 1.5rem; }
+.md\:mr-8 { margin-right: 2rem; }
+.md\:mr-10 { margin-right: 2.5rem; }
+.md\:mr-12 { margin-right: 3rem; }
+.md\:mr-16 { margin-right: 4rem; }
+.md\:mr-20 { margin-right: 5rem; }
+.md\:mr-24 { margin-right: 6rem; }
+.md\:mr-32 { margin-right: 8rem; }
+.md\:mx-0 { margin-left: 0; margin-right: 0; }
+.md\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.md\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.md\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.md\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.md\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.md\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.md\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.md\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.md\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.md\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.md\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.md\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.md\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.md\:my-0 { margin-top: 0; margin-bottom: 0; }
+.md\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.md\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.md\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.md\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.md\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.md\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.md\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.md\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.md\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.md\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.md\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.md\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.md\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.md\:p-0 { padding: 0; }
+.md\:p-1 { padding: 0.25rem; }
+.md\:p-2 { padding: 0.5rem; }
+.md\:p-3 { padding: 0.75rem; }
+.md\:p-4 { padding: 1rem; }
+.md\:p-5 { padding: 1.25rem; }
+.md\:p-6 { padding: 1.5rem; }
+.md\:p-8 { padding: 2rem; }
+.md\:p-10 { padding: 2.5rem; }
+.md\:p-12 { padding: 3rem; }
+.md\:p-16 { padding: 4rem; }
+.md\:p-20 { padding: 5rem; }
+.md\:p-24 { padding: 6rem; }
+.md\:p-32 { padding: 8rem; }
+.md\:pt-0 { padding-top: 0; }
+.md\:pt-1 { padding-top: 0.25rem; }
+.md\:pt-2 { padding-top: 0.5rem; }
+.md\:pt-3 { padding-top: 0.75rem; }
+.md\:pt-4 { padding-top: 1rem; }
+.md\:pt-5 { padding-top: 1.25rem; }
+.md\:pt-6 { padding-top: 1.5rem; }
+.md\:pt-8 { padding-top: 2rem; }
+.md\:pt-10 { padding-top: 2.5rem; }
+.md\:pt-12 { padding-top: 3rem; }
+.md\:pt-16 { padding-top: 4rem; }
+.md\:pt-20 { padding-top: 5rem; }
+.md\:pt-24 { padding-top: 6rem; }
+.md\:pt-32 { padding-top: 8rem; }
+.md\:pb-0 { padding-bottom: 0; }
+.md\:pb-1 { padding-bottom: 0.25rem; }
+.md\:pb-2 { padding-bottom: 0.5rem; }
+.md\:pb-3 { padding-bottom: 0.75rem; }
+.md\:pb-4 { padding-bottom: 1rem; }
+.md\:pb-5 { padding-bottom: 1.25rem; }
+.md\:pb-6 { padding-bottom: 1.5rem; }
+.md\:pb-8 { padding-bottom: 2rem; }
+.md\:pb-10 { padding-bottom: 2.5rem; }
+.md\:pb-12 { padding-bottom: 3rem; }
+.md\:pb-16 { padding-bottom: 4rem; }
+.md\:pb-20 { padding-bottom: 5rem; }
+.md\:pb-24 { padding-bottom: 6rem; }
+.md\:pb-32 { padding-bottom: 8rem; }
+.md\:pl-0 { padding-left: 0; }
+.md\:pl-1 { padding-left: 0.25rem; }
+.md\:pl-2 { padding-left: 0.5rem; }
+.md\:pl-3 { padding-left: 0.75rem; }
+.md\:pl-4 { padding-left: 1rem; }
+.md\:pl-5 { padding-left: 1.25rem; }
+.md\:pl-6 { padding-left: 1.5rem; }
+.md\:pl-8 { padding-left: 2rem; }
+.md\:pl-10 { padding-left: 2.5rem; }
+.md\:pl-12 { padding-left: 3rem; }
+.md\:pl-16 { padding-left: 4rem; }
+.md\:pl-20 { padding-left: 5rem; }
+.md\:pl-24 { padding-left: 6rem; }
+.md\:pl-32 { padding-left: 8rem; }
+.md\:pr-0 { padding-right: 0; }
+.md\:pr-1 { padding-right: 0.25rem; }
+.md\:pr-2 { padding-right: 0.5rem; }
+.md\:pr-3 { padding-right: 0.75rem; }
+.md\:pr-4 { padding-right: 1rem; }
+.md\:pr-5 { padding-right: 1.25rem; }
+.md\:pr-6 { padding-right: 1.5rem; }
+.md\:pr-8 { padding-right: 2rem; }
+.md\:pr-10 { padding-right: 2.5rem; }
+.md\:pr-12 { padding-right: 3rem; }
+.md\:pr-16 { padding-right: 4rem; }
+.md\:pr-20 { padding-right: 5rem; }
+.md\:pr-24 { padding-right: 6rem; }
+.md\:pr-32 { padding-right: 8rem; }
+.md\:px-0 { padding-left: 0; padding-right: 0; }
+.md\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.md\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.md\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.md\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.md\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.md\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.md\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.md\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.md\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.md\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.md\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.md\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.md\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.md\:py-0 { padding-top: 0; padding-bottom: 0; }
+.md\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.md\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.md\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.md\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.md\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.md\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.md\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.md\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.md\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.md\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.md\:gap-0 { gap: 0; }
+.md\:gap-1 { gap: 0.25rem; }
+.md\:gap-2 { gap: 0.5rem; }
+.md\:gap-3 { gap: 0.75rem; }
+.md\:gap-4 { gap: 1rem; }
+.md\:gap-5 { gap: 1.25rem; }
+.md\:gap-6 { gap: 1.5rem; }
+.md\:gap-8 { gap: 2rem; }
+.md\:gap-10 { gap: 2.5rem; }
+.md\:gap-12 { gap: 3rem; }
+.md\:gap-16 { gap: 4rem; }
+.md\:gap-20 { gap: 5rem; }
+.md\:gap-24 { gap: 6rem; }
+.md\:gap-32 { gap: 8rem; }
+}
+@media (width >= 62rem) {
+.lg\:m-0 { margin: 0; }
+.lg\:m-1 { margin: 0.25rem; }
+.lg\:m-2 { margin: 0.5rem; }
+.lg\:m-3 { margin: 0.75rem; }
+.lg\:m-4 { margin: 1rem; }
+.lg\:m-5 { margin: 1.25rem; }
+.lg\:m-6 { margin: 1.5rem; }
+.lg\:m-8 { margin: 2rem; }
+.lg\:m-10 { margin: 2.5rem; }
+.lg\:m-12 { margin: 3rem; }
+.lg\:m-16 { margin: 4rem; }
+.lg\:m-20 { margin: 5rem; }
+.lg\:m-24 { margin: 6rem; }
+.lg\:m-32 { margin: 8rem; }
+.lg\:mt-0 { margin-top: 0; }
+.lg\:mt-1 { margin-top: 0.25rem; }
+.lg\:mt-2 { margin-top: 0.5rem; }
+.lg\:mt-3 { margin-top: 0.75rem; }
+.lg\:mt-4 { margin-top: 1rem; }
+.lg\:mt-5 { margin-top: 1.25rem; }
+.lg\:mt-6 { margin-top: 1.5rem; }
+.lg\:mt-8 { margin-top: 2rem; }
+.lg\:mt-10 { margin-top: 2.5rem; }
+.lg\:mt-12 { margin-top: 3rem; }
+.lg\:mt-16 { margin-top: 4rem; }
+.lg\:mt-20 { margin-top: 5rem; }
+.lg\:mt-24 { margin-top: 6rem; }
+.lg\:mt-32 { margin-top: 8rem; }
+.lg\:mb-0 { margin-bottom: 0; }
+.lg\:mb-1 { margin-bottom: 0.25rem; }
+.lg\:mb-2 { margin-bottom: 0.5rem; }
+.lg\:mb-3 { margin-bottom: 0.75rem; }
+.lg\:mb-4 { margin-bottom: 1rem; }
+.lg\:mb-5 { margin-bottom: 1.25rem; }
+.lg\:mb-6 { margin-bottom: 1.5rem; }
+.lg\:mb-8 { margin-bottom: 2rem; }
+.lg\:mb-10 { margin-bottom: 2.5rem; }
+.lg\:mb-12 { margin-bottom: 3rem; }
+.lg\:mb-16 { margin-bottom: 4rem; }
+.lg\:mb-20 { margin-bottom: 5rem; }
+.lg\:mb-24 { margin-bottom: 6rem; }
+.lg\:mb-32 { margin-bottom: 8rem; }
+.lg\:ml-0 { margin-left: 0; }
+.lg\:ml-1 { margin-left: 0.25rem; }
+.lg\:ml-2 { margin-left: 0.5rem; }
+.lg\:ml-3 { margin-left: 0.75rem; }
+.lg\:ml-4 { margin-left: 1rem; }
+.lg\:ml-5 { margin-left: 1.25rem; }
+.lg\:ml-6 { margin-left: 1.5rem; }
+.lg\:ml-8 { margin-left: 2rem; }
+.lg\:ml-10 { margin-left: 2.5rem; }
+.lg\:ml-12 { margin-left: 3rem; }
+.lg\:ml-16 { margin-left: 4rem; }
+.lg\:ml-20 { margin-left: 5rem; }
+.lg\:ml-24 { margin-left: 6rem; }
+.lg\:ml-32 { margin-left: 8rem; }
+.lg\:mr-0 { margin-right: 0; }
+.lg\:mr-1 { margin-right: 0.25rem; }
+.lg\:mr-2 { margin-right: 0.5rem; }
+.lg\:mr-3 { margin-right: 0.75rem; }
+.lg\:mr-4 { margin-right: 1rem; }
+.lg\:mr-5 { margin-right: 1.25rem; }
+.lg\:mr-6 { margin-right: 1.5rem; }
+.lg\:mr-8 { margin-right: 2rem; }
+.lg\:mr-10 { margin-right: 2.5rem; }
+.lg\:mr-12 { margin-right: 3rem; }
+.lg\:mr-16 { margin-right: 4rem; }
+.lg\:mr-20 { margin-right: 5rem; }
+.lg\:mr-24 { margin-right: 6rem; }
+.lg\:mr-32 { margin-right: 8rem; }
+.lg\:mx-0 { margin-left: 0; margin-right: 0; }
+.lg\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.lg\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.lg\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.lg\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.lg\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.lg\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.lg\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.lg\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.lg\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.lg\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.lg\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.lg\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.lg\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.lg\:my-0 { margin-top: 0; margin-bottom: 0; }
+.lg\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.lg\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.lg\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.lg\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.lg\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.lg\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.lg\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.lg\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.lg\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.lg\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.lg\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.lg\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.lg\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.lg\:p-0 { padding: 0; }
+.lg\:p-1 { padding: 0.25rem; }
+.lg\:p-2 { padding: 0.5rem; }
+.lg\:p-3 { padding: 0.75rem; }
+.lg\:p-4 { padding: 1rem; }
+.lg\:p-5 { padding: 1.25rem; }
+.lg\:p-6 { padding: 1.5rem; }
+.lg\:p-8 { padding: 2rem; }
+.lg\:p-10 { padding: 2.5rem; }
+.lg\:p-12 { padding: 3rem; }
+.lg\:p-16 { padding: 4rem; }
+.lg\:p-20 { padding: 5rem; }
+.lg\:p-24 { padding: 6rem; }
+.lg\:p-32 { padding: 8rem; }
+.lg\:pt-0 { padding-top: 0; }
+.lg\:pt-1 { padding-top: 0.25rem; }
+.lg\:pt-2 { padding-top: 0.5rem; }
+.lg\:pt-3 { padding-top: 0.75rem; }
+.lg\:pt-4 { padding-top: 1rem; }
+.lg\:pt-5 { padding-top: 1.25rem; }
+.lg\:pt-6 { padding-top: 1.5rem; }
+.lg\:pt-8 { padding-top: 2rem; }
+.lg\:pt-10 { padding-top: 2.5rem; }
+.lg\:pt-12 { padding-top: 3rem; }
+.lg\:pt-16 { padding-top: 4rem; }
+.lg\:pt-20 { padding-top: 5rem; }
+.lg\:pt-24 { padding-top: 6rem; }
+.lg\:pt-32 { padding-top: 8rem; }
+.lg\:pb-0 { padding-bottom: 0; }
+.lg\:pb-1 { padding-bottom: 0.25rem; }
+.lg\:pb-2 { padding-bottom: 0.5rem; }
+.lg\:pb-3 { padding-bottom: 0.75rem; }
+.lg\:pb-4 { padding-bottom: 1rem; }
+.lg\:pb-5 { padding-bottom: 1.25rem; }
+.lg\:pb-6 { padding-bottom: 1.5rem; }
+.lg\:pb-8 { padding-bottom: 2rem; }
+.lg\:pb-10 { padding-bottom: 2.5rem; }
+.lg\:pb-12 { padding-bottom: 3rem; }
+.lg\:pb-16 { padding-bottom: 4rem; }
+.lg\:pb-20 { padding-bottom: 5rem; }
+.lg\:pb-24 { padding-bottom: 6rem; }
+.lg\:pb-32 { padding-bottom: 8rem; }
+.lg\:pl-0 { padding-left: 0; }
+.lg\:pl-1 { padding-left: 0.25rem; }
+.lg\:pl-2 { padding-left: 0.5rem; }
+.lg\:pl-3 { padding-left: 0.75rem; }
+.lg\:pl-4 { padding-left: 1rem; }
+.lg\:pl-5 { padding-left: 1.25rem; }
+.lg\:pl-6 { padding-left: 1.5rem; }
+.lg\:pl-8 { padding-left: 2rem; }
+.lg\:pl-10 { padding-left: 2.5rem; }
+.lg\:pl-12 { padding-left: 3rem; }
+.lg\:pl-16 { padding-left: 4rem; }
+.lg\:pl-20 { padding-left: 5rem; }
+.lg\:pl-24 { padding-left: 6rem; }
+.lg\:pl-32 { padding-left: 8rem; }
+.lg\:pr-0 { padding-right: 0; }
+.lg\:pr-1 { padding-right: 0.25rem; }
+.lg\:pr-2 { padding-right: 0.5rem; }
+.lg\:pr-3 { padding-right: 0.75rem; }
+.lg\:pr-4 { padding-right: 1rem; }
+.lg\:pr-5 { padding-right: 1.25rem; }
+.lg\:pr-6 { padding-right: 1.5rem; }
+.lg\:pr-8 { padding-right: 2rem; }
+.lg\:pr-10 { padding-right: 2.5rem; }
+.lg\:pr-12 { padding-right: 3rem; }
+.lg\:pr-16 { padding-right: 4rem; }
+.lg\:pr-20 { padding-right: 5rem; }
+.lg\:pr-24 { padding-right: 6rem; }
+.lg\:pr-32 { padding-right: 8rem; }
+.lg\:px-0 { padding-left: 0; padding-right: 0; }
+.lg\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.lg\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.lg\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.lg\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.lg\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.lg\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.lg\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.lg\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.lg\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.lg\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.lg\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.lg\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.lg\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.lg\:py-0 { padding-top: 0; padding-bottom: 0; }
+.lg\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.lg\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.lg\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.lg\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.lg\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.lg\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.lg\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.lg\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.lg\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.lg\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.lg\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.lg\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.lg\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.lg\:gap-0 { gap: 0; }
+.lg\:gap-1 { gap: 0.25rem; }
+.lg\:gap-2 { gap: 0.5rem; }
+.lg\:gap-3 { gap: 0.75rem; }
+.lg\:gap-4 { gap: 1rem; }
+.lg\:gap-5 { gap: 1.25rem; }
+.lg\:gap-6 { gap: 1.5rem; }
+.lg\:gap-8 { gap: 2rem; }
+.lg\:gap-10 { gap: 2.5rem; }
+.lg\:gap-12 { gap: 3rem; }
+.lg\:gap-16 { gap: 4rem; }
+.lg\:gap-20 { gap: 5rem; }
+.lg\:gap-24 { gap: 6rem; }
+.lg\:gap-32 { gap: 8rem; }
+}
+@media (width >= 80rem) {
+.xl\:m-0 { margin: 0; }
+.xl\:m-1 { margin: 0.25rem; }
+.xl\:m-2 { margin: 0.5rem; }
+.xl\:m-3 { margin: 0.75rem; }
+.xl\:m-4 { margin: 1rem; }
+.xl\:m-5 { margin: 1.25rem; }
+.xl\:m-6 { margin: 1.5rem; }
+.xl\:m-8 { margin: 2rem; }
+.xl\:m-10 { margin: 2.5rem; }
+.xl\:m-12 { margin: 3rem; }
+.xl\:m-16 { margin: 4rem; }
+.xl\:m-20 { margin: 5rem; }
+.xl\:m-24 { margin: 6rem; }
+.xl\:m-32 { margin: 8rem; }
+.xl\:mt-0 { margin-top: 0; }
+.xl\:mt-1 { margin-top: 0.25rem; }
+.xl\:mt-2 { margin-top: 0.5rem; }
+.xl\:mt-3 { margin-top: 0.75rem; }
+.xl\:mt-4 { margin-top: 1rem; }
+.xl\:mt-5 { margin-top: 1.25rem; }
+.xl\:mt-6 { margin-top: 1.5rem; }
+.xl\:mt-8 { margin-top: 2rem; }
+.xl\:mt-10 { margin-top: 2.5rem; }
+.xl\:mt-12 { margin-top: 3rem; }
+.xl\:mt-16 { margin-top: 4rem; }
+.xl\:mt-20 { margin-top: 5rem; }
+.xl\:mt-24 { margin-top: 6rem; }
+.xl\:mt-32 { margin-top: 8rem; }
+.xl\:mb-0 { margin-bottom: 0; }
+.xl\:mb-1 { margin-bottom: 0.25rem; }
+.xl\:mb-2 { margin-bottom: 0.5rem; }
+.xl\:mb-3 { margin-bottom: 0.75rem; }
+.xl\:mb-4 { margin-bottom: 1rem; }
+.xl\:mb-5 { margin-bottom: 1.25rem; }
+.xl\:mb-6 { margin-bottom: 1.5rem; }
+.xl\:mb-8 { margin-bottom: 2rem; }
+.xl\:mb-10 { margin-bottom: 2.5rem; }
+.xl\:mb-12 { margin-bottom: 3rem; }
+.xl\:mb-16 { margin-bottom: 4rem; }
+.xl\:mb-20 { margin-bottom: 5rem; }
+.xl\:mb-24 { margin-bottom: 6rem; }
+.xl\:mb-32 { margin-bottom: 8rem; }
+.xl\:ml-0 { margin-left: 0; }
+.xl\:ml-1 { margin-left: 0.25rem; }
+.xl\:ml-2 { margin-left: 0.5rem; }
+.xl\:ml-3 { margin-left: 0.75rem; }
+.xl\:ml-4 { margin-left: 1rem; }
+.xl\:ml-5 { margin-left: 1.25rem; }
+.xl\:ml-6 { margin-left: 1.5rem; }
+.xl\:ml-8 { margin-left: 2rem; }
+.xl\:ml-10 { margin-left: 2.5rem; }
+.xl\:ml-12 { margin-left: 3rem; }
+.xl\:ml-16 { margin-left: 4rem; }
+.xl\:ml-20 { margin-left: 5rem; }
+.xl\:ml-24 { margin-left: 6rem; }
+.xl\:ml-32 { margin-left: 8rem; }
+.xl\:mr-0 { margin-right: 0; }
+.xl\:mr-1 { margin-right: 0.25rem; }
+.xl\:mr-2 { margin-right: 0.5rem; }
+.xl\:mr-3 { margin-right: 0.75rem; }
+.xl\:mr-4 { margin-right: 1rem; }
+.xl\:mr-5 { margin-right: 1.25rem; }
+.xl\:mr-6 { margin-right: 1.5rem; }
+.xl\:mr-8 { margin-right: 2rem; }
+.xl\:mr-10 { margin-right: 2.5rem; }
+.xl\:mr-12 { margin-right: 3rem; }
+.xl\:mr-16 { margin-right: 4rem; }
+.xl\:mr-20 { margin-right: 5rem; }
+.xl\:mr-24 { margin-right: 6rem; }
+.xl\:mr-32 { margin-right: 8rem; }
+.xl\:mx-0 { margin-left: 0; margin-right: 0; }
+.xl\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.xl\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.xl\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.xl\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.xl\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.xl\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.xl\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.xl\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.xl\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.xl\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.xl\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.xl\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.xl\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.xl\:my-0 { margin-top: 0; margin-bottom: 0; }
+.xl\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.xl\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.xl\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.xl\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.xl\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.xl\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.xl\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.xl\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.xl\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.xl\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.xl\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.xl\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.xl\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.xl\:p-0 { padding: 0; }
+.xl\:p-1 { padding: 0.25rem; }
+.xl\:p-2 { padding: 0.5rem; }
+.xl\:p-3 { padding: 0.75rem; }
+.xl\:p-4 { padding: 1rem; }
+.xl\:p-5 { padding: 1.25rem; }
+.xl\:p-6 { padding: 1.5rem; }
+.xl\:p-8 { padding: 2rem; }
+.xl\:p-10 { padding: 2.5rem; }
+.xl\:p-12 { padding: 3rem; }
+.xl\:p-16 { padding: 4rem; }
+.xl\:p-20 { padding: 5rem; }
+.xl\:p-24 { padding: 6rem; }
+.xl\:p-32 { padding: 8rem; }
+.xl\:pt-0 { padding-top: 0; }
+.xl\:pt-1 { padding-top: 0.25rem; }
+.xl\:pt-2 { padding-top: 0.5rem; }
+.xl\:pt-3 { padding-top: 0.75rem; }
+.xl\:pt-4 { padding-top: 1rem; }
+.xl\:pt-5 { padding-top: 1.25rem; }
+.xl\:pt-6 { padding-top: 1.5rem; }
+.xl\:pt-8 { padding-top: 2rem; }
+.xl\:pt-10 { padding-top: 2.5rem; }
+.xl\:pt-12 { padding-top: 3rem; }
+.xl\:pt-16 { padding-top: 4rem; }
+.xl\:pt-20 { padding-top: 5rem; }
+.xl\:pt-24 { padding-top: 6rem; }
+.xl\:pt-32 { padding-top: 8rem; }
+.xl\:pb-0 { padding-bottom: 0; }
+.xl\:pb-1 { padding-bottom: 0.25rem; }
+.xl\:pb-2 { padding-bottom: 0.5rem; }
+.xl\:pb-3 { padding-bottom: 0.75rem; }
+.xl\:pb-4 { padding-bottom: 1rem; }
+.xl\:pb-5 { padding-bottom: 1.25rem; }
+.xl\:pb-6 { padding-bottom: 1.5rem; }
+.xl\:pb-8 { padding-bottom: 2rem; }
+.xl\:pb-10 { padding-bottom: 2.5rem; }
+.xl\:pb-12 { padding-bottom: 3rem; }
+.xl\:pb-16 { padding-bottom: 4rem; }
+.xl\:pb-20 { padding-bottom: 5rem; }
+.xl\:pb-24 { padding-bottom: 6rem; }
+.xl\:pb-32 { padding-bottom: 8rem; }
+.xl\:pl-0 { padding-left: 0; }
+.xl\:pl-1 { padding-left: 0.25rem; }
+.xl\:pl-2 { padding-left: 0.5rem; }
+.xl\:pl-3 { padding-left: 0.75rem; }
+.xl\:pl-4 { padding-left: 1rem; }
+.xl\:pl-5 { padding-left: 1.25rem; }
+.xl\:pl-6 { padding-left: 1.5rem; }
+.xl\:pl-8 { padding-left: 2rem; }
+.xl\:pl-10 { padding-left: 2.5rem; }
+.xl\:pl-12 { padding-left: 3rem; }
+.xl\:pl-16 { padding-left: 4rem; }
+.xl\:pl-20 { padding-left: 5rem; }
+.xl\:pl-24 { padding-left: 6rem; }
+.xl\:pl-32 { padding-left: 8rem; }
+.xl\:pr-0 { padding-right: 0; }
+.xl\:pr-1 { padding-right: 0.25rem; }
+.xl\:pr-2 { padding-right: 0.5rem; }
+.xl\:pr-3 { padding-right: 0.75rem; }
+.xl\:pr-4 { padding-right: 1rem; }
+.xl\:pr-5 { padding-right: 1.25rem; }
+.xl\:pr-6 { padding-right: 1.5rem; }
+.xl\:pr-8 { padding-right: 2rem; }
+.xl\:pr-10 { padding-right: 2.5rem; }
+.xl\:pr-12 { padding-right: 3rem; }
+.xl\:pr-16 { padding-right: 4rem; }
+.xl\:pr-20 { padding-right: 5rem; }
+.xl\:pr-24 { padding-right: 6rem; }
+.xl\:pr-32 { padding-right: 8rem; }
+.xl\:px-0 { padding-left: 0; padding-right: 0; }
+.xl\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.xl\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.xl\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.xl\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.xl\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.xl\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.xl\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.xl\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.xl\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.xl\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.xl\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.xl\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.xl\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.xl\:py-0 { padding-top: 0; padding-bottom: 0; }
+.xl\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.xl\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.xl\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.xl\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.xl\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.xl\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.xl\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.xl\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.xl\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.xl\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.xl\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.xl\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.xl\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.xl\:gap-0 { gap: 0; }
+.xl\:gap-1 { gap: 0.25rem; }
+.xl\:gap-2 { gap: 0.5rem; }
+.xl\:gap-3 { gap: 0.75rem; }
+.xl\:gap-4 { gap: 1rem; }
+.xl\:gap-5 { gap: 1.25rem; }
+.xl\:gap-6 { gap: 1.5rem; }
+.xl\:gap-8 { gap: 2rem; }
+.xl\:gap-10 { gap: 2.5rem; }
+.xl\:gap-12 { gap: 3rem; }
+.xl\:gap-16 { gap: 4rem; }
+.xl\:gap-20 { gap: 5rem; }
+.xl\:gap-24 { gap: 6rem; }
+.xl\:gap-32 { gap: 8rem; }
+}
+
+/* display utilities */
+.hide { display: none !important; }
+.show { display: revert !important; }
+.invisible { visibility: hidden !important; }
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+}
+.sr-only-focusable {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+}
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-within {
+  position: static; width: auto; height: auto;
+  padding: 0; margin: 0; overflow: visible;
+  clip: auto; white-space: normal;
+}
+@media (width >= 30rem) {
+.sm\:hide { display: none !important; }
+.sm\:show { display: revert !important; }
+.sm\:invisible { visibility: hidden !important; }
+}
+@media (width >= 48rem) {
+.md\:hide { display: none !important; }
+.md\:show { display: revert !important; }
+.md\:invisible { visibility: hidden !important; }
+}
+@media (width >= 62rem) {
+.lg\:hide { display: none !important; }
+.lg\:show { display: revert !important; }
+.lg\:invisible { visibility: hidden !important; }
+}
+@media (width >= 80rem) {
+.xl\:hide { display: none !important; }
+.xl\:show { display: revert !important; }
+.xl\:invisible { visibility: hidden !important; }
+}
+@media print { .print\:hide { display: none !important; } }
+
+/* flex utilities */
+.flex { display: flex; }
+.inline-flex { display: inline-flex; }
+.flex-row { flex-direction: row; }
+.flex-row-reverse { flex-direction: row-reverse; }
+.flex-col { flex-direction: column; }
+.flex-col-reverse { flex-direction: column-reverse; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-nowrap { flex-wrap: nowrap; }
+.flex-1 { flex: 1 1 0%; }
+.flex-auto { flex: 1 1 auto; }
+.flex-none { flex: none; }
+.justify-start { justify-content: flex-start; }
+.justify-end { justify-content: flex-end; }
+.justify-center { justify-content: center; }
+.justify-between { justify-content: space-between; }
+.justify-around { justify-content: space-around; }
+.items-start { align-items: flex-start; }
+.items-end { align-items: flex-end; }
+.items-center { align-items: center; }
+.items-baseline { align-items: baseline; }
+.items-stretch { align-items: stretch; }
+
+@media (width >= 30rem) {
+.sm\:flex { display: flex; }
+.sm\:inline-flex { display: inline-flex; }
+.sm\:flex-row { flex-direction: row; }
+.sm\:flex-row-reverse { flex-direction: row-reverse; }
+.sm\:flex-col { flex-direction: column; }
+.sm\:flex-col-reverse { flex-direction: column-reverse; }
+.sm\:flex-wrap { flex-wrap: wrap; }
+.sm\:flex-nowrap { flex-wrap: nowrap; }
+.sm\:flex-1 { flex: 1 1 0%; }
+.sm\:flex-auto { flex: 1 1 auto; }
+.sm\:flex-none { flex: none; }
+.sm\:justify-start { justify-content: flex-start; }
+.sm\:justify-end { justify-content: flex-end; }
+.sm\:justify-center { justify-content: center; }
+.sm\:justify-between { justify-content: space-between; }
+.sm\:justify-around { justify-content: space-around; }
+.sm\:items-start { align-items: flex-start; }
+.sm\:items-end { align-items: flex-end; }
+.sm\:items-center { align-items: center; }
+.sm\:items-baseline { align-items: baseline; }
+.sm\:items-stretch { align-items: stretch; }
+}
+@media (width >= 48rem) {
+.md\:flex { display: flex; }
+.md\:inline-flex { display: inline-flex; }
+.md\:flex-row { flex-direction: row; }
+.md\:flex-row-reverse { flex-direction: row-reverse; }
+.md\:flex-col { flex-direction: column; }
+.md\:flex-col-reverse { flex-direction: column-reverse; }
+.md\:flex-wrap { flex-wrap: wrap; }
+.md\:flex-nowrap { flex-wrap: nowrap; }
+.md\:flex-1 { flex: 1 1 0%; }
+.md\:flex-auto { flex: 1 1 auto; }
+.md\:flex-none { flex: none; }
+.md\:justify-start { justify-content: flex-start; }
+.md\:justify-end { justify-content: flex-end; }
+.md\:justify-center { justify-content: center; }
+.md\:justify-between { justify-content: space-between; }
+.md\:justify-around { justify-content: space-around; }
+.md\:items-start { align-items: flex-start; }
+.md\:items-end { align-items: flex-end; }
+.md\:items-center { align-items: center; }
+.md\:items-baseline { align-items: baseline; }
+.md\:items-stretch { align-items: stretch; }
+}
+@media (width >= 62rem) {
+.lg\:flex { display: flex; }
+.lg\:inline-flex { display: inline-flex; }
+.lg\:flex-row { flex-direction: row; }
+.lg\:flex-row-reverse { flex-direction: row-reverse; }
+.lg\:flex-col { flex-direction: column; }
+.lg\:flex-col-reverse { flex-direction: column-reverse; }
+.lg\:flex-wrap { flex-wrap: wrap; }
+.lg\:flex-nowrap { flex-wrap: nowrap; }
+.lg\:flex-1 { flex: 1 1 0%; }
+.lg\:flex-auto { flex: 1 1 auto; }
+.lg\:flex-none { flex: none; }
+.lg\:justify-start { justify-content: flex-start; }
+.lg\:justify-end { justify-content: flex-end; }
+.lg\:justify-center { justify-content: center; }
+.lg\:justify-between { justify-content: space-between; }
+.lg\:justify-around { justify-content: space-around; }
+.lg\:items-start { align-items: flex-start; }
+.lg\:items-end { align-items: flex-end; }
+.lg\:items-center { align-items: center; }
+.lg\:items-baseline { align-items: baseline; }
+.lg\:items-stretch { align-items: stretch; }
+}
+@media (width >= 80rem) {
+.xl\:flex { display: flex; }
+.xl\:inline-flex { display: inline-flex; }
+.xl\:flex-row { flex-direction: row; }
+.xl\:flex-row-reverse { flex-direction: row-reverse; }
+.xl\:flex-col { flex-direction: column; }
+.xl\:flex-col-reverse { flex-direction: column-reverse; }
+.xl\:flex-wrap { flex-wrap: wrap; }
+.xl\:flex-nowrap { flex-wrap: nowrap; }
+.xl\:flex-1 { flex: 1 1 0%; }
+.xl\:flex-auto { flex: 1 1 auto; }
+.xl\:flex-none { flex: none; }
+.xl\:justify-start { justify-content: flex-start; }
+.xl\:justify-end { justify-content: flex-end; }
+.xl\:justify-center { justify-content: center; }
+.xl\:justify-between { justify-content: space-between; }
+.xl\:justify-around { justify-content: space-around; }
+.xl\:items-start { align-items: flex-start; }
+.xl\:items-end { align-items: flex-end; }
+.xl\:items-center { align-items: center; }
+.xl\:items-baseline { align-items: baseline; }
+.xl\:items-stretch { align-items: stretch; }
+}
+
+/* grid utilities */
+.grid { display: grid; }
+.inline-grid { display: inline-grid; }
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+
+@media (width >= 30rem) {
+.sm\:grid { display: grid; }
+.sm\:inline-grid { display: inline-grid; }
+.sm\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.sm\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.sm\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.sm\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.sm\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.sm\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.sm\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.sm\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.sm\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.sm\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.sm\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.sm\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.sm\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.sm\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.sm\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.sm\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.sm\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 48rem) {
+.md\:grid { display: grid; }
+.md\:inline-grid { display: inline-grid; }
+.md\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.md\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.md\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.md\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.md\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.md\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.md\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.md\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.md\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.md\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.md\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.md\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.md\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.md\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.md\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 62rem) {
+.lg\:grid { display: grid; }
+.lg\:inline-grid { display: inline-grid; }
+.lg\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.lg\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.lg\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.lg\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.lg\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.lg\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.lg\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.lg\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.lg\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.lg\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.lg\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.lg\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.lg\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.lg\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 80rem) {
+.xl\:grid { display: grid; }
+.xl\:inline-grid { display: inline-grid; }
+.xl\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.xl\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.xl\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.xl\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.xl\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.xl\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.xl\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.xl\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.xl\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.xl\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.xl\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.xl\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.xl\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.xl\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.xl\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.xl\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.xl\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.xl\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+
+/* type utilities */
+.text-xs { font-size: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-base { font-size: 1rem; }
+.text-lg { font-size: 1.125rem; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-3xl { font-size: 1.875rem; }
+.text-4xl { font-size: 2.25rem; }
+.font-normal { font-weight: 400; }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.leading-tight { line-height: 1.25; }
+.leading-normal { line-height: 1.5; }
+.leading-loose { line-height: 1.75; }
+.text-left { text-align: left; }
+.text-center { text-align: center; }
+.text-right { text-align: right; }
+.text-justify { text-align: justify; }
+
+/* radius utilities */
+.rounded-none { border-radius: 0; }
+.rounded-sm { border-radius: 0.125rem; }
+.rounded { border-radius: 0.375rem; }
+.rounded-md { border-radius: 0.375rem; }
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-xl { border-radius: 0.75rem; }
+.rounded-full { border-radius: 9999px; }
+
+/* shadow utilities */
+.shadow-none { box-shadow: none; }
+.shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.shadow { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1); }
+.shadow-md { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1); }
+.shadow-lg { box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1); }
+.shadow-xl { box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1); }
+
+/* position utilities */
+.static { position: static; }
+.relative { position: relative; }
+.absolute { position: absolute; }
+.fixed { position: fixed; }
+.sticky { position: sticky; }
+
+/* z-index utilities */
+.z-0 { z-index: 0; }
+.z-10 { z-index: 10; }
+.z-20 { z-index: 20; }
+.z-30 { z-index: 30; }
+.z-40 { z-index: 40; }
+.z-50 { z-index: 50; }
+.z-auto { z-index: auto; }

--- a/plugins/acss-utilities/assets/utilities.tokens.json
+++ b/plugins/acss-utilities/assets/utilities.tokens.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "./utilities.tokens.schema.json",
+  "version": "0.1.0",
+  "fpkitUpstream": "@fpkit/acss@6.5.0",
+  "bundleSizeBudgetKb": 80,
+  "breakpoints": {
+    "sm": "30rem",
+    "md": "48rem",
+    "lg": "62rem",
+    "xl": "80rem"
+  },
+  "colorRoles": {
+    "primary": "--color-primary",
+    "primary-light": "--color-primary-light",
+    "secondary": "--color-secondary",
+    "success": "--color-success",
+    "error": "--color-error",
+    "warning": "--color-warning",
+    "info": "--color-info",
+    "text": "--color-text",
+    "muted": "--color-text-muted",
+    "surface": "--color-surface",
+    "surface-secondary": "--color-surface-secondary"
+  },
+  "stateBg": {
+    "success": "--color-success-bg",
+    "error": "--color-error-bg",
+    "warning": "--color-warning-bg",
+    "info": "--color-info-bg"
+  },
+  "spacing": {
+    "baseline": "0.25rem",
+    "scale": [0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32],
+    "properties": ["m", "mt", "mb", "ml", "mr", "mx", "my", "p", "pt", "pb", "pl", "pr", "px", "py", "gap"]
+  },
+  "type": {
+    "fontSize": {
+      "xs": "0.75rem",
+      "sm": "0.875rem",
+      "base": "1rem",
+      "lg": "1.125rem",
+      "xl": "1.25rem",
+      "2xl": "1.5rem",
+      "3xl": "1.875rem",
+      "4xl": "2.25rem"
+    },
+    "fontWeight": {
+      "normal": "400",
+      "medium": "500",
+      "semibold": "600",
+      "bold": "700"
+    },
+    "leading": {
+      "tight": "1.25",
+      "normal": "1.5",
+      "loose": "1.75"
+    },
+    "align": ["left", "center", "right", "justify"]
+  },
+  "radius": {
+    "none": "0",
+    "sm": "0.125rem",
+    "md": "0.375rem",
+    "lg": "0.5rem",
+    "xl": "0.75rem",
+    "full": "9999px"
+  },
+  "shadow": {
+    "none": "none",
+    "sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+    "md": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+    "lg": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",
+    "xl": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)"
+  },
+  "zIndex": ["0", "10", "20", "30", "40", "50", "auto"],
+  "positions": ["static", "relative", "absolute", "fixed", "sticky"],
+  "families": {
+    "color-bg":     { "enabled": true, "responsive": false },
+    "color-text":   { "enabled": true, "responsive": false },
+    "color-border": { "enabled": true, "responsive": false },
+    "spacing":      { "enabled": true, "responsive": true },
+    "display":      { "enabled": true, "responsive": true },
+    "flex":         { "enabled": true, "responsive": true },
+    "grid":         { "enabled": true, "responsive": true },
+    "type":         { "enabled": true, "responsive": false },
+    "radius":       { "enabled": true, "responsive": false },
+    "shadow":       { "enabled": true, "responsive": false },
+    "position":     { "enabled": true, "responsive": false },
+    "z-index":      { "enabled": true, "responsive": false }
+  }
+}

--- a/plugins/acss-utilities/assets/utilities.tokens.json
+++ b/plugins/acss-utilities/assets/utilities.tokens.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "./utilities.tokens.schema.json",
   "version": "0.1.0",
   "fpkitUpstream": "@fpkit/acss@6.5.0",
   "bundleSizeBudgetKb": 80,

--- a/plugins/acss-utilities/assets/utilities/color-bg.css
+++ b/plugins/acss-utilities/assets/utilities/color-bg.css
@@ -1,0 +1,17 @@
+/* color-bg utilities */
+.bg-primary { background-color: var(--color-primary, transparent); }
+.bg-primary-light { background-color: var(--color-primary-light, transparent); }
+.bg-secondary { background-color: var(--color-secondary, transparent); }
+.bg-success { background-color: var(--color-success, transparent); }
+.bg-error { background-color: var(--color-error, transparent); }
+.bg-warning { background-color: var(--color-warning, transparent); }
+.bg-info { background-color: var(--color-info, transparent); }
+.bg-text { background-color: var(--color-text, transparent); }
+.bg-muted { background-color: var(--color-text-muted, transparent); }
+.bg-surface { background-color: var(--color-surface, transparent); }
+.bg-surface-secondary { background-color: var(--color-surface-secondary, transparent); }
+.bg-success-subtle { background-color: var(--color-success-bg, transparent); }
+.bg-error-subtle { background-color: var(--color-error-bg, transparent); }
+.bg-warning-subtle { background-color: var(--color-warning-bg, transparent); }
+.bg-info-subtle { background-color: var(--color-info-bg, transparent); }
+.bg-transparent { background-color: transparent; }

--- a/plugins/acss-utilities/assets/utilities/color-border.css
+++ b/plugins/acss-utilities/assets/utilities/color-border.css
@@ -1,0 +1,12 @@
+/* color-border utilities */
+.border-primary { border-color: var(--color-primary, currentColor); }
+.border-primary-light { border-color: var(--color-primary-light, currentColor); }
+.border-secondary { border-color: var(--color-secondary, currentColor); }
+.border-success { border-color: var(--color-success, currentColor); }
+.border-error { border-color: var(--color-error, currentColor); }
+.border-warning { border-color: var(--color-warning, currentColor); }
+.border-info { border-color: var(--color-info, currentColor); }
+.border-text { border-color: var(--color-text, currentColor); }
+.border-muted { border-color: var(--color-text-muted, currentColor); }
+.border-surface { border-color: var(--color-surface, currentColor); }
+.border-surface-secondary { border-color: var(--color-surface-secondary, currentColor); }

--- a/plugins/acss-utilities/assets/utilities/color-text.css
+++ b/plugins/acss-utilities/assets/utilities/color-text.css
@@ -1,0 +1,12 @@
+/* color-text utilities */
+.text-primary { color: var(--color-primary, currentColor); }
+.text-primary-light { color: var(--color-primary-light, currentColor); }
+.text-secondary { color: var(--color-secondary, currentColor); }
+.text-success { color: var(--color-success, currentColor); }
+.text-error { color: var(--color-error, currentColor); }
+.text-warning { color: var(--color-warning, currentColor); }
+.text-info { color: var(--color-info, currentColor); }
+.text-text { color: var(--color-text, currentColor); }
+.text-muted { color: var(--color-text-muted, currentColor); }
+.text-surface { color: var(--color-surface, currentColor); }
+.text-surface-secondary { color: var(--color-surface-secondary, currentColor); }

--- a/plugins/acss-utilities/assets/utilities/display.css
+++ b/plugins/acss-utilities/assets/utilities/display.css
@@ -1,0 +1,41 @@
+/* display utilities */
+.hide { display: none !important; }
+.show { display: revert !important; }
+.invisible { visibility: hidden !important; }
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+}
+.sr-only-focusable {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+}
+.sr-only-focusable:focus,
+.sr-only-focusable:focus-within {
+  position: static; width: auto; height: auto;
+  padding: 0; margin: 0; overflow: visible;
+  clip: auto; white-space: normal;
+}
+@media (width >= 30rem) {
+.sm\:hide { display: none !important; }
+.sm\:show { display: revert !important; }
+.sm\:invisible { visibility: hidden !important; }
+}
+@media (width >= 48rem) {
+.md\:hide { display: none !important; }
+.md\:show { display: revert !important; }
+.md\:invisible { visibility: hidden !important; }
+}
+@media (width >= 62rem) {
+.lg\:hide { display: none !important; }
+.lg\:show { display: revert !important; }
+.lg\:invisible { visibility: hidden !important; }
+}
+@media (width >= 80rem) {
+.xl\:hide { display: none !important; }
+.xl\:show { display: revert !important; }
+.xl\:invisible { visibility: hidden !important; }
+}
+@media print { .print\:hide { display: none !important; } }

--- a/plugins/acss-utilities/assets/utilities/flex.css
+++ b/plugins/acss-utilities/assets/utilities/flex.css
@@ -1,0 +1,115 @@
+/* flex utilities */
+.flex { display: flex; }
+.inline-flex { display: inline-flex; }
+.flex-row { flex-direction: row; }
+.flex-row-reverse { flex-direction: row-reverse; }
+.flex-col { flex-direction: column; }
+.flex-col-reverse { flex-direction: column-reverse; }
+.flex-wrap { flex-wrap: wrap; }
+.flex-nowrap { flex-wrap: nowrap; }
+.flex-1 { flex: 1 1 0%; }
+.flex-auto { flex: 1 1 auto; }
+.flex-none { flex: none; }
+.justify-start { justify-content: flex-start; }
+.justify-end { justify-content: flex-end; }
+.justify-center { justify-content: center; }
+.justify-between { justify-content: space-between; }
+.justify-around { justify-content: space-around; }
+.items-start { align-items: flex-start; }
+.items-end { align-items: flex-end; }
+.items-center { align-items: center; }
+.items-baseline { align-items: baseline; }
+.items-stretch { align-items: stretch; }
+
+@media (width >= 30rem) {
+.sm\:flex { display: flex; }
+.sm\:inline-flex { display: inline-flex; }
+.sm\:flex-row { flex-direction: row; }
+.sm\:flex-row-reverse { flex-direction: row-reverse; }
+.sm\:flex-col { flex-direction: column; }
+.sm\:flex-col-reverse { flex-direction: column-reverse; }
+.sm\:flex-wrap { flex-wrap: wrap; }
+.sm\:flex-nowrap { flex-wrap: nowrap; }
+.sm\:flex-1 { flex: 1 1 0%; }
+.sm\:flex-auto { flex: 1 1 auto; }
+.sm\:flex-none { flex: none; }
+.sm\:justify-start { justify-content: flex-start; }
+.sm\:justify-end { justify-content: flex-end; }
+.sm\:justify-center { justify-content: center; }
+.sm\:justify-between { justify-content: space-between; }
+.sm\:justify-around { justify-content: space-around; }
+.sm\:items-start { align-items: flex-start; }
+.sm\:items-end { align-items: flex-end; }
+.sm\:items-center { align-items: center; }
+.sm\:items-baseline { align-items: baseline; }
+.sm\:items-stretch { align-items: stretch; }
+}
+@media (width >= 48rem) {
+.md\:flex { display: flex; }
+.md\:inline-flex { display: inline-flex; }
+.md\:flex-row { flex-direction: row; }
+.md\:flex-row-reverse { flex-direction: row-reverse; }
+.md\:flex-col { flex-direction: column; }
+.md\:flex-col-reverse { flex-direction: column-reverse; }
+.md\:flex-wrap { flex-wrap: wrap; }
+.md\:flex-nowrap { flex-wrap: nowrap; }
+.md\:flex-1 { flex: 1 1 0%; }
+.md\:flex-auto { flex: 1 1 auto; }
+.md\:flex-none { flex: none; }
+.md\:justify-start { justify-content: flex-start; }
+.md\:justify-end { justify-content: flex-end; }
+.md\:justify-center { justify-content: center; }
+.md\:justify-between { justify-content: space-between; }
+.md\:justify-around { justify-content: space-around; }
+.md\:items-start { align-items: flex-start; }
+.md\:items-end { align-items: flex-end; }
+.md\:items-center { align-items: center; }
+.md\:items-baseline { align-items: baseline; }
+.md\:items-stretch { align-items: stretch; }
+}
+@media (width >= 62rem) {
+.lg\:flex { display: flex; }
+.lg\:inline-flex { display: inline-flex; }
+.lg\:flex-row { flex-direction: row; }
+.lg\:flex-row-reverse { flex-direction: row-reverse; }
+.lg\:flex-col { flex-direction: column; }
+.lg\:flex-col-reverse { flex-direction: column-reverse; }
+.lg\:flex-wrap { flex-wrap: wrap; }
+.lg\:flex-nowrap { flex-wrap: nowrap; }
+.lg\:flex-1 { flex: 1 1 0%; }
+.lg\:flex-auto { flex: 1 1 auto; }
+.lg\:flex-none { flex: none; }
+.lg\:justify-start { justify-content: flex-start; }
+.lg\:justify-end { justify-content: flex-end; }
+.lg\:justify-center { justify-content: center; }
+.lg\:justify-between { justify-content: space-between; }
+.lg\:justify-around { justify-content: space-around; }
+.lg\:items-start { align-items: flex-start; }
+.lg\:items-end { align-items: flex-end; }
+.lg\:items-center { align-items: center; }
+.lg\:items-baseline { align-items: baseline; }
+.lg\:items-stretch { align-items: stretch; }
+}
+@media (width >= 80rem) {
+.xl\:flex { display: flex; }
+.xl\:inline-flex { display: inline-flex; }
+.xl\:flex-row { flex-direction: row; }
+.xl\:flex-row-reverse { flex-direction: row-reverse; }
+.xl\:flex-col { flex-direction: column; }
+.xl\:flex-col-reverse { flex-direction: column-reverse; }
+.xl\:flex-wrap { flex-wrap: wrap; }
+.xl\:flex-nowrap { flex-wrap: nowrap; }
+.xl\:flex-1 { flex: 1 1 0%; }
+.xl\:flex-auto { flex: 1 1 auto; }
+.xl\:flex-none { flex: none; }
+.xl\:justify-start { justify-content: flex-start; }
+.xl\:justify-end { justify-content: flex-end; }
+.xl\:justify-center { justify-content: center; }
+.xl\:justify-between { justify-content: space-between; }
+.xl\:justify-around { justify-content: space-around; }
+.xl\:items-start { align-items: flex-start; }
+.xl\:items-end { align-items: flex-end; }
+.xl\:items-center { align-items: center; }
+.xl\:items-baseline { align-items: baseline; }
+.xl\:items-stretch { align-items: stretch; }
+}

--- a/plugins/acss-utilities/assets/utilities/grid.css
+++ b/plugins/acss-utilities/assets/utilities/grid.css
@@ -1,0 +1,110 @@
+/* grid utilities */
+.grid { display: grid; }
+.inline-grid { display: inline-grid; }
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+
+@media (width >= 30rem) {
+.sm\:grid { display: grid; }
+.sm\:inline-grid { display: inline-grid; }
+.sm\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.sm\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.sm\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.sm\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.sm\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.sm\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.sm\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.sm\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.sm\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.sm\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.sm\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.sm\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.sm\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.sm\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.sm\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.sm\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.sm\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 48rem) {
+.md\:grid { display: grid; }
+.md\:inline-grid { display: inline-grid; }
+.md\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.md\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.md\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.md\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.md\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.md\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.md\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.md\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.md\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.md\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.md\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.md\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.md\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.md\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.md\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 62rem) {
+.lg\:grid { display: grid; }
+.lg\:inline-grid { display: inline-grid; }
+.lg\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.lg\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.lg\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.lg\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.lg\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.lg\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.lg\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.lg\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.lg\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.lg\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.lg\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.lg\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.lg\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.lg\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.lg\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}
+@media (width >= 80rem) {
+.xl\:grid { display: grid; }
+.xl\:inline-grid { display: inline-grid; }
+.xl\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.xl\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.xl\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.xl\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.xl\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.xl\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.xl\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.xl\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.xl\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.xl\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.xl\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.xl\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.xl\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.xl\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.xl\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.xl\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.xl\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.xl\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+}

--- a/plugins/acss-utilities/assets/utilities/position.css
+++ b/plugins/acss-utilities/assets/utilities/position.css
@@ -1,0 +1,6 @@
+/* position utilities */
+.static { position: static; }
+.relative { position: relative; }
+.absolute { position: absolute; }
+.fixed { position: fixed; }
+.sticky { position: sticky; }

--- a/plugins/acss-utilities/assets/utilities/radius.css
+++ b/plugins/acss-utilities/assets/utilities/radius.css
@@ -1,0 +1,8 @@
+/* radius utilities */
+.rounded-none { border-radius: 0; }
+.rounded-sm { border-radius: 0.125rem; }
+.rounded { border-radius: 0.375rem; }
+.rounded-md { border-radius: 0.375rem; }
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-xl { border-radius: 0.75rem; }
+.rounded-full { border-radius: 9999px; }

--- a/plugins/acss-utilities/assets/utilities/shadow.css
+++ b/plugins/acss-utilities/assets/utilities/shadow.css
@@ -1,0 +1,7 @@
+/* shadow utilities */
+.shadow-none { box-shadow: none; }
+.shadow-sm { box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05); }
+.shadow { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1); }
+.shadow-md { box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1); }
+.shadow-lg { box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1); }
+.shadow-xl { box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1); }

--- a/plugins/acss-utilities/assets/utilities/spacing.css
+++ b/plugins/acss-utilities/assets/utilities/spacing.css
@@ -1,0 +1,1060 @@
+/* spacing utilities */
+.m-0 { margin: 0; }
+.m-1 { margin: 0.25rem; }
+.m-2 { margin: 0.5rem; }
+.m-3 { margin: 0.75rem; }
+.m-4 { margin: 1rem; }
+.m-5 { margin: 1.25rem; }
+.m-6 { margin: 1.5rem; }
+.m-8 { margin: 2rem; }
+.m-10 { margin: 2.5rem; }
+.m-12 { margin: 3rem; }
+.m-16 { margin: 4rem; }
+.m-20 { margin: 5rem; }
+.m-24 { margin: 6rem; }
+.m-32 { margin: 8rem; }
+.mt-0 { margin-top: 0; }
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
+.mt-5 { margin-top: 1.25rem; }
+.mt-6 { margin-top: 1.5rem; }
+.mt-8 { margin-top: 2rem; }
+.mt-10 { margin-top: 2.5rem; }
+.mt-12 { margin-top: 3rem; }
+.mt-16 { margin-top: 4rem; }
+.mt-20 { margin-top: 5rem; }
+.mt-24 { margin-top: 6rem; }
+.mt-32 { margin-top: 8rem; }
+.mb-0 { margin-bottom: 0; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-5 { margin-bottom: 1.25rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+.mb-10 { margin-bottom: 2.5rem; }
+.mb-12 { margin-bottom: 3rem; }
+.mb-16 { margin-bottom: 4rem; }
+.mb-20 { margin-bottom: 5rem; }
+.mb-24 { margin-bottom: 6rem; }
+.mb-32 { margin-bottom: 8rem; }
+.ml-0 { margin-left: 0; }
+.ml-1 { margin-left: 0.25rem; }
+.ml-2 { margin-left: 0.5rem; }
+.ml-3 { margin-left: 0.75rem; }
+.ml-4 { margin-left: 1rem; }
+.ml-5 { margin-left: 1.25rem; }
+.ml-6 { margin-left: 1.5rem; }
+.ml-8 { margin-left: 2rem; }
+.ml-10 { margin-left: 2.5rem; }
+.ml-12 { margin-left: 3rem; }
+.ml-16 { margin-left: 4rem; }
+.ml-20 { margin-left: 5rem; }
+.ml-24 { margin-left: 6rem; }
+.ml-32 { margin-left: 8rem; }
+.mr-0 { margin-right: 0; }
+.mr-1 { margin-right: 0.25rem; }
+.mr-2 { margin-right: 0.5rem; }
+.mr-3 { margin-right: 0.75rem; }
+.mr-4 { margin-right: 1rem; }
+.mr-5 { margin-right: 1.25rem; }
+.mr-6 { margin-right: 1.5rem; }
+.mr-8 { margin-right: 2rem; }
+.mr-10 { margin-right: 2.5rem; }
+.mr-12 { margin-right: 3rem; }
+.mr-16 { margin-right: 4rem; }
+.mr-20 { margin-right: 5rem; }
+.mr-24 { margin-right: 6rem; }
+.mr-32 { margin-right: 8rem; }
+.mx-0 { margin-left: 0; margin-right: 0; }
+.mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.my-0 { margin-top: 0; margin-bottom: 0; }
+.my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.p-0 { padding: 0; }
+.p-1 { padding: 0.25rem; }
+.p-2 { padding: 0.5rem; }
+.p-3 { padding: 0.75rem; }
+.p-4 { padding: 1rem; }
+.p-5 { padding: 1.25rem; }
+.p-6 { padding: 1.5rem; }
+.p-8 { padding: 2rem; }
+.p-10 { padding: 2.5rem; }
+.p-12 { padding: 3rem; }
+.p-16 { padding: 4rem; }
+.p-20 { padding: 5rem; }
+.p-24 { padding: 6rem; }
+.p-32 { padding: 8rem; }
+.pt-0 { padding-top: 0; }
+.pt-1 { padding-top: 0.25rem; }
+.pt-2 { padding-top: 0.5rem; }
+.pt-3 { padding-top: 0.75rem; }
+.pt-4 { padding-top: 1rem; }
+.pt-5 { padding-top: 1.25rem; }
+.pt-6 { padding-top: 1.5rem; }
+.pt-8 { padding-top: 2rem; }
+.pt-10 { padding-top: 2.5rem; }
+.pt-12 { padding-top: 3rem; }
+.pt-16 { padding-top: 4rem; }
+.pt-20 { padding-top: 5rem; }
+.pt-24 { padding-top: 6rem; }
+.pt-32 { padding-top: 8rem; }
+.pb-0 { padding-bottom: 0; }
+.pb-1 { padding-bottom: 0.25rem; }
+.pb-2 { padding-bottom: 0.5rem; }
+.pb-3 { padding-bottom: 0.75rem; }
+.pb-4 { padding-bottom: 1rem; }
+.pb-5 { padding-bottom: 1.25rem; }
+.pb-6 { padding-bottom: 1.5rem; }
+.pb-8 { padding-bottom: 2rem; }
+.pb-10 { padding-bottom: 2.5rem; }
+.pb-12 { padding-bottom: 3rem; }
+.pb-16 { padding-bottom: 4rem; }
+.pb-20 { padding-bottom: 5rem; }
+.pb-24 { padding-bottom: 6rem; }
+.pb-32 { padding-bottom: 8rem; }
+.pl-0 { padding-left: 0; }
+.pl-1 { padding-left: 0.25rem; }
+.pl-2 { padding-left: 0.5rem; }
+.pl-3 { padding-left: 0.75rem; }
+.pl-4 { padding-left: 1rem; }
+.pl-5 { padding-left: 1.25rem; }
+.pl-6 { padding-left: 1.5rem; }
+.pl-8 { padding-left: 2rem; }
+.pl-10 { padding-left: 2.5rem; }
+.pl-12 { padding-left: 3rem; }
+.pl-16 { padding-left: 4rem; }
+.pl-20 { padding-left: 5rem; }
+.pl-24 { padding-left: 6rem; }
+.pl-32 { padding-left: 8rem; }
+.pr-0 { padding-right: 0; }
+.pr-1 { padding-right: 0.25rem; }
+.pr-2 { padding-right: 0.5rem; }
+.pr-3 { padding-right: 0.75rem; }
+.pr-4 { padding-right: 1rem; }
+.pr-5 { padding-right: 1.25rem; }
+.pr-6 { padding-right: 1.5rem; }
+.pr-8 { padding-right: 2rem; }
+.pr-10 { padding-right: 2.5rem; }
+.pr-12 { padding-right: 3rem; }
+.pr-16 { padding-right: 4rem; }
+.pr-20 { padding-right: 5rem; }
+.pr-24 { padding-right: 6rem; }
+.pr-32 { padding-right: 8rem; }
+.px-0 { padding-left: 0; padding-right: 0; }
+.px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+.px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+.px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.px-12 { padding-left: 3rem; padding-right: 3rem; }
+.px-16 { padding-left: 4rem; padding-right: 4rem; }
+.px-20 { padding-left: 5rem; padding-right: 5rem; }
+.px-24 { padding-left: 6rem; padding-right: 6rem; }
+.px-32 { padding-left: 8rem; padding-right: 8rem; }
+.py-0 { padding-top: 0; padding-bottom: 0; }
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.gap-0 { gap: 0; }
+.gap-1 { gap: 0.25rem; }
+.gap-2 { gap: 0.5rem; }
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-5 { gap: 1.25rem; }
+.gap-6 { gap: 1.5rem; }
+.gap-8 { gap: 2rem; }
+.gap-10 { gap: 2.5rem; }
+.gap-12 { gap: 3rem; }
+.gap-16 { gap: 4rem; }
+.gap-20 { gap: 5rem; }
+.gap-24 { gap: 6rem; }
+.gap-32 { gap: 8rem; }
+
+@media (width >= 30rem) {
+.sm\:m-0 { margin: 0; }
+.sm\:m-1 { margin: 0.25rem; }
+.sm\:m-2 { margin: 0.5rem; }
+.sm\:m-3 { margin: 0.75rem; }
+.sm\:m-4 { margin: 1rem; }
+.sm\:m-5 { margin: 1.25rem; }
+.sm\:m-6 { margin: 1.5rem; }
+.sm\:m-8 { margin: 2rem; }
+.sm\:m-10 { margin: 2.5rem; }
+.sm\:m-12 { margin: 3rem; }
+.sm\:m-16 { margin: 4rem; }
+.sm\:m-20 { margin: 5rem; }
+.sm\:m-24 { margin: 6rem; }
+.sm\:m-32 { margin: 8rem; }
+.sm\:mt-0 { margin-top: 0; }
+.sm\:mt-1 { margin-top: 0.25rem; }
+.sm\:mt-2 { margin-top: 0.5rem; }
+.sm\:mt-3 { margin-top: 0.75rem; }
+.sm\:mt-4 { margin-top: 1rem; }
+.sm\:mt-5 { margin-top: 1.25rem; }
+.sm\:mt-6 { margin-top: 1.5rem; }
+.sm\:mt-8 { margin-top: 2rem; }
+.sm\:mt-10 { margin-top: 2.5rem; }
+.sm\:mt-12 { margin-top: 3rem; }
+.sm\:mt-16 { margin-top: 4rem; }
+.sm\:mt-20 { margin-top: 5rem; }
+.sm\:mt-24 { margin-top: 6rem; }
+.sm\:mt-32 { margin-top: 8rem; }
+.sm\:mb-0 { margin-bottom: 0; }
+.sm\:mb-1 { margin-bottom: 0.25rem; }
+.sm\:mb-2 { margin-bottom: 0.5rem; }
+.sm\:mb-3 { margin-bottom: 0.75rem; }
+.sm\:mb-4 { margin-bottom: 1rem; }
+.sm\:mb-5 { margin-bottom: 1.25rem; }
+.sm\:mb-6 { margin-bottom: 1.5rem; }
+.sm\:mb-8 { margin-bottom: 2rem; }
+.sm\:mb-10 { margin-bottom: 2.5rem; }
+.sm\:mb-12 { margin-bottom: 3rem; }
+.sm\:mb-16 { margin-bottom: 4rem; }
+.sm\:mb-20 { margin-bottom: 5rem; }
+.sm\:mb-24 { margin-bottom: 6rem; }
+.sm\:mb-32 { margin-bottom: 8rem; }
+.sm\:ml-0 { margin-left: 0; }
+.sm\:ml-1 { margin-left: 0.25rem; }
+.sm\:ml-2 { margin-left: 0.5rem; }
+.sm\:ml-3 { margin-left: 0.75rem; }
+.sm\:ml-4 { margin-left: 1rem; }
+.sm\:ml-5 { margin-left: 1.25rem; }
+.sm\:ml-6 { margin-left: 1.5rem; }
+.sm\:ml-8 { margin-left: 2rem; }
+.sm\:ml-10 { margin-left: 2.5rem; }
+.sm\:ml-12 { margin-left: 3rem; }
+.sm\:ml-16 { margin-left: 4rem; }
+.sm\:ml-20 { margin-left: 5rem; }
+.sm\:ml-24 { margin-left: 6rem; }
+.sm\:ml-32 { margin-left: 8rem; }
+.sm\:mr-0 { margin-right: 0; }
+.sm\:mr-1 { margin-right: 0.25rem; }
+.sm\:mr-2 { margin-right: 0.5rem; }
+.sm\:mr-3 { margin-right: 0.75rem; }
+.sm\:mr-4 { margin-right: 1rem; }
+.sm\:mr-5 { margin-right: 1.25rem; }
+.sm\:mr-6 { margin-right: 1.5rem; }
+.sm\:mr-8 { margin-right: 2rem; }
+.sm\:mr-10 { margin-right: 2.5rem; }
+.sm\:mr-12 { margin-right: 3rem; }
+.sm\:mr-16 { margin-right: 4rem; }
+.sm\:mr-20 { margin-right: 5rem; }
+.sm\:mr-24 { margin-right: 6rem; }
+.sm\:mr-32 { margin-right: 8rem; }
+.sm\:mx-0 { margin-left: 0; margin-right: 0; }
+.sm\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.sm\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.sm\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.sm\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.sm\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.sm\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.sm\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.sm\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.sm\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.sm\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.sm\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.sm\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.sm\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.sm\:my-0 { margin-top: 0; margin-bottom: 0; }
+.sm\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.sm\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.sm\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.sm\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.sm\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.sm\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.sm\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.sm\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.sm\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.sm\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.sm\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.sm\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.sm\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.sm\:p-0 { padding: 0; }
+.sm\:p-1 { padding: 0.25rem; }
+.sm\:p-2 { padding: 0.5rem; }
+.sm\:p-3 { padding: 0.75rem; }
+.sm\:p-4 { padding: 1rem; }
+.sm\:p-5 { padding: 1.25rem; }
+.sm\:p-6 { padding: 1.5rem; }
+.sm\:p-8 { padding: 2rem; }
+.sm\:p-10 { padding: 2.5rem; }
+.sm\:p-12 { padding: 3rem; }
+.sm\:p-16 { padding: 4rem; }
+.sm\:p-20 { padding: 5rem; }
+.sm\:p-24 { padding: 6rem; }
+.sm\:p-32 { padding: 8rem; }
+.sm\:pt-0 { padding-top: 0; }
+.sm\:pt-1 { padding-top: 0.25rem; }
+.sm\:pt-2 { padding-top: 0.5rem; }
+.sm\:pt-3 { padding-top: 0.75rem; }
+.sm\:pt-4 { padding-top: 1rem; }
+.sm\:pt-5 { padding-top: 1.25rem; }
+.sm\:pt-6 { padding-top: 1.5rem; }
+.sm\:pt-8 { padding-top: 2rem; }
+.sm\:pt-10 { padding-top: 2.5rem; }
+.sm\:pt-12 { padding-top: 3rem; }
+.sm\:pt-16 { padding-top: 4rem; }
+.sm\:pt-20 { padding-top: 5rem; }
+.sm\:pt-24 { padding-top: 6rem; }
+.sm\:pt-32 { padding-top: 8rem; }
+.sm\:pb-0 { padding-bottom: 0; }
+.sm\:pb-1 { padding-bottom: 0.25rem; }
+.sm\:pb-2 { padding-bottom: 0.5rem; }
+.sm\:pb-3 { padding-bottom: 0.75rem; }
+.sm\:pb-4 { padding-bottom: 1rem; }
+.sm\:pb-5 { padding-bottom: 1.25rem; }
+.sm\:pb-6 { padding-bottom: 1.5rem; }
+.sm\:pb-8 { padding-bottom: 2rem; }
+.sm\:pb-10 { padding-bottom: 2.5rem; }
+.sm\:pb-12 { padding-bottom: 3rem; }
+.sm\:pb-16 { padding-bottom: 4rem; }
+.sm\:pb-20 { padding-bottom: 5rem; }
+.sm\:pb-24 { padding-bottom: 6rem; }
+.sm\:pb-32 { padding-bottom: 8rem; }
+.sm\:pl-0 { padding-left: 0; }
+.sm\:pl-1 { padding-left: 0.25rem; }
+.sm\:pl-2 { padding-left: 0.5rem; }
+.sm\:pl-3 { padding-left: 0.75rem; }
+.sm\:pl-4 { padding-left: 1rem; }
+.sm\:pl-5 { padding-left: 1.25rem; }
+.sm\:pl-6 { padding-left: 1.5rem; }
+.sm\:pl-8 { padding-left: 2rem; }
+.sm\:pl-10 { padding-left: 2.5rem; }
+.sm\:pl-12 { padding-left: 3rem; }
+.sm\:pl-16 { padding-left: 4rem; }
+.sm\:pl-20 { padding-left: 5rem; }
+.sm\:pl-24 { padding-left: 6rem; }
+.sm\:pl-32 { padding-left: 8rem; }
+.sm\:pr-0 { padding-right: 0; }
+.sm\:pr-1 { padding-right: 0.25rem; }
+.sm\:pr-2 { padding-right: 0.5rem; }
+.sm\:pr-3 { padding-right: 0.75rem; }
+.sm\:pr-4 { padding-right: 1rem; }
+.sm\:pr-5 { padding-right: 1.25rem; }
+.sm\:pr-6 { padding-right: 1.5rem; }
+.sm\:pr-8 { padding-right: 2rem; }
+.sm\:pr-10 { padding-right: 2.5rem; }
+.sm\:pr-12 { padding-right: 3rem; }
+.sm\:pr-16 { padding-right: 4rem; }
+.sm\:pr-20 { padding-right: 5rem; }
+.sm\:pr-24 { padding-right: 6rem; }
+.sm\:pr-32 { padding-right: 8rem; }
+.sm\:px-0 { padding-left: 0; padding-right: 0; }
+.sm\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.sm\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.sm\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.sm\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.sm\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.sm\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.sm\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.sm\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.sm\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.sm\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.sm\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.sm\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.sm\:py-0 { padding-top: 0; padding-bottom: 0; }
+.sm\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.sm\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.sm\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.sm\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.sm\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.sm\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.sm\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.sm\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.sm\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.sm\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.sm\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.sm\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.sm\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.sm\:gap-0 { gap: 0; }
+.sm\:gap-1 { gap: 0.25rem; }
+.sm\:gap-2 { gap: 0.5rem; }
+.sm\:gap-3 { gap: 0.75rem; }
+.sm\:gap-4 { gap: 1rem; }
+.sm\:gap-5 { gap: 1.25rem; }
+.sm\:gap-6 { gap: 1.5rem; }
+.sm\:gap-8 { gap: 2rem; }
+.sm\:gap-10 { gap: 2.5rem; }
+.sm\:gap-12 { gap: 3rem; }
+.sm\:gap-16 { gap: 4rem; }
+.sm\:gap-20 { gap: 5rem; }
+.sm\:gap-24 { gap: 6rem; }
+.sm\:gap-32 { gap: 8rem; }
+}
+@media (width >= 48rem) {
+.md\:m-0 { margin: 0; }
+.md\:m-1 { margin: 0.25rem; }
+.md\:m-2 { margin: 0.5rem; }
+.md\:m-3 { margin: 0.75rem; }
+.md\:m-4 { margin: 1rem; }
+.md\:m-5 { margin: 1.25rem; }
+.md\:m-6 { margin: 1.5rem; }
+.md\:m-8 { margin: 2rem; }
+.md\:m-10 { margin: 2.5rem; }
+.md\:m-12 { margin: 3rem; }
+.md\:m-16 { margin: 4rem; }
+.md\:m-20 { margin: 5rem; }
+.md\:m-24 { margin: 6rem; }
+.md\:m-32 { margin: 8rem; }
+.md\:mt-0 { margin-top: 0; }
+.md\:mt-1 { margin-top: 0.25rem; }
+.md\:mt-2 { margin-top: 0.5rem; }
+.md\:mt-3 { margin-top: 0.75rem; }
+.md\:mt-4 { margin-top: 1rem; }
+.md\:mt-5 { margin-top: 1.25rem; }
+.md\:mt-6 { margin-top: 1.5rem; }
+.md\:mt-8 { margin-top: 2rem; }
+.md\:mt-10 { margin-top: 2.5rem; }
+.md\:mt-12 { margin-top: 3rem; }
+.md\:mt-16 { margin-top: 4rem; }
+.md\:mt-20 { margin-top: 5rem; }
+.md\:mt-24 { margin-top: 6rem; }
+.md\:mt-32 { margin-top: 8rem; }
+.md\:mb-0 { margin-bottom: 0; }
+.md\:mb-1 { margin-bottom: 0.25rem; }
+.md\:mb-2 { margin-bottom: 0.5rem; }
+.md\:mb-3 { margin-bottom: 0.75rem; }
+.md\:mb-4 { margin-bottom: 1rem; }
+.md\:mb-5 { margin-bottom: 1.25rem; }
+.md\:mb-6 { margin-bottom: 1.5rem; }
+.md\:mb-8 { margin-bottom: 2rem; }
+.md\:mb-10 { margin-bottom: 2.5rem; }
+.md\:mb-12 { margin-bottom: 3rem; }
+.md\:mb-16 { margin-bottom: 4rem; }
+.md\:mb-20 { margin-bottom: 5rem; }
+.md\:mb-24 { margin-bottom: 6rem; }
+.md\:mb-32 { margin-bottom: 8rem; }
+.md\:ml-0 { margin-left: 0; }
+.md\:ml-1 { margin-left: 0.25rem; }
+.md\:ml-2 { margin-left: 0.5rem; }
+.md\:ml-3 { margin-left: 0.75rem; }
+.md\:ml-4 { margin-left: 1rem; }
+.md\:ml-5 { margin-left: 1.25rem; }
+.md\:ml-6 { margin-left: 1.5rem; }
+.md\:ml-8 { margin-left: 2rem; }
+.md\:ml-10 { margin-left: 2.5rem; }
+.md\:ml-12 { margin-left: 3rem; }
+.md\:ml-16 { margin-left: 4rem; }
+.md\:ml-20 { margin-left: 5rem; }
+.md\:ml-24 { margin-left: 6rem; }
+.md\:ml-32 { margin-left: 8rem; }
+.md\:mr-0 { margin-right: 0; }
+.md\:mr-1 { margin-right: 0.25rem; }
+.md\:mr-2 { margin-right: 0.5rem; }
+.md\:mr-3 { margin-right: 0.75rem; }
+.md\:mr-4 { margin-right: 1rem; }
+.md\:mr-5 { margin-right: 1.25rem; }
+.md\:mr-6 { margin-right: 1.5rem; }
+.md\:mr-8 { margin-right: 2rem; }
+.md\:mr-10 { margin-right: 2.5rem; }
+.md\:mr-12 { margin-right: 3rem; }
+.md\:mr-16 { margin-right: 4rem; }
+.md\:mr-20 { margin-right: 5rem; }
+.md\:mr-24 { margin-right: 6rem; }
+.md\:mr-32 { margin-right: 8rem; }
+.md\:mx-0 { margin-left: 0; margin-right: 0; }
+.md\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.md\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.md\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.md\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.md\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.md\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.md\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.md\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.md\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.md\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.md\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.md\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.md\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.md\:my-0 { margin-top: 0; margin-bottom: 0; }
+.md\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.md\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.md\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.md\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.md\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.md\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.md\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.md\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.md\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.md\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.md\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.md\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.md\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.md\:p-0 { padding: 0; }
+.md\:p-1 { padding: 0.25rem; }
+.md\:p-2 { padding: 0.5rem; }
+.md\:p-3 { padding: 0.75rem; }
+.md\:p-4 { padding: 1rem; }
+.md\:p-5 { padding: 1.25rem; }
+.md\:p-6 { padding: 1.5rem; }
+.md\:p-8 { padding: 2rem; }
+.md\:p-10 { padding: 2.5rem; }
+.md\:p-12 { padding: 3rem; }
+.md\:p-16 { padding: 4rem; }
+.md\:p-20 { padding: 5rem; }
+.md\:p-24 { padding: 6rem; }
+.md\:p-32 { padding: 8rem; }
+.md\:pt-0 { padding-top: 0; }
+.md\:pt-1 { padding-top: 0.25rem; }
+.md\:pt-2 { padding-top: 0.5rem; }
+.md\:pt-3 { padding-top: 0.75rem; }
+.md\:pt-4 { padding-top: 1rem; }
+.md\:pt-5 { padding-top: 1.25rem; }
+.md\:pt-6 { padding-top: 1.5rem; }
+.md\:pt-8 { padding-top: 2rem; }
+.md\:pt-10 { padding-top: 2.5rem; }
+.md\:pt-12 { padding-top: 3rem; }
+.md\:pt-16 { padding-top: 4rem; }
+.md\:pt-20 { padding-top: 5rem; }
+.md\:pt-24 { padding-top: 6rem; }
+.md\:pt-32 { padding-top: 8rem; }
+.md\:pb-0 { padding-bottom: 0; }
+.md\:pb-1 { padding-bottom: 0.25rem; }
+.md\:pb-2 { padding-bottom: 0.5rem; }
+.md\:pb-3 { padding-bottom: 0.75rem; }
+.md\:pb-4 { padding-bottom: 1rem; }
+.md\:pb-5 { padding-bottom: 1.25rem; }
+.md\:pb-6 { padding-bottom: 1.5rem; }
+.md\:pb-8 { padding-bottom: 2rem; }
+.md\:pb-10 { padding-bottom: 2.5rem; }
+.md\:pb-12 { padding-bottom: 3rem; }
+.md\:pb-16 { padding-bottom: 4rem; }
+.md\:pb-20 { padding-bottom: 5rem; }
+.md\:pb-24 { padding-bottom: 6rem; }
+.md\:pb-32 { padding-bottom: 8rem; }
+.md\:pl-0 { padding-left: 0; }
+.md\:pl-1 { padding-left: 0.25rem; }
+.md\:pl-2 { padding-left: 0.5rem; }
+.md\:pl-3 { padding-left: 0.75rem; }
+.md\:pl-4 { padding-left: 1rem; }
+.md\:pl-5 { padding-left: 1.25rem; }
+.md\:pl-6 { padding-left: 1.5rem; }
+.md\:pl-8 { padding-left: 2rem; }
+.md\:pl-10 { padding-left: 2.5rem; }
+.md\:pl-12 { padding-left: 3rem; }
+.md\:pl-16 { padding-left: 4rem; }
+.md\:pl-20 { padding-left: 5rem; }
+.md\:pl-24 { padding-left: 6rem; }
+.md\:pl-32 { padding-left: 8rem; }
+.md\:pr-0 { padding-right: 0; }
+.md\:pr-1 { padding-right: 0.25rem; }
+.md\:pr-2 { padding-right: 0.5rem; }
+.md\:pr-3 { padding-right: 0.75rem; }
+.md\:pr-4 { padding-right: 1rem; }
+.md\:pr-5 { padding-right: 1.25rem; }
+.md\:pr-6 { padding-right: 1.5rem; }
+.md\:pr-8 { padding-right: 2rem; }
+.md\:pr-10 { padding-right: 2.5rem; }
+.md\:pr-12 { padding-right: 3rem; }
+.md\:pr-16 { padding-right: 4rem; }
+.md\:pr-20 { padding-right: 5rem; }
+.md\:pr-24 { padding-right: 6rem; }
+.md\:pr-32 { padding-right: 8rem; }
+.md\:px-0 { padding-left: 0; padding-right: 0; }
+.md\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.md\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.md\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.md\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.md\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.md\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.md\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.md\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.md\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.md\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.md\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.md\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.md\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.md\:py-0 { padding-top: 0; padding-bottom: 0; }
+.md\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.md\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.md\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.md\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.md\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.md\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.md\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.md\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.md\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.md\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.md\:gap-0 { gap: 0; }
+.md\:gap-1 { gap: 0.25rem; }
+.md\:gap-2 { gap: 0.5rem; }
+.md\:gap-3 { gap: 0.75rem; }
+.md\:gap-4 { gap: 1rem; }
+.md\:gap-5 { gap: 1.25rem; }
+.md\:gap-6 { gap: 1.5rem; }
+.md\:gap-8 { gap: 2rem; }
+.md\:gap-10 { gap: 2.5rem; }
+.md\:gap-12 { gap: 3rem; }
+.md\:gap-16 { gap: 4rem; }
+.md\:gap-20 { gap: 5rem; }
+.md\:gap-24 { gap: 6rem; }
+.md\:gap-32 { gap: 8rem; }
+}
+@media (width >= 62rem) {
+.lg\:m-0 { margin: 0; }
+.lg\:m-1 { margin: 0.25rem; }
+.lg\:m-2 { margin: 0.5rem; }
+.lg\:m-3 { margin: 0.75rem; }
+.lg\:m-4 { margin: 1rem; }
+.lg\:m-5 { margin: 1.25rem; }
+.lg\:m-6 { margin: 1.5rem; }
+.lg\:m-8 { margin: 2rem; }
+.lg\:m-10 { margin: 2.5rem; }
+.lg\:m-12 { margin: 3rem; }
+.lg\:m-16 { margin: 4rem; }
+.lg\:m-20 { margin: 5rem; }
+.lg\:m-24 { margin: 6rem; }
+.lg\:m-32 { margin: 8rem; }
+.lg\:mt-0 { margin-top: 0; }
+.lg\:mt-1 { margin-top: 0.25rem; }
+.lg\:mt-2 { margin-top: 0.5rem; }
+.lg\:mt-3 { margin-top: 0.75rem; }
+.lg\:mt-4 { margin-top: 1rem; }
+.lg\:mt-5 { margin-top: 1.25rem; }
+.lg\:mt-6 { margin-top: 1.5rem; }
+.lg\:mt-8 { margin-top: 2rem; }
+.lg\:mt-10 { margin-top: 2.5rem; }
+.lg\:mt-12 { margin-top: 3rem; }
+.lg\:mt-16 { margin-top: 4rem; }
+.lg\:mt-20 { margin-top: 5rem; }
+.lg\:mt-24 { margin-top: 6rem; }
+.lg\:mt-32 { margin-top: 8rem; }
+.lg\:mb-0 { margin-bottom: 0; }
+.lg\:mb-1 { margin-bottom: 0.25rem; }
+.lg\:mb-2 { margin-bottom: 0.5rem; }
+.lg\:mb-3 { margin-bottom: 0.75rem; }
+.lg\:mb-4 { margin-bottom: 1rem; }
+.lg\:mb-5 { margin-bottom: 1.25rem; }
+.lg\:mb-6 { margin-bottom: 1.5rem; }
+.lg\:mb-8 { margin-bottom: 2rem; }
+.lg\:mb-10 { margin-bottom: 2.5rem; }
+.lg\:mb-12 { margin-bottom: 3rem; }
+.lg\:mb-16 { margin-bottom: 4rem; }
+.lg\:mb-20 { margin-bottom: 5rem; }
+.lg\:mb-24 { margin-bottom: 6rem; }
+.lg\:mb-32 { margin-bottom: 8rem; }
+.lg\:ml-0 { margin-left: 0; }
+.lg\:ml-1 { margin-left: 0.25rem; }
+.lg\:ml-2 { margin-left: 0.5rem; }
+.lg\:ml-3 { margin-left: 0.75rem; }
+.lg\:ml-4 { margin-left: 1rem; }
+.lg\:ml-5 { margin-left: 1.25rem; }
+.lg\:ml-6 { margin-left: 1.5rem; }
+.lg\:ml-8 { margin-left: 2rem; }
+.lg\:ml-10 { margin-left: 2.5rem; }
+.lg\:ml-12 { margin-left: 3rem; }
+.lg\:ml-16 { margin-left: 4rem; }
+.lg\:ml-20 { margin-left: 5rem; }
+.lg\:ml-24 { margin-left: 6rem; }
+.lg\:ml-32 { margin-left: 8rem; }
+.lg\:mr-0 { margin-right: 0; }
+.lg\:mr-1 { margin-right: 0.25rem; }
+.lg\:mr-2 { margin-right: 0.5rem; }
+.lg\:mr-3 { margin-right: 0.75rem; }
+.lg\:mr-4 { margin-right: 1rem; }
+.lg\:mr-5 { margin-right: 1.25rem; }
+.lg\:mr-6 { margin-right: 1.5rem; }
+.lg\:mr-8 { margin-right: 2rem; }
+.lg\:mr-10 { margin-right: 2.5rem; }
+.lg\:mr-12 { margin-right: 3rem; }
+.lg\:mr-16 { margin-right: 4rem; }
+.lg\:mr-20 { margin-right: 5rem; }
+.lg\:mr-24 { margin-right: 6rem; }
+.lg\:mr-32 { margin-right: 8rem; }
+.lg\:mx-0 { margin-left: 0; margin-right: 0; }
+.lg\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.lg\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.lg\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.lg\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.lg\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.lg\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.lg\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.lg\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.lg\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.lg\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.lg\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.lg\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.lg\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.lg\:my-0 { margin-top: 0; margin-bottom: 0; }
+.lg\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.lg\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.lg\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.lg\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.lg\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.lg\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.lg\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.lg\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.lg\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.lg\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.lg\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.lg\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.lg\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.lg\:p-0 { padding: 0; }
+.lg\:p-1 { padding: 0.25rem; }
+.lg\:p-2 { padding: 0.5rem; }
+.lg\:p-3 { padding: 0.75rem; }
+.lg\:p-4 { padding: 1rem; }
+.lg\:p-5 { padding: 1.25rem; }
+.lg\:p-6 { padding: 1.5rem; }
+.lg\:p-8 { padding: 2rem; }
+.lg\:p-10 { padding: 2.5rem; }
+.lg\:p-12 { padding: 3rem; }
+.lg\:p-16 { padding: 4rem; }
+.lg\:p-20 { padding: 5rem; }
+.lg\:p-24 { padding: 6rem; }
+.lg\:p-32 { padding: 8rem; }
+.lg\:pt-0 { padding-top: 0; }
+.lg\:pt-1 { padding-top: 0.25rem; }
+.lg\:pt-2 { padding-top: 0.5rem; }
+.lg\:pt-3 { padding-top: 0.75rem; }
+.lg\:pt-4 { padding-top: 1rem; }
+.lg\:pt-5 { padding-top: 1.25rem; }
+.lg\:pt-6 { padding-top: 1.5rem; }
+.lg\:pt-8 { padding-top: 2rem; }
+.lg\:pt-10 { padding-top: 2.5rem; }
+.lg\:pt-12 { padding-top: 3rem; }
+.lg\:pt-16 { padding-top: 4rem; }
+.lg\:pt-20 { padding-top: 5rem; }
+.lg\:pt-24 { padding-top: 6rem; }
+.lg\:pt-32 { padding-top: 8rem; }
+.lg\:pb-0 { padding-bottom: 0; }
+.lg\:pb-1 { padding-bottom: 0.25rem; }
+.lg\:pb-2 { padding-bottom: 0.5rem; }
+.lg\:pb-3 { padding-bottom: 0.75rem; }
+.lg\:pb-4 { padding-bottom: 1rem; }
+.lg\:pb-5 { padding-bottom: 1.25rem; }
+.lg\:pb-6 { padding-bottom: 1.5rem; }
+.lg\:pb-8 { padding-bottom: 2rem; }
+.lg\:pb-10 { padding-bottom: 2.5rem; }
+.lg\:pb-12 { padding-bottom: 3rem; }
+.lg\:pb-16 { padding-bottom: 4rem; }
+.lg\:pb-20 { padding-bottom: 5rem; }
+.lg\:pb-24 { padding-bottom: 6rem; }
+.lg\:pb-32 { padding-bottom: 8rem; }
+.lg\:pl-0 { padding-left: 0; }
+.lg\:pl-1 { padding-left: 0.25rem; }
+.lg\:pl-2 { padding-left: 0.5rem; }
+.lg\:pl-3 { padding-left: 0.75rem; }
+.lg\:pl-4 { padding-left: 1rem; }
+.lg\:pl-5 { padding-left: 1.25rem; }
+.lg\:pl-6 { padding-left: 1.5rem; }
+.lg\:pl-8 { padding-left: 2rem; }
+.lg\:pl-10 { padding-left: 2.5rem; }
+.lg\:pl-12 { padding-left: 3rem; }
+.lg\:pl-16 { padding-left: 4rem; }
+.lg\:pl-20 { padding-left: 5rem; }
+.lg\:pl-24 { padding-left: 6rem; }
+.lg\:pl-32 { padding-left: 8rem; }
+.lg\:pr-0 { padding-right: 0; }
+.lg\:pr-1 { padding-right: 0.25rem; }
+.lg\:pr-2 { padding-right: 0.5rem; }
+.lg\:pr-3 { padding-right: 0.75rem; }
+.lg\:pr-4 { padding-right: 1rem; }
+.lg\:pr-5 { padding-right: 1.25rem; }
+.lg\:pr-6 { padding-right: 1.5rem; }
+.lg\:pr-8 { padding-right: 2rem; }
+.lg\:pr-10 { padding-right: 2.5rem; }
+.lg\:pr-12 { padding-right: 3rem; }
+.lg\:pr-16 { padding-right: 4rem; }
+.lg\:pr-20 { padding-right: 5rem; }
+.lg\:pr-24 { padding-right: 6rem; }
+.lg\:pr-32 { padding-right: 8rem; }
+.lg\:px-0 { padding-left: 0; padding-right: 0; }
+.lg\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.lg\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.lg\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.lg\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.lg\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.lg\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.lg\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.lg\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.lg\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.lg\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.lg\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.lg\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.lg\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.lg\:py-0 { padding-top: 0; padding-bottom: 0; }
+.lg\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.lg\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.lg\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.lg\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.lg\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.lg\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.lg\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.lg\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.lg\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.lg\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.lg\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.lg\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.lg\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.lg\:gap-0 { gap: 0; }
+.lg\:gap-1 { gap: 0.25rem; }
+.lg\:gap-2 { gap: 0.5rem; }
+.lg\:gap-3 { gap: 0.75rem; }
+.lg\:gap-4 { gap: 1rem; }
+.lg\:gap-5 { gap: 1.25rem; }
+.lg\:gap-6 { gap: 1.5rem; }
+.lg\:gap-8 { gap: 2rem; }
+.lg\:gap-10 { gap: 2.5rem; }
+.lg\:gap-12 { gap: 3rem; }
+.lg\:gap-16 { gap: 4rem; }
+.lg\:gap-20 { gap: 5rem; }
+.lg\:gap-24 { gap: 6rem; }
+.lg\:gap-32 { gap: 8rem; }
+}
+@media (width >= 80rem) {
+.xl\:m-0 { margin: 0; }
+.xl\:m-1 { margin: 0.25rem; }
+.xl\:m-2 { margin: 0.5rem; }
+.xl\:m-3 { margin: 0.75rem; }
+.xl\:m-4 { margin: 1rem; }
+.xl\:m-5 { margin: 1.25rem; }
+.xl\:m-6 { margin: 1.5rem; }
+.xl\:m-8 { margin: 2rem; }
+.xl\:m-10 { margin: 2.5rem; }
+.xl\:m-12 { margin: 3rem; }
+.xl\:m-16 { margin: 4rem; }
+.xl\:m-20 { margin: 5rem; }
+.xl\:m-24 { margin: 6rem; }
+.xl\:m-32 { margin: 8rem; }
+.xl\:mt-0 { margin-top: 0; }
+.xl\:mt-1 { margin-top: 0.25rem; }
+.xl\:mt-2 { margin-top: 0.5rem; }
+.xl\:mt-3 { margin-top: 0.75rem; }
+.xl\:mt-4 { margin-top: 1rem; }
+.xl\:mt-5 { margin-top: 1.25rem; }
+.xl\:mt-6 { margin-top: 1.5rem; }
+.xl\:mt-8 { margin-top: 2rem; }
+.xl\:mt-10 { margin-top: 2.5rem; }
+.xl\:mt-12 { margin-top: 3rem; }
+.xl\:mt-16 { margin-top: 4rem; }
+.xl\:mt-20 { margin-top: 5rem; }
+.xl\:mt-24 { margin-top: 6rem; }
+.xl\:mt-32 { margin-top: 8rem; }
+.xl\:mb-0 { margin-bottom: 0; }
+.xl\:mb-1 { margin-bottom: 0.25rem; }
+.xl\:mb-2 { margin-bottom: 0.5rem; }
+.xl\:mb-3 { margin-bottom: 0.75rem; }
+.xl\:mb-4 { margin-bottom: 1rem; }
+.xl\:mb-5 { margin-bottom: 1.25rem; }
+.xl\:mb-6 { margin-bottom: 1.5rem; }
+.xl\:mb-8 { margin-bottom: 2rem; }
+.xl\:mb-10 { margin-bottom: 2.5rem; }
+.xl\:mb-12 { margin-bottom: 3rem; }
+.xl\:mb-16 { margin-bottom: 4rem; }
+.xl\:mb-20 { margin-bottom: 5rem; }
+.xl\:mb-24 { margin-bottom: 6rem; }
+.xl\:mb-32 { margin-bottom: 8rem; }
+.xl\:ml-0 { margin-left: 0; }
+.xl\:ml-1 { margin-left: 0.25rem; }
+.xl\:ml-2 { margin-left: 0.5rem; }
+.xl\:ml-3 { margin-left: 0.75rem; }
+.xl\:ml-4 { margin-left: 1rem; }
+.xl\:ml-5 { margin-left: 1.25rem; }
+.xl\:ml-6 { margin-left: 1.5rem; }
+.xl\:ml-8 { margin-left: 2rem; }
+.xl\:ml-10 { margin-left: 2.5rem; }
+.xl\:ml-12 { margin-left: 3rem; }
+.xl\:ml-16 { margin-left: 4rem; }
+.xl\:ml-20 { margin-left: 5rem; }
+.xl\:ml-24 { margin-left: 6rem; }
+.xl\:ml-32 { margin-left: 8rem; }
+.xl\:mr-0 { margin-right: 0; }
+.xl\:mr-1 { margin-right: 0.25rem; }
+.xl\:mr-2 { margin-right: 0.5rem; }
+.xl\:mr-3 { margin-right: 0.75rem; }
+.xl\:mr-4 { margin-right: 1rem; }
+.xl\:mr-5 { margin-right: 1.25rem; }
+.xl\:mr-6 { margin-right: 1.5rem; }
+.xl\:mr-8 { margin-right: 2rem; }
+.xl\:mr-10 { margin-right: 2.5rem; }
+.xl\:mr-12 { margin-right: 3rem; }
+.xl\:mr-16 { margin-right: 4rem; }
+.xl\:mr-20 { margin-right: 5rem; }
+.xl\:mr-24 { margin-right: 6rem; }
+.xl\:mr-32 { margin-right: 8rem; }
+.xl\:mx-0 { margin-left: 0; margin-right: 0; }
+.xl\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.xl\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.xl\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.xl\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.xl\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.xl\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.xl\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.xl\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.xl\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.xl\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.xl\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.xl\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.xl\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.xl\:my-0 { margin-top: 0; margin-bottom: 0; }
+.xl\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.xl\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.xl\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.xl\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.xl\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.xl\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.xl\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.xl\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.xl\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.xl\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.xl\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.xl\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.xl\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.xl\:p-0 { padding: 0; }
+.xl\:p-1 { padding: 0.25rem; }
+.xl\:p-2 { padding: 0.5rem; }
+.xl\:p-3 { padding: 0.75rem; }
+.xl\:p-4 { padding: 1rem; }
+.xl\:p-5 { padding: 1.25rem; }
+.xl\:p-6 { padding: 1.5rem; }
+.xl\:p-8 { padding: 2rem; }
+.xl\:p-10 { padding: 2.5rem; }
+.xl\:p-12 { padding: 3rem; }
+.xl\:p-16 { padding: 4rem; }
+.xl\:p-20 { padding: 5rem; }
+.xl\:p-24 { padding: 6rem; }
+.xl\:p-32 { padding: 8rem; }
+.xl\:pt-0 { padding-top: 0; }
+.xl\:pt-1 { padding-top: 0.25rem; }
+.xl\:pt-2 { padding-top: 0.5rem; }
+.xl\:pt-3 { padding-top: 0.75rem; }
+.xl\:pt-4 { padding-top: 1rem; }
+.xl\:pt-5 { padding-top: 1.25rem; }
+.xl\:pt-6 { padding-top: 1.5rem; }
+.xl\:pt-8 { padding-top: 2rem; }
+.xl\:pt-10 { padding-top: 2.5rem; }
+.xl\:pt-12 { padding-top: 3rem; }
+.xl\:pt-16 { padding-top: 4rem; }
+.xl\:pt-20 { padding-top: 5rem; }
+.xl\:pt-24 { padding-top: 6rem; }
+.xl\:pt-32 { padding-top: 8rem; }
+.xl\:pb-0 { padding-bottom: 0; }
+.xl\:pb-1 { padding-bottom: 0.25rem; }
+.xl\:pb-2 { padding-bottom: 0.5rem; }
+.xl\:pb-3 { padding-bottom: 0.75rem; }
+.xl\:pb-4 { padding-bottom: 1rem; }
+.xl\:pb-5 { padding-bottom: 1.25rem; }
+.xl\:pb-6 { padding-bottom: 1.5rem; }
+.xl\:pb-8 { padding-bottom: 2rem; }
+.xl\:pb-10 { padding-bottom: 2.5rem; }
+.xl\:pb-12 { padding-bottom: 3rem; }
+.xl\:pb-16 { padding-bottom: 4rem; }
+.xl\:pb-20 { padding-bottom: 5rem; }
+.xl\:pb-24 { padding-bottom: 6rem; }
+.xl\:pb-32 { padding-bottom: 8rem; }
+.xl\:pl-0 { padding-left: 0; }
+.xl\:pl-1 { padding-left: 0.25rem; }
+.xl\:pl-2 { padding-left: 0.5rem; }
+.xl\:pl-3 { padding-left: 0.75rem; }
+.xl\:pl-4 { padding-left: 1rem; }
+.xl\:pl-5 { padding-left: 1.25rem; }
+.xl\:pl-6 { padding-left: 1.5rem; }
+.xl\:pl-8 { padding-left: 2rem; }
+.xl\:pl-10 { padding-left: 2.5rem; }
+.xl\:pl-12 { padding-left: 3rem; }
+.xl\:pl-16 { padding-left: 4rem; }
+.xl\:pl-20 { padding-left: 5rem; }
+.xl\:pl-24 { padding-left: 6rem; }
+.xl\:pl-32 { padding-left: 8rem; }
+.xl\:pr-0 { padding-right: 0; }
+.xl\:pr-1 { padding-right: 0.25rem; }
+.xl\:pr-2 { padding-right: 0.5rem; }
+.xl\:pr-3 { padding-right: 0.75rem; }
+.xl\:pr-4 { padding-right: 1rem; }
+.xl\:pr-5 { padding-right: 1.25rem; }
+.xl\:pr-6 { padding-right: 1.5rem; }
+.xl\:pr-8 { padding-right: 2rem; }
+.xl\:pr-10 { padding-right: 2.5rem; }
+.xl\:pr-12 { padding-right: 3rem; }
+.xl\:pr-16 { padding-right: 4rem; }
+.xl\:pr-20 { padding-right: 5rem; }
+.xl\:pr-24 { padding-right: 6rem; }
+.xl\:pr-32 { padding-right: 8rem; }
+.xl\:px-0 { padding-left: 0; padding-right: 0; }
+.xl\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.xl\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.xl\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.xl\:px-4 { padding-left: 1rem; padding-right: 1rem; }
+.xl\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.xl\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.xl\:px-8 { padding-left: 2rem; padding-right: 2rem; }
+.xl\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.xl\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+.xl\:px-16 { padding-left: 4rem; padding-right: 4rem; }
+.xl\:px-20 { padding-left: 5rem; padding-right: 5rem; }
+.xl\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+.xl\:px-32 { padding-left: 8rem; padding-right: 8rem; }
+.xl\:py-0 { padding-top: 0; padding-bottom: 0; }
+.xl\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.xl\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.xl\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.xl\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.xl\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.xl\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.xl\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.xl\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.xl\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.xl\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.xl\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.xl\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.xl\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.xl\:gap-0 { gap: 0; }
+.xl\:gap-1 { gap: 0.25rem; }
+.xl\:gap-2 { gap: 0.5rem; }
+.xl\:gap-3 { gap: 0.75rem; }
+.xl\:gap-4 { gap: 1rem; }
+.xl\:gap-5 { gap: 1.25rem; }
+.xl\:gap-6 { gap: 1.5rem; }
+.xl\:gap-8 { gap: 2rem; }
+.xl\:gap-10 { gap: 2.5rem; }
+.xl\:gap-12 { gap: 3rem; }
+.xl\:gap-16 { gap: 4rem; }
+.xl\:gap-20 { gap: 5rem; }
+.xl\:gap-24 { gap: 6rem; }
+.xl\:gap-32 { gap: 8rem; }
+}

--- a/plugins/acss-utilities/assets/utilities/type.css
+++ b/plugins/acss-utilities/assets/utilities/type.css
@@ -1,0 +1,20 @@
+/* type utilities */
+.text-xs { font-size: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-base { font-size: 1rem; }
+.text-lg { font-size: 1.125rem; }
+.text-xl { font-size: 1.25rem; }
+.text-2xl { font-size: 1.5rem; }
+.text-3xl { font-size: 1.875rem; }
+.text-4xl { font-size: 2.25rem; }
+.font-normal { font-weight: 400; }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.leading-tight { line-height: 1.25; }
+.leading-normal { line-height: 1.5; }
+.leading-loose { line-height: 1.75; }
+.text-left { text-align: left; }
+.text-center { text-align: center; }
+.text-right { text-align: right; }
+.text-justify { text-align: justify; }

--- a/plugins/acss-utilities/assets/utilities/z-index.css
+++ b/plugins/acss-utilities/assets/utilities/z-index.css
@@ -1,0 +1,8 @@
+/* z-index utilities */
+.z-0 { z-index: 0; }
+.z-10 { z-index: 10; }
+.z-20 { z-index: 20; }
+.z-30 { z-index: 30; }
+.z-40 { z-index: 40; }
+.z-50 { z-index: 50; }
+.z-auto { z-index: auto; }

--- a/plugins/acss-utilities/commands/utility-add.md
+++ b/plugins/acss-utilities/commands/utility-add.md
@@ -1,0 +1,27 @@
+---
+description: Copy the prebuilt utilities.css bundle (and token-bridge.css) into a target React project
+argument-hint: [--target=<dir>] [--families=<comma-list>] [--no-bridge]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+
+Copy the bundled `utilities.css` and `token-bridge.css` into the user's React project.
+
+Follow the `/utility-add` section of `${CLAUDE_PLUGIN_ROOT}/skills/utilities/SKILL.md`.
+
+**Arguments:**
+
+- `--target=<dir>` — override the auto-detected drop directory (default: `src/styles/`).
+- `--families=<comma-list>` — emit only the listed family partials concatenated into a single file. Otherwise the full bundle is copied verbatim. Example: `--families=color-bg,color-text,spacing,display`.
+- `--no-bridge` — skip copying `token-bridge.css`. Use when the project ships its own theme without acss-kit.
+
+**Quick steps:**
+
+1. Run `scripts/detect_utility_target.py`. Use the result to pick the drop directory unless `--target` overrides.
+2. If `--families=` is present, concatenate the requested partials from `assets/utilities/<family>.css` plus the bundle header. Otherwise copy `assets/utilities.css` verbatim to `<target>/utilities.css`.
+3. Unless `--no-bridge`, copy `assets/token-bridge.css` to `<target>/token-bridge.css`.
+4. Print the recommended import order:
+   ```ts
+   import "./styles/token-bridge.css";   // first — defines the aliases
+   import "./styles/utilities.css";       // then — utility classes consume them
+   ```
+5. Print a summary: files written, total size, families included.

--- a/plugins/acss-utilities/commands/utility-bridge.md
+++ b/plugins/acss-utilities/commands/utility-bridge.md
@@ -1,0 +1,22 @@
+---
+description: Regenerate token-bridge.css against the active acss-kit theme (with mandatory dark-mode parity)
+argument-hint: [--theme=<file>]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+
+Regenerate `token-bridge.css` so the fpkit-style aliases (`--color-error`, `--color-error-bg`, `--color-primary-light`, …) resolve to the user's active acss-kit theme. Always emits both `:root` and `[data-theme="dark"]` blocks.
+
+Follow the `/utility-bridge` section of `${CLAUDE_PLUGIN_ROOT}/skills/utilities/SKILL.md`.
+
+**Arguments:**
+
+- `--theme=<file>` — override the source theme. Otherwise the command auto-detects `src/styles/theme/light.css` and `dark.css` in the project root.
+
+**Quick steps:**
+
+1. Resolve the source theme(s). On no-find, fall back to the bundled defaults at `${CLAUDE_PLUGIN_ROOT}/assets/token-bridge.css` and warn the user.
+2. Extract `--color-danger`, `--color-primary`, `--color-success`, `--color-warning`, `--color-info` for both light and dark modes.
+3. Build the bridge with `var()` chains and embedded hex fallbacks. Synthesize `-bg` and `-light` variants via `color-mix(in oklch, …)`.
+4. Write the file to `<projectRoot>/<utilitiesDir>/token-bridge.css` (default `src/styles/token-bridge.css`).
+5. Run `scripts/validate_utilities.py <bridge-file>` to enforce dark-mode parity.
+6. Print a summary: which roles were aliased, dark-mode parity status, fallback values used.

--- a/plugins/acss-utilities/commands/utility-list.md
+++ b/plugins/acss-utilities/commands/utility-list.md
@@ -1,0 +1,31 @@
+---
+description: List utility families and their classes
+argument-hint: [family]
+allowed-tools: Read, Glob, Grep
+---
+
+Read-only catalogue printer for the acss-utilities bundle.
+
+Follow the `/utility-list` section of `${CLAUDE_PLUGIN_ROOT}/skills/utilities/SKILL.md`.
+
+**Arguments:**
+
+- `family` — *optional*. One of `color-bg`, `color-text`, `color-border`, `spacing`, `display`, `flex`, `grid`, `type`, `radius`, `shadow`, `position`, `z-index`. When given, the command prints every class in that family with the property and CSS custom property each one references.
+
+**Quick steps:**
+
+### `/utility-list` (no arguments)
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/assets/utilities.tokens.json`.
+2. Print every entry from `families` with `enabled` and `responsive` status.
+3. Print the spacing scale and breakpoints (since they parameterize multiple families).
+4. Suggest `/utility-list <family>` for class-level detail.
+
+### `/utility-list <family>`
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/assets/utilities/<family>.css`.
+2. Print every selector with the property it sets, one line per class.
+3. For families that reference `--color-*` tokens, also print the `var()` chain and how `token-bridge.css` resolves it.
+4. Print class count and file size.
+
+This command writes nothing.

--- a/plugins/acss-utilities/commands/utility-tune.md
+++ b/plugins/acss-utilities/commands/utility-tune.md
@@ -1,0 +1,30 @@
+---
+description: Adjust the utility-class tokens (spacing baseline, breakpoints, family enables) via natural language
+argument-hint: <natural-language description>
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+
+Adjust `utilities.tokens.json` based on a natural-language request, regenerate the bundle, and validate the result.
+
+Follow the `/utility-tune` section of `${CLAUDE_PLUGIN_ROOT}/skills/utilities/SKILL.md`.
+
+**Examples:**
+
+```
+/utility-tune use a 4px spacing baseline
+/utility-tune use an 8px spacing baseline
+/utility-tune add an xs breakpoint at 20rem
+/utility-tune disable shadow utilities
+/utility-tune drop responsive variants from spacing
+/utility-tune add a 'soft' radius value at 1rem
+```
+
+**Quick steps:**
+
+1. Parse the prompt into one or more concrete edits to `utilities.tokens.json`. If ambiguous, use `AskUserQuestion` to clarify before writing.
+2. Read `${CLAUDE_PLUGIN_ROOT}/assets/utilities.tokens.json`. Apply edits.
+3. Write the updated tokens back to disk (preserve key order).
+4. Run `scripts/generate_utilities.py --tokens <file> --out-dir ${CLAUDE_PLUGIN_ROOT}/assets/`.
+5. Run `scripts/validate_utilities.py ${CLAUDE_PLUGIN_ROOT}/assets/`.
+   - On `ok: false`: print reasons, **revert the tokens edit**, halt. The committed bundle should never go out of contract.
+6. Print a summary: which tokens fields changed, new bundle size, classes added/removed.

--- a/plugins/acss-utilities/docs/README.md
+++ b/plugins/acss-utilities/docs/README.md
@@ -1,0 +1,39 @@
+# acss-utilities — Developer Guide
+
+This directory contains the developer guide for the `acss-utilities` Claude Code plugin. For installation and a command overview, see the [plugin README](../README.md).
+
+## For consumers
+
+Developers using the plugin to add Tailwind-style atomic CSS utility classes to their own projects.
+
+| Guide | What it covers |
+|-------|---------------|
+| [tutorial.md](tutorial.md) | A guided walkthrough: drop the bundle into a React project, import it, and confirm it resolves correctly in dark mode |
+| [concepts.md](concepts.md) | The mental model: kebab-case classes, mandatory `var()` fallbacks, responsive `\:` escaping, `!important` policy, the token bridge, and dark-mode parity |
+| [commands.md](commands.md) | Full reference for `/utility-add`, `/utility-list`, `/utility-tune`, and `/utility-bridge` |
+| [recipes.md](recipes.md) | Step-by-step walkthroughs for the most common tasks |
+| [troubleshooting.md](troubleshooting.md) | Concrete failure modes and how to resolve them |
+
+## For contributors
+
+Developers maintaining or extending the plugin itself (token catalogue, generator, validator, family emitters).
+
+| Guide | What it covers |
+|-------|---------------|
+| [architecture.md](architecture.md) | Plugin internals: layout, the generator/validator contract, how to add a new family, the bundle-size budget resolution order, version-bump checklist |
+
+A diagrams-first companion (`visual-guide.md`) is planned but deferred — see the [architecture guide](architecture.md#deferred-work) for the gap.
+
+## Reference material (canonical sources)
+
+These files are the authoritative source of truth. The guides in this folder summarize and link into them rather than duplicate them.
+
+| File | Purpose |
+|------|---------|
+| [`../skills/utilities/SKILL.md`](../skills/utilities/SKILL.md) | Full per-command workflow invoked by Claude on every `/utility-*` call |
+| [`../skills/utilities/references/utility-catalogue.md`](../skills/utilities/references/utility-catalogue.md) | Every family the plugin emits, every class within it, and the CSS custom property each one references |
+| [`../skills/utilities/references/naming-convention.md`](../skills/utilities/references/naming-convention.md) | Selector grammar, prefix rules, fallback policy, and the `!important` exemption list |
+| [`../skills/utilities/references/breakpoints.md`](../skills/utilities/references/breakpoints.md) | Responsive prefixes, `@media (width >= …)` syntax, and the escaped colon rule |
+| [`../skills/utilities/references/token-bridge.md`](../skills/utilities/references/token-bridge.md) | Bridge mapping, dark-mode parity contract, and regeneration workflow |
+| [`../assets/utilities.tokens.json`](../assets/utilities.tokens.json) | Source-of-truth for the generator: spacing scale, breakpoints, color roles, family-enable map, bundle-size budget |
+| [`../assets/utilities.css`](../assets/utilities.css) | Committed pre-built bundle. Regenerated from the tokens file via `scripts/generate_utilities.py`; idempotency is enforced by `tests/run.sh` |

--- a/plugins/acss-utilities/docs/architecture.md
+++ b/plugins/acss-utilities/docs/architecture.md
@@ -134,12 +134,13 @@ When releasing a new `acss-utilities` version:
 
 `tests/run.sh` covers (post-`acss-utilities`):
 
-- Manifest validation (every `plugins/<name>/.claude-plugin/plugin.json` has required fields)
-- SCSS/CSS contract (every utility CSS file's selectors and `var()` fallbacks)
-- Idempotency: regenerate `utilities.css` from tokens and diff against the committed file
-- Bridge parity: every alias in `:root` is also in `[data-theme="dark"]`
-- Bundle-size budget: bundle ≤ `bundleSizeBudgetKb` (or `--max-kb` override)
-- Bad-fixture self-tests: PascalCase selector, missing `var()` fallback, missing dark bridge entry, oversize bundle — each must exit 1
+- Manifest validation (every `plugins/<name>/.claude-plugin/plugin.json` has required fields) — Step 5
+- **Step 8: utility validator** — runs `validate_utilities.py` over `plugins/acss-utilities/assets/`. Enforces selector grammar, `var()` fallbacks, no duplicate selectors per context, responsive parity, bridge dark-mode parity, and bundle-size budget (against `bundleSizeBudgetKb` from the tokens file).
+- **Step 9: idempotency** — regenerates the bundle and per-family partials from `utilities.tokens.json` into a tmp dir and diffs against the committed copy. Any divergence fails the harness with the regenerate-and-commit instruction inline.
+
+What is **not** in the harness yet:
+
+- Bad-fixture self-tests (PascalCase selector, missing `var()` fallback, missing `[data-theme="dark"]` alias, oversize bundle). Each fixture would assert that the validator exits non-zero. Wiring is deferred — the `[Unreleased]` CHANGELOG entry tracks this.
 
 One-time install for the test runner: `npm --prefix tests ci && pip3 install --user tinycss2`.
 

--- a/plugins/acss-utilities/docs/architecture.md
+++ b/plugins/acss-utilities/docs/architecture.md
@@ -1,0 +1,160 @@
+# acss-utilities — Architecture
+
+This guide is for maintainers extending the plugin (adding a family, tightening the validator, swapping the generator). Consumers should start with [tutorial.md](tutorial.md) instead.
+
+## Plugin layout
+
+```text
+plugins/acss-utilities/
+├── .claude-plugin/
+│   └── plugin.json                      # name, version (authoritative), description, license
+├── README.md                            # user-facing install + command summary
+├── CHANGELOG.md                         # Keep-a-Changelog 1.1.0
+├── ATTRIBUTION.md                       # fpkit/acss upstream pin + mirrored-vs-extended scope
+├── docs/                                # this developer guide (you are here)
+├── commands/
+│   ├── utility-add.md                   # YAML front-matter + delegation to skills/utilities/SKILL.md
+│   ├── utility-list.md
+│   ├── utility-tune.md
+│   └── utility-bridge.md
+├── skills/utilities/
+│   ├── SKILL.md                         # canonical per-command workflow
+│   └── references/
+│       ├── utility-catalogue.md         # every family, every class, the property each one references
+│       ├── naming-convention.md         # selector grammar + !important policy
+│       ├── breakpoints.md               # responsive prefix + media-query syntax
+│       └── token-bridge.md              # alias mapping + dark-mode parity contract
+├── scripts/
+│   ├── generate_utilities.py            # tokens JSON → utilities.css + per-family partials
+│   ├── validate_utilities.py            # selector grammar, var() fallbacks, parity, budget
+│   └── detect_utility_target.py         # find React root + drop directory
+└── assets/
+    ├── utilities.tokens.json            # source-of-truth (committed)
+    ├── utilities.css                    # generated bundle (committed; regeneratable)
+    ├── utilities/                       # per-family partials (committed; regeneratable)
+    │   ├── color-bg.css
+    │   ├── color-text.css
+    │   └── …
+    └── token-bridge.css                 # acss-kit ↔ fpkit alias layer (committed)
+```
+
+The committed bundle (`utilities.css`) and per-family partials are **canonical artifacts**. `tests/run.sh` enforces idempotency: regenerating from `utilities.tokens.json` must produce byte-identical output to what's checked in. Edits go through the tokens file and the generator, not by hand.
+
+## Command → SKILL delegation
+
+Every command file follows the same pattern:
+
+```yaml
+---
+description: <one line>
+argument-hint: [--option] [--flag]
+allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+---
+
+Body delegates to `${CLAUDE_PLUGIN_ROOT}/skills/utilities/SKILL.md`.
+```
+
+The body is intentionally thin — three to five sentences plus a "Quick steps" outline. The full per-command workflow lives in [`skills/utilities/SKILL.md`](../skills/utilities/SKILL.md), which the slash command tells Claude to follow. Every section in `SKILL.md` lists the references it should load (`references/utility-catalogue.md`, etc.) so Claude pulls only what's needed.
+
+**Never re-implement command logic inline in the command file.** The contract is: command file = entry point + arguments doc, SKILL.md = the workflow.
+
+## Generator/validator contract
+
+Both scripts follow the project's [generator/validator contract](../../../.claude/rules/python-scripts.md) — Python 3 stdlib only (`generate_utilities.py`) or stdlib + `tinycss2` (`validate_utilities.py`).
+
+| Script | Output | Exit codes |
+|---|---|---|
+| `generate_utilities.py` | CSS (bundle to stdout, or per-family files via `--out-dir`); errors on stderr | 0 success, 1 logical (unknown family), 2 usage/IO |
+| `validate_utilities.py` | JSON to stdout with `ok` and `reasons` | 0 success, 1 contract violation, 2 usage/IO |
+| `detect_utility_target.py` | JSON to stdout with `source`, `projectRoot`, `utilitiesDir`, `reasons` | 0 success (configured / default), 1 no React root |
+
+The detector is the only script that follows the **detector** contract (machine-callable, structured); the other two are generator/validator (data + reasons).
+
+## How to add a new family
+
+Concrete walkthrough — say you want to add a `border-width` family (`.border-0`, `.border-1`, `.border-2`).
+
+| Step | What to touch |
+|---|---|
+| 1 | `assets/utilities.tokens.json#families` → add `"border-width": { "enabled": true, "responsive": false }`. Add the scale (e.g. `"borderWidth": [0, 1, 2, 4, 8]`) at the top level of the tokens file. |
+| 2 | `scripts/generate_utilities.py` → write an `emit_border_width(tokens)` function returning `_section("border-width utilities", body)`. Register it in the `EMITTERS` dict and append `"border-width"` to `FAMILY_ORDER` in canonical position (after `color-border`). |
+| 3 | Run the generator: `python3 plugins/acss-utilities/scripts/generate_utilities.py --tokens plugins/acss-utilities/assets/utilities.tokens.json --out-dir plugins/acss-utilities/assets/`. Inspect `assets/utilities/border-width.css` and the regenerated bundle. |
+| 4 | Run the validator: `python3 plugins/acss-utilities/scripts/validate_utilities.py plugins/acss-utilities/assets/`. Should be `ok: true`. |
+| 5 | `skills/utilities/references/utility-catalogue.md` → add a section listing the new family's classes and the `border-width` value each one sets. Update the family-inventory table at the top with the class count. |
+| 6 | `commands/utility-list.md` and `commands/utility-add.md` → add `border-width` to any explicit family lists. |
+| 7 | Bump `CHANGELOG.md` under `[Unreleased]` → `### Added`. |
+
+The maintainer skill at `.claude/skills/utility-author/SKILL.md` (planned, see plugin-health) automates steps 1–7 for typical families. For now do them by hand.
+
+## Bundle-size budget resolution
+
+When `validate_utilities.py` checks bundle size, it resolves the budget in this order:
+
+1. **Explicit `--max-kb N` flag** wins. Used by `tests/run.sh` and ad-hoc runs.
+2. **`bundleSizeBudgetKb` from a co-located `utilities.tokens.json`** — the validator searches `<bundle.parent>/utilities.tokens.json`, then `<bundle.parent.parent>/utilities.tokens.json`, then `<target>/utilities.tokens.json`.
+3. **Hard-coded fallback of 80 KB** when neither is found.
+
+This was wired up in commit `2af654e` after a Copilot review noted the field was previously dead.
+
+## `.acss-target.json` schema (utilities-relevant fields)
+
+The detector reads the same `.acss-target.json` that `acss-kit` uses, with one added field:
+
+```json
+{
+  "componentsDir": "src/components/fpkit",   // acss-kit's
+  "utilitiesDir": "src/styles"               // acss-utilities'
+}
+```
+
+Both fields are optional. The detector requires that `(projectRoot / utilitiesDir)` exists on disk before honoring it — a stale entry pointing at a deleted directory falls through to the default. The same fail-safe lives in `acss-kit/scripts/detect_target.py` for `componentsDir`.
+
+## Hooks the plugin opts into
+
+The repo's `.claude/settings.json` runs validation after every Write/Edit:
+
+| Hook | Matcher | Effect |
+|---|---|---|
+| Validate utility CSS | `Write\|Edit` on `plugins/acss-utilities/assets/.*\.css$` | Runs `validate_utilities.py` and reports the reasons array if non-empty |
+
+Existing project-wide hooks (JSON-syntax check, `plugin.json` required-fields, command front-matter, SKILL.md front-matter) cover the new plugin automatically — no per-plugin matcher edit is needed.
+
+## Version-bump checklist
+
+When releasing a new `acss-utilities` version:
+
+1. Update `plugins/acss-utilities/.claude-plugin/plugin.json#version` (authoritative).
+2. **Do not** add a `version:` key to `.claude-plugin/marketplace.json` — the manifest always wins silently. Update only the `description` field if the user-facing scope changed.
+3. Move bullets from `## [Unreleased]` to a new dated section in `plugins/acss-utilities/CHANGELOG.md`.
+4. If commands or scripts changed, update `plugins/acss-utilities/README.md` and the docs in this folder.
+5. Run `tests/run.sh` to confirm structural validation, idempotency, and the bad-fixture self-tests pass.
+6. The maintainer skill `.claude/skills/release-plugin/` automates steps 1–3; `.claude/skills/release-check/` audits the paperwork before a PR.
+
+## Tests
+
+`tests/run.sh` covers (post-`acss-utilities`):
+
+- Manifest validation (every `plugins/<name>/.claude-plugin/plugin.json` has required fields)
+- SCSS/CSS contract (every utility CSS file's selectors and `var()` fallbacks)
+- Idempotency: regenerate `utilities.css` from tokens and diff against the committed file
+- Bridge parity: every alias in `:root` is also in `[data-theme="dark"]`
+- Bundle-size budget: bundle ≤ `bundleSizeBudgetKb` (or `--max-kb` override)
+- Bad-fixture self-tests: PascalCase selector, missing `var()` fallback, missing dark bridge entry, oversize bundle — each must exit 1
+
+One-time install for the test runner: `npm --prefix tests ci && pip3 install --user tinycss2`.
+
+## Deferred work
+
+- **`docs/visual-guide.md`** — Mermaid + SVG diagram-first portal mirroring `acss-kit/docs/visual-guide.md`. Requires authoring system-overview, command-flow, and class-anatomy diagrams. Deferred to keep the initial docs PR focused.
+- **`assets/utilities.tokens.schema.json`** — JSON Schema for the source-of-truth file, for editor autocompletion. The `$schema` pointer was removed in commit `2af654e` rather than shipping a real schema; a future maintainer pass should add the schema and re-introduce the pointer.
+- **`utility-author` and `utility-update` maintainer skills** — listed in `.claude/skills/` but not yet authored. Would automate "add a new family" and "re-validate after token-bridge or naming changes" respectively. Until then, follow the manual walkthrough in [How to add a new family](#how-to-add-a-new-family).
+
+## Cross-plugin coordination
+
+`acss-utilities` and `acss-kit` are deliberately decoupled. Pairing happens at the user level:
+
+- `acss-kit` ships components + themes; `acss-utilities` ships the atomic layer.
+- The bridge file is the **only** integration point — and it's regeneratable from any acss-kit theme via `/utility-bridge`.
+- `/utility-add` does not invoke `acss-kit` flows; `/setup` (acss-kit) does not invoke `/utility-add`. Each plugin is self-contained.
+
+This matters when bumping the upstream `@fpkit/acss` pin in `ATTRIBUTION.md` — the bump should not require coordinated changes to `acss-kit` unless a new fpkit role lands that requires a new alias in the bridge.

--- a/plugins/acss-utilities/docs/commands.md
+++ b/plugins/acss-utilities/docs/commands.md
@@ -1,0 +1,142 @@
+# acss-utilities — Commands
+
+Four slash commands ship with the plugin. Each delegates to a section of [`skills/utilities/SKILL.md`](../skills/utilities/SKILL.md); this page is the user-facing reference.
+
+| Command | Side effects | Argument hint |
+|---|---|---|
+| [`/utility-add`](#utility-add) | Writes `utilities.css` and `token-bridge.css` into your project | `[--target=<dir>] [--families=<comma-list>] [--no-bridge]` |
+| [`/utility-list`](#utility-list) | None — read-only catalogue | `[family]` |
+| [`/utility-tune`](#utility-tune) | Edits `utilities.tokens.json`, regenerates the bundle, validates | `<natural-language description>` |
+| [`/utility-bridge`](#utility-bridge) | Writes `token-bridge.css` against your active acss-kit theme | `[--theme=<file>]` |
+
+---
+
+## `/utility-add`
+
+Copy the prebuilt `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into a target React project.
+
+**Signature:** `/utility-add [--target=<dir>] [--families=<comma-list>] [--no-bridge]`
+
+**Reads:** `assets/utilities.css`, `assets/utilities/<family>.css`, `assets/token-bridge.css`, the active `.acss-target.json` if present.
+
+**Writes:** `<target>/utilities.css`, `<target>/token-bridge.css`.
+
+### Workflow
+
+| Step | What happens |
+|---|---|
+| 1 | Run `scripts/detect_utility_target.py`. The detector walks ancestors looking for a React `package.json`, then reads `.acss-target.json#utilitiesDir` if present and the directory exists. Falls back to `src/styles`. |
+| 2 | If `--target=<dir>` is passed, override the detected drop location. |
+| 3a | If `--families=` is passed, concatenate the requested partials in canonical order plus the bundle header. Write to `<target>/utilities.css`. |
+| 3b | Otherwise copy `assets/utilities.css` verbatim. |
+| 4 | Unless `--no-bridge`, copy `assets/token-bridge.css` to `<target>/token-bridge.css`. |
+| 5 | Print the import order: `token-bridge.css` first, `utilities.css` second. |
+| 6 | Print a summary: files written, total size, families included. |
+
+### Examples
+
+```text
+/utility-add                                           # full bundle, default target
+/utility-add --target=apps/web/src/styles              # explicit target
+/utility-add --families=color-bg,color-text,spacing    # filtered subset
+/utility-add --no-bridge                               # standalone with your own theme
+```
+
+### Family ids accepted by `--families=`
+
+`color-bg`, `color-text`, `color-border`, `spacing`, `display`, `flex`, `grid`, `type`, `radius`, `shadow`, `position`, `z-index`. There is **no** `color` alias group — pass the three color families explicitly if you want them all.
+
+---
+
+## `/utility-list`
+
+Read-only catalogue printer. Writes nothing.
+
+**Signature:** `/utility-list [family]`
+
+**Reads:** `assets/utilities.tokens.json`, `assets/utilities/<family>.css`.
+
+### `/utility-list` (no argument)
+
+Prints every family from `tokens.families` with its `enabled` and `responsive` flags, the spacing scale, and the breakpoint values. Suggests `/utility-list <family>` for class-level detail.
+
+### `/utility-list <family>`
+
+Prints every selector in the per-family partial with the property it sets and the `var()` chain it references. For color families, also prints how the bridge resolves the alias against `acss-kit`.
+
+### Examples
+
+```text
+/utility-list             # print the family inventory
+/utility-list color-bg    # every .bg-* class with its var() chain
+/utility-list spacing     # every .m-*, .p-*, .gap-* class
+/utility-list display     # hide/show/invisible + sr-only utilities + responsive variants
+```
+
+---
+
+## `/utility-tune`
+
+Adjust `utilities.tokens.json` via natural language, regenerate the bundle, and validate.
+
+**Signature:** `/utility-tune <natural-language description>`
+
+**Reads:** `assets/utilities.tokens.json`.
+
+**Writes:** `assets/utilities.tokens.json`, `assets/utilities.css`, `assets/utilities/<family>.css` (regenerated). Reverts the tokens edit if validation fails.
+
+### Examples
+
+| Phrase | Effect |
+|---|---|
+| `use a 4px spacing baseline` | `spacing.baseline = "0.25rem"` |
+| `use an 8px spacing baseline` | `spacing.baseline = "0.5rem"` |
+| `add an xs breakpoint at 20rem` | `breakpoints.xs = "20rem"` |
+| `disable shadow utilities` | `families.shadow.enabled = false` |
+| `drop responsive variants from spacing` | `families.spacing.responsive = false` |
+| `add a 'soft' radius value at 1rem` | `radius.soft = "1rem"` |
+
+### Workflow
+
+| Step | What happens |
+|---|---|
+| 1 | Parse the request into concrete edits. If ambiguous, the assistant asks one clarifying question via `AskUserQuestion`. |
+| 2 | Read `assets/utilities.tokens.json` and apply edits in memory. |
+| 3 | Write the updated tokens back to disk. |
+| 4 | Run `scripts/generate_utilities.py --tokens <file> --out-dir assets/`. |
+| 5 | Run `scripts/validate_utilities.py assets/`. On `ok: false`, revert the tokens edit and report the reasons. |
+| 6 | Print a summary: which fields changed, new bundle size, classes added/removed. |
+
+The committed bundle is contract-protected: tokens edits are only persisted if the regenerated bundle passes the validator.
+
+---
+
+## `/utility-bridge`
+
+Regenerate `token-bridge.css` against the user's active `acss-kit` theme. Always emits both `:root` and `[data-theme="dark"]` blocks.
+
+**Signature:** `/utility-bridge [--theme=<file>]`
+
+**Reads:** the source theme(s) — by default `<projectRoot>/src/styles/theme/light.css` and `dark.css`, or whatever `--theme=` points at.
+
+**Writes:** `<projectRoot>/<utilitiesDir>/token-bridge.css` (default `src/styles/token-bridge.css`).
+
+### Workflow
+
+| Step | What happens |
+|---|---|
+| 1 | Resolve the source theme. With `--theme=<file>`, use it. Otherwise auto-detect `src/styles/theme/{light,dark}.css`. If nothing is found, fall back to the bundled defaults and warn. |
+| 2 | Extract `--color-danger`, `--color-primary`, `--color-success`, `--color-warning`, `--color-info` for both light and dark modes. |
+| 3 | Build the bridge with `var()` chains and embedded hex fallbacks. Synthesize `-bg` and `-light` variants via `color-mix(in oklch, …)`. |
+| 4 | Write the file to the resolved target. Always emit both `:root` and `[data-theme="dark"]` blocks; if the source theme has no dark block, warn and use the same values. |
+| 5 | Run `scripts/validate_utilities.py <bridge-file>` to enforce parity. Halt on any reason. |
+| 6 | Print a summary: which roles were aliased, dark-mode parity status, fallback hex values used. |
+
+### Examples
+
+```text
+/utility-bridge                                        # auto-detect theme files
+/utility-bridge --theme=apps/web/src/styles/theme/light.css
+```
+
+The bridge's job is to **define** fallbacks for utilities, so the validator does **not** require `var()` fallbacks inside `token-bridge.css` itself — only the dark-mode parity check applies.

--- a/plugins/acss-utilities/docs/concepts.md
+++ b/plugins/acss-utilities/docs/concepts.md
@@ -1,0 +1,129 @@
+# acss-utilities — Core Concepts
+
+This page covers the mental model you need before running `/utility-add`. Understanding these ideas will help you reason about what gets shipped into your project, why the bundle looks the way it does, and what to do when a class does not resolve the way you expect.
+
+## Why a committed bundle instead of a build step
+
+The plugin ships a hand-tested `utilities.css` (the full atomic suite) plus per-family partials under `assets/utilities/`. There is **no JIT scanner, no purge step, and no JS runtime**. `/utility-add` copies pre-built CSS into your project; you ship that file as-is. The trade-off: the bundle is ~58 KB unminified out of the box. If you only need a subset, pass `--families=color-bg,spacing,display` to filter at copy-time.
+
+The committed bundle is regeneratable from `assets/utilities.tokens.json` via `scripts/generate_utilities.py`, and `tests/run.sh` enforces byte-for-byte idempotency between the two. Edits to tokens always go through the generator; no one hand-writes the bundle.
+
+## kebab-case selectors, no prefix
+
+Class names mirror fpkit upstream verbatim — kebab-case, no library prefix, no hashing:
+
+```html
+<div class="bg-primary p-4 rounded-md">…</div>
+```
+
+The validator (`scripts/validate_utilities.py`) enforces this with a single regex: `\.[a-z][a-z0-9-]*` with an optional `\<prefix>:` escape (see [breakpoints](#responsive-variants-and-the-escaped-colon)) and an optional pseudo-class. PascalCase, underscores, and library-style prefixes (`acss-`, `u-`) all fail validation.
+
+See [`references/naming-convention.md`](../skills/utilities/references/naming-convention.md) for the full grammar.
+
+## Mandatory `var()` fallbacks
+
+Every CSS custom property reference in a utility class **must** include a hardcoded fallback:
+
+```css
+.bg-primary { background-color: var(--color-primary, transparent); }   /* correct */
+.bg-primary { background-color: var(--color-primary); }                /* wrong */
+```
+
+This rule comes from [`scss-conventions.md`](../../../.claude/rules/scss-conventions.md), and the validator checks every emitted file. Fallbacks let utility classes work in isolation — drop the bundle into a project with no theme and `.bg-primary` still renders something visible (`transparent` for color-bg, `currentColor` for color-text and color-border).
+
+When `acss-kit` or another theme is loaded, the variable resolves to the theme's value and the fallback is shadowed.
+
+## Responsive variants and the escaped colon
+
+Five prefixes ship by default: `sm`, `md`, `lg`, `xl`, `print`. The breakpoint widths come from `assets/utilities.tokens.json#breakpoints`:
+
+| Prefix | Width | Generated rule |
+|---|---|---|
+| `sm` | 30rem | `@media (width >= 30rem) { .sm\:hide { … } }` |
+| `md` | 48rem | `@media (width >= 48rem)` |
+| `lg` | 62rem | `@media (width >= 62rem)` |
+| `xl` | 80rem | `@media (width >= 80rem)` |
+| `print` | — | `@media print { .print\:hide { … } }` (only `hide` is emitted) |
+
+In the stylesheet the colon is escaped as `\:`. In your JSX/HTML it is **not** escaped:
+
+```tsx
+<div className="hide md:show lg:hide">…</div>
+```
+
+If you write `.sm:hide` in CSS without the backslash, the selector is invalid and the rule never matches. See [`references/breakpoints.md`](../skills/utilities/references/breakpoints.md).
+
+Not every family is responsive. Color, type, radius, shadow, position, and z-index emit only base classes. Spacing, display, flex, and grid emit the full `sm/md/lg/xl` set. The `families.<name>.responsive` flag in the tokens file controls this.
+
+## `!important` is reserved for display and visibility
+
+Utility classes generally compose with component styles. They do **not** stamp `!important` on every property, because the user should be able to override `.bg-primary` with a more specific component rule.
+
+The exceptions are `display`, `visibility`, and the `print:hide` / `sm:hide` family — these need to win over any positioning or layout rule that the component author may have set. So:
+
+```css
+.hide { display: none !important; }
+.invisible { visibility: hidden !important; }
+.bg-primary { background-color: var(--color-primary, transparent); }   /* no !important */
+```
+
+This matches fpkit upstream policy and is documented in [`references/naming-convention.md`](../skills/utilities/references/naming-convention.md).
+
+## The token bridge
+
+Utility classes reference fpkit-style token names (`--color-error`, `--color-error-bg`, `--color-primary-light`). `acss-kit` defines roles under different names (`--color-danger`, no `-bg` variants, no `-light` variants). The bridge — `assets/token-bridge.css` — closes the gap:
+
+```css
+:root {
+  --color-error:        var(--color-danger, #dc2626);
+  --color-error-bg:     color-mix(in oklch, var(--color-danger, #dc2626) 12%, var(--color-background, #ffffff));
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #2563eb) 80%, white);
+}
+[data-theme="dark"] {
+  --color-error:        var(--color-danger, #f87171);
+  --color-error-bg:     color-mix(in oklch, var(--color-danger, #f87171) 18%, var(--color-background, #0f172a));
+  --color-primary-light: color-mix(in oklch, var(--color-primary, #7dd3fc) 70%, black);
+}
+```
+
+You import it **before** `utilities.css`, so the aliases are defined when utility classes resolve them:
+
+```ts
+import "./styles/token-bridge.css";   // first — defines aliases
+import "./styles/utilities.css";       // then — utility classes consume them
+```
+
+If you don't run `acss-kit`, the bridge's hex fallbacks resolve standalone — every utility still renders. See [`references/token-bridge.md`](../skills/utilities/references/token-bridge.md) for the full mapping.
+
+## Dark-mode parity is enforced
+
+Every alias defined in `:root` **must** also be defined in `[data-theme="dark"]`. Without the second block, every `.bg-error` / `.text-error` / `.border-error` resolves to the light-mode fallback even when the page is in dark mode. The validator's bridge mode flags any missing alias by name:
+
+```text
+token-bridge.css: bridge dark-mode parity gap — declared in :root
+but missing in [data-theme="dark"]: --color-error, --color-success-bg
+```
+
+`/utility-bridge` always emits both blocks. If you hand-edit the file, run `validate_utilities.py path/to/token-bridge.css` to confirm parity before committing.
+
+## Bundle-size budget
+
+`assets/utilities.tokens.json#bundleSizeBudgetKb` (default 80) is a soft ceiling. The validator reads it from the tokens file when no `--max-kb` flag is passed:
+
+```text
+utilities.css: bundle size 84520 bytes exceeds budget 80 KB (81920 bytes)
+```
+
+If you grow a family or add a new one, raise the budget in the tokens file or remove unused families via `--families=`. The CLI flag (`--max-kb 120`) overrides the tokens value when you need a one-off check.
+
+## Generation flow at a glance
+
+```text
+utilities.tokens.json  ──▶  generate_utilities.py  ──▶  utilities/<family>.css
+                                                  └──▶  utilities.css (concatenated bundle)
+
+utilities.css         ──▶  validate_utilities.py  ──▶  reasons array (exit 0/1)
+token-bridge.css      ──▶  validate_utilities.py  ──▶  reasons array (exit 0/1)
+```
+
+`/utility-tune` runs the generator and the validator in sequence, reverting tokens edits if the validator complains. `/utility-bridge` reads your acss-kit theme and writes a new `token-bridge.css`, then validates it for parity.

--- a/plugins/acss-utilities/docs/recipes.md
+++ b/plugins/acss-utilities/docs/recipes.md
@@ -1,0 +1,181 @@
+# acss-utilities — Recipes
+
+Short, task-oriented walkthroughs for the most common workflows. Each recipe assumes you've already installed the plugin (`/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins`).
+
+---
+
+## First-run install on a fresh project
+
+```text
+/utility-add
+```
+
+The plugin walks ancestors looking for a React `package.json`. If found, it drops `utilities.css` and `token-bridge.css` into `src/styles/`. If your styles directory is named differently, override:
+
+```text
+/utility-add --target=src/css
+```
+
+Then add the two import lines to your app entry — `token-bridge.css` first, `utilities.css` second. See [tutorial.md](tutorial.md) for the full walkthrough.
+
+---
+
+## Install a filtered subset
+
+Every family is enabled by default. To ship only colors, spacing, and display:
+
+```text
+/utility-add --families=color-bg,color-text,color-border,spacing,display
+```
+
+The selected partials are concatenated into a single `utilities.css` (still one import, still cached as one file). Family ids are exact: `color-bg` ≠ `color`, `display` ≠ `visibility`.
+
+---
+
+## Regenerate after editing `utilities.tokens.json`
+
+If you hand-edit the source-of-truth (e.g. add a custom radius token), run the generator to refresh the committed bundle:
+
+```bash
+python3 plugins/acss-utilities/scripts/generate_utilities.py \
+  --tokens plugins/acss-utilities/assets/utilities.tokens.json \
+  --out-dir plugins/acss-utilities/assets/
+```
+
+Then validate:
+
+```bash
+python3 plugins/acss-utilities/scripts/validate_utilities.py \
+  plugins/acss-utilities/assets/
+```
+
+`tests/run.sh` runs an idempotency check that fails if the committed bundle drifts from what the generator emits — keep them in sync.
+
+---
+
+## Switch the spacing baseline to 4px
+
+```text
+/utility-tune use a 4px spacing baseline
+```
+
+The skill edits `assets/utilities.tokens.json`:
+
+```jsonc
+"spacing": { "baseline": "0.25rem", … }
+```
+
+…regenerates `utilities.css` (every `.m-1`, `.p-2`, `.gap-4` recomputes), and runs the validator. If the new bundle exceeds `bundleSizeBudgetKb` or breaks any contract, the tokens edit is reverted.
+
+For an 8px baseline use `use an 8px spacing baseline`.
+
+---
+
+## Add an extra breakpoint
+
+```text
+/utility-tune add an xs breakpoint at 20rem
+```
+
+Adds `breakpoints.xs = "20rem"` to the tokens file. The generator emits `.xs\:hide`, `.xs\:p-4`, etc. The validator's allowed-prefix list extends automatically because `--prefixes` defaults to whatever is in the tokens file.
+
+In JSX, write `<div className="xs:hide">…`. In CSS the rule is `@media (width >= 20rem) { .xs\:hide { … } }`.
+
+---
+
+## Disable a family
+
+```text
+/utility-tune disable shadow utilities
+```
+
+Sets `families.shadow.enabled = false`. The next generator run drops `assets/utilities/shadow.css` from the bundle and shrinks `utilities.css` accordingly. No `.shadow-*` classes are emitted.
+
+To re-enable: `/utility-tune enable shadow utilities`.
+
+---
+
+## Regenerate the token bridge after a theme change
+
+If you've edited `acss-kit`'s theme files (or run `/theme-create` to swap brand presets), the bundled bridge may resolve to stale fallbacks. Regenerate:
+
+```text
+/utility-bridge
+```
+
+The skill auto-detects `<projectRoot>/src/styles/theme/light.css` and `dark.css`, extracts the role colors, and writes a new `token-bridge.css` with both `:root` and `[data-theme="dark"]` blocks. The validator's parity check runs automatically.
+
+To point at a specific file:
+
+```text
+/utility-bridge --theme=apps/web/src/styles/theme/brand-warm-light.css
+```
+
+---
+
+## Raise the bundle-size budget
+
+The default is 80 KB unminified. If you've enabled a custom family or extended the spacing scale and the bundle exceeds budget, edit `assets/utilities.tokens.json`:
+
+```jsonc
+"bundleSizeBudgetKb": 120
+```
+
+Or pass `--max-kb` to the validator for a one-off check:
+
+```bash
+python3 plugins/acss-utilities/scripts/validate_utilities.py \
+  plugins/acss-utilities/assets/ --max-kb 120
+```
+
+Resolution order: explicit `--max-kb` flag → tokens file → 80 KB fallback. The flag always wins.
+
+---
+
+## Standalone mode (no acss-kit)
+
+If you're using a hand-written theme or another design-token system, skip the bridge:
+
+```text
+/utility-add --no-bridge
+```
+
+Then either:
+
+- Define the fpkit-style names yourself (`--color-error`, `--color-error-bg`, `--color-primary-light`) in your theme — utilities will pick them up.
+- Lean on the embedded hex fallbacks in `utilities.css`. Every `var()` has one, so the bundle renders something visible without any theme.
+
+You can also use the bridge with your own values: copy `assets/token-bridge.css` to your project, edit the `:root` and `[data-theme="dark"]` blocks to point at your token names, and import it before `utilities.css`.
+
+---
+
+## Inspect a single family
+
+```text
+/utility-list spacing
+```
+
+Prints every spacing class with the property it sets. For color families, also shows the `var()` chain and how the bridge resolves it.
+
+```text
+/utility-list
+```
+
+(no argument) prints the family inventory with `enabled`/`responsive` flags, the spacing scale, and the breakpoint table. Useful for sanity-checking what `/utility-tune` did.
+
+---
+
+## Custom drop location with `.acss-target.json`
+
+If your project keeps styles outside `src/styles/`, drop a `.acss-target.json` at the project root:
+
+```json
+{
+  "componentsDir": "src/components/fpkit",
+  "utilitiesDir": "src/css"
+}
+```
+
+`utilitiesDir` is honored by `/utility-add` and `/utility-bridge`. The detector validates that the path exists before using it; a stale entry pointing at a deleted directory falls back to `src/styles/` automatically (so you won't write into an unintended location).
+
+`componentsDir` is `acss-kit`'s field; it's safe to share the same file between both plugins.

--- a/plugins/acss-utilities/docs/recipes.md
+++ b/plugins/acss-utilities/docs/recipes.md
@@ -77,7 +77,17 @@ For an 8px baseline use `use an 8px spacing baseline`.
 /utility-tune add an xs breakpoint at 20rem
 ```
 
-Adds `breakpoints.xs = "20rem"` to the tokens file. The generator emits `.xs\:hide`, `.xs\:p-4`, etc. The validator's allowed-prefix list extends automatically because `--prefixes` defaults to whatever is in the tokens file.
+Adds `breakpoints.xs = "20rem"` to the tokens file. The generator emits `.xs\:hide`, `.xs\:p-4`, etc.
+
+The validator's `--prefixes` flag is **not** auto-derived from the tokens file — its default is `sm,md,lg,xl,print`. After adding a new breakpoint, pass the extended list explicitly:
+
+```bash
+python3 plugins/acss-utilities/scripts/validate_utilities.py \
+  plugins/acss-utilities/assets/ \
+  --prefixes=sm,md,lg,xl,xs,print
+```
+
+(The `/utility-tune` skill takes care of this for you when the tune flow runs the validator. The flag matters only when you invoke the validator manually.)
 
 In JSX, write `<div className="xs:hide">…`. In CSS the rule is `@media (width >= 20rem) { .xs\:hide { … } }`.
 

--- a/plugins/acss-utilities/docs/troubleshooting.md
+++ b/plugins/acss-utilities/docs/troubleshooting.md
@@ -1,0 +1,174 @@
+# acss-utilities — Troubleshooting
+
+---
+
+## "tinycss2 not installed"
+
+**Symptom:** `validate_utilities.py` exits 2 immediately with:
+
+```json
+{ "ok": false, "reasons": ["tinycss2 not installed: run `pip3 install --user tinycss2`"] }
+```
+
+**Fix:**
+
+```bash
+pip3 install --user tinycss2
+```
+
+`tinycss2` is the only non-stdlib dependency in the plugin's scripts and is also used by `tests/run.sh` for the SCSS contract check, so installing it once unblocks both.
+
+---
+
+## `.sm:hide` is not firing
+
+**Symptom:** A class like `.md:show` or `.lg:hide` does not match any element.
+
+**Cause:** The CSS file uses an escaped colon (`.md\:show`); the JSX/HTML uses an **unescaped** colon (`md:show`). If you write `.md:show` in your stylesheet, the parser treats `:show` as a pseudo-class and the rule never matches.
+
+**Fix:**
+
+- **In stylesheets** (the bundled `utilities.css` and any custom rules): always write `\:` — `.md\:show { … }`.
+- **In JSX / HTML / template literals**: never escape — `<div className="md:show">…`.
+
+The bundled `utilities.css` already gets this right; the issue only comes up when you author additional utilities by hand.
+
+---
+
+## Bundle exceeds the size budget
+
+**Symptom:** `validate_utilities.py` reports:
+
+```text
+utilities.css: bundle size 84520 bytes exceeds budget 80 KB (81920 bytes)
+```
+
+**Causes:**
+
+1. You added a new family or extended the spacing scale; the bundle grew past 80 KB.
+2. You raised `bundleSizeBudgetKb` in your fork of the tokens file but the validator is still reading the old value.
+
+**Fix:**
+
+- Raise `bundleSizeBudgetKb` in `assets/utilities.tokens.json` (recipes: [Raise the bundle-size budget](recipes.md#raise-the-bundle-size-budget)).
+- Pass `--max-kb 120` for a one-off override.
+- Or trim the bundle with `/utility-add --families=…` — every family you drop reduces the file.
+
+Resolution order: explicit `--max-kb` → tokens file → 80 KB fallback.
+
+---
+
+## Bridge dark-mode parity gap
+
+**Symptom:**
+
+```text
+token-bridge.css: bridge dark-mode parity gap — declared in :root
+but missing in [data-theme="dark"]: --color-error, --color-success-bg
+```
+
+**Cause:** Every alias defined in `:root` of the bridge **must** also be defined in `[data-theme="dark"]`. Missing aliases silently fall back to their `:root` values when the page is in dark mode, which usually looks broken.
+
+**Fix:**
+
+- If you ran `/utility-bridge`, the tool always emits both blocks — re-run it.
+- If you hand-edited `token-bridge.css`, copy each new `:root` declaration into the `[data-theme="dark"]` block (with a dark-appropriate fallback). Then re-run `validate_utilities.py path/to/token-bridge.css` to confirm.
+
+---
+
+## `var()` always resolves to the hex fallback
+
+**Symptom:** `.bg-primary` always renders the same color whether you toggle `data-theme="dark"` or not. `acss-kit` is installed but the bridge doesn't seem to be working.
+
+**Causes:**
+
+1. **Wrong import order.** `utilities.css` is imported before `token-bridge.css`, so the aliases aren't defined when utilities resolve them.
+2. **acss-kit theme is not loaded.** `acss-kit`'s role variables (`--color-danger`, `--color-primary`) aren't on the page, so the bridge's `var()` chain falls through to the hex fallback every time.
+3. **`data-theme="dark"` is on the wrong element.** It needs to be on `<html>` or a parent of the styled element — putting it on `<body>` works; putting it on a sibling does not.
+
+**Fix:**
+
+```ts
+import "./styles/token-bridge.css";   // first
+import "./styles/utilities.css";       // then
+// plus whatever loads acss-kit's theme.css
+```
+
+Inspect the rendered element in dev tools. If `--color-primary` is `inherit`/`initial` on `:root`, the theme isn't loaded. If it's defined but the utility still uses the fallback, the import order is wrong.
+
+---
+
+## `.acss-target.json#utilitiesDir` is being ignored
+
+**Symptom:** You set `"utilitiesDir": "src/css"` in `.acss-target.json` but `/utility-add` still writes to `src/styles/`.
+
+**Cause (since commit `2af654e`):** The detector now validates that `(projectRoot / utilitiesDir)` actually exists before honoring it. If the directory doesn't exist on disk, the detector silently falls back to the default (`src/styles`) so `/utility-add` cannot write into an unintended location.
+
+**Fix:** Create the directory first:
+
+```bash
+mkdir -p src/css
+```
+
+Then re-run `/utility-add`. The detector will return `source: "configured"` and use your path. Or pass `--target=src/css` to override the detection entirely.
+
+---
+
+## "no project root containing react was found"
+
+**Symptom:** `detect_utility_target.py` (or the slash command that wraps it) exits 1 with:
+
+```json
+{
+  "source": "none",
+  "projectRoot": null,
+  "reasons": ["No project root containing react was found."]
+}
+```
+
+**Cause:** The detector walks ancestors looking for a `package.json` with `react` in `dependencies` or `devDependencies`. If you're in a repo that doesn't have one (e.g. a monorepo from above the app, or a non-React project), it fails by design.
+
+**Fix:**
+
+- Run the command from inside the React app's directory tree (so the ancestor walk finds the right `package.json`).
+- Or pass `--target=<dir>` explicitly to bypass detection:
+
+```text
+/utility-add --target=apps/web/src/styles
+```
+
+---
+
+## Validator complains about a duplicate selector
+
+**Symptom:**
+
+```text
+utilities.css: duplicate selector .bg-primary in top-level (2×)
+```
+
+**Cause:** Two rules with the same selector in the same nesting context. Usually means a hand-edit appended a second `.bg-primary { … }` block instead of replacing the first.
+
+**Fix:** Search the file for the duplicate and merge the declarations. Then re-run `generate_utilities.py` if you wanted the change to come from the tokens file rather than a hand-edit — that way the next generator run won't reintroduce the duplicate.
+
+---
+
+## A generator-emitted class is missing at one breakpoint but not another
+
+**Symptom:**
+
+```text
+utilities.css: responsive parity gap — '.lg\:p-4' is declared but missing at: sm, md, xl
+```
+
+**Cause:** Every utility that has a responsive variant at one declared breakpoint must have it at every other declared breakpoint. The generator emits these in lockstep; if you're seeing a parity gap, something hand-edited the bundle.
+
+**Fix:** Re-run the generator from the source tokens — it will produce a complete set:
+
+```bash
+python3 plugins/acss-utilities/scripts/generate_utilities.py \
+  --tokens plugins/acss-utilities/assets/utilities.tokens.json \
+  --out-dir plugins/acss-utilities/assets/
+```
+
+Then commit the regenerated bundle.

--- a/plugins/acss-utilities/docs/tutorial.md
+++ b/plugins/acss-utilities/docs/tutorial.md
@@ -1,0 +1,131 @@
+# acss-utilities — Tutorial: your first utility class
+
+Drop the bundle into a React project, import it, and use a couple of classes — including one that resolves through the token bridge to confirm dark mode is wired up. About five minutes.
+
+If you want the mental model first, read [concepts.md](concepts.md). Otherwise, start here.
+
+---
+
+## Before you start
+
+Prerequisites:
+
+- A React project with a `package.json` that has `react` in `dependencies` or `devDependencies`
+- `acss-utilities` installed via `/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins`
+- (Optional but recommended) `acss-kit` installed for OKLCH theme tokens
+
+There is **no SCSS / sass requirement** — utilities are plain CSS. There is no JS runtime to install either.
+
+---
+
+## Step 1 — Drop the bundle into your project
+
+Open Claude Code in your project directory and run:
+
+```text
+/utility-add
+```
+
+The plugin auto-detects your React root, resolves a drop directory (default `src/styles/`), and writes two files:
+
+```text
+src/styles/token-bridge.css     # acss-kit ↔ fpkit alias layer
+src/styles/utilities.css        # the atomic suite (~58 KB unminified)
+```
+
+The summary it prints lists the files written, the total bundle size, and the families included. By default every family ships; pass `--families=color-bg,spacing,display` to copy a filtered subset.
+
+---
+
+## Step 2 — Import in the right order
+
+Add these two lines to your app entry (`src/main.tsx`, `src/index.tsx`, or wherever you import global CSS). **Order matters** — the bridge defines aliases that the bundle consumes.
+
+```ts
+import "./styles/token-bridge.css";   // first — defines the aliases
+import "./styles/utilities.css";       // then — utility classes consume them
+```
+
+If you reverse the order, color utilities still render — but they fall back to their hex defaults instead of resolving against your acss-kit theme.
+
+---
+
+## Step 3 — Use a class
+
+Pick any component and apply a few utilities:
+
+```tsx
+export function Hero() {
+  return (
+    <section className="bg-surface p-6 rounded-lg">
+      <h1 className="text-primary text-2xl font-bold">Welcome back</h1>
+      <p className="text-muted">Sign in to continue.</p>
+    </section>
+  );
+}
+```
+
+Run your dev server. You should see:
+
+- Padding around the section (`p-6` → `padding: 1.5rem`)
+- A rounded corner (`rounded-lg` → `border-radius: 0.5rem`)
+- The heading colored by your active primary token
+
+Every class in the bundle is documented in [`references/utility-catalogue.md`](../skills/utilities/references/utility-catalogue.md).
+
+---
+
+## Step 4 — Hide a class on small screens
+
+Responsive prefixes use `sm:`, `md:`, `lg:`, `xl:`. In your JSX, the colon is **not** escaped:
+
+```tsx
+<aside className="hide md:show">…</aside>
+```
+
+This element is hidden by default and revealed at `≥ 48rem` (the `md` breakpoint). The CSS rule it matches looks like:
+
+```css
+@media (width >= 48rem) {
+  .md\:show { display: revert !important; }
+}
+```
+
+Note the `\:` in the CSS file — that's the escaped form. JSX/HTML always uses the unescaped `md:show`.
+
+See [`references/breakpoints.md`](../skills/utilities/references/breakpoints.md) for the full breakpoint table.
+
+---
+
+## Step 5 — Confirm dark mode resolves
+
+Toggle the theme on the document root:
+
+```tsx
+<html data-theme="dark">
+```
+
+Try a class that goes through the bridge:
+
+```tsx
+<div className="bg-error text-base p-4">Something went wrong.</div>
+```
+
+`.bg-error` reads `var(--color-error, transparent)`. The bridge defines `--color-error` differently for `:root` vs. `[data-theme="dark"]`, so the rendered background should visibly shift when you toggle the data attribute.
+
+If it does not shift, check:
+
+1. `token-bridge.css` is imported **before** `utilities.css`
+2. `acss-kit` is loaded (or the bridge's hex fallbacks are reaching the element)
+3. `data-theme="dark"` is on `<html>` or a parent of the styled element
+
+[Troubleshooting](troubleshooting.md) covers each of these in detail.
+
+---
+
+## Where to next
+
+- **Filter the bundle** — `/utility-add --families=color-bg,spacing,display` if you don't need flex, grid, type, etc.
+- **Tune the spacing scale** — `/utility-tune use a 4px spacing baseline` ([recipes.md](recipes.md#switch-the-spacing-baseline-to-4px)).
+- **Regenerate the bridge after a theme change** — `/utility-bridge` ([commands.md](commands.md#utility-bridge)).
+- **List a family in detail** — `/utility-list spacing` to see every spacing class.

--- a/plugins/acss-utilities/scripts/detect_utility_target.py
+++ b/plugins/acss-utilities/scripts/detect_utility_target.py
@@ -79,14 +79,21 @@ def find_project_root(start: Path) -> Optional[Path]:
 
 
 def read_utilities_dir(root: Path) -> tuple[str, str]:
-    """Return (utilities_dir, source) where source is 'configured' or 'default'."""
+    """Return (utilities_dir, source) where source is 'configured' or 'default'.
+
+    A configured `utilitiesDir` is only honored when `(root / utilitiesDir)`
+    actually exists — otherwise the caller would select a non-existent path
+    and `/utility-add` would fail later.
+    """
     target = root / ".acss-target.json"
     if target.is_file():
         try:
             data = json.loads(target.read_text(encoding="utf-8"))
             cd = data.get("utilitiesDir")
-            if isinstance(cd, str) and cd.strip():
-                return cd.strip(), "configured"
+            if isinstance(cd, str):
+                configured = cd.strip()
+                if configured and (root / configured).is_dir():
+                    return configured, "configured"
         except Exception:
             pass
     return DEFAULT_UTILITIES_DIR, "default"

--- a/plugins/acss-utilities/scripts/detect_utility_target.py
+++ b/plugins/acss-utilities/scripts/detect_utility_target.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Detect the target directory for the acss-utilities CSS bundle.
+
+Resolution:
+  1. "configured" — `.acss-target.json` at project root has a
+     `utilitiesDir` field pointing at an existing directory.
+  2. "default"    — project root has react in dependencies, fall back
+     to `src/styles/`.
+  3. "none"       — no React project root in the path's ancestors.
+
+Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and the
+`.acss-target.json` schema. Adds an optional `utilitiesDir` field
+without breaking existing acss-kit consumers.
+
+Usage:
+    python detect_utility_target.py [project_root]
+
+Output (JSON to stdout):
+
+    Configured path:
+    {
+      "source": "configured",
+      "projectRoot": "/abs/path",
+      "utilitiesDir": "src/styles",
+      "bundlePath": "src/styles/utilities.css",
+      "bridgePath": "src/styles/token-bridge.css",
+      "reasons": []
+    }
+
+    Default path (react found, no .acss-target.json#utilitiesDir):
+    {
+      "source": "default",
+      "projectRoot": "/abs/path",
+      "utilitiesDir": "src/styles",
+      "bundlePath": "src/styles/utilities.css",
+      "bridgePath": "src/styles/token-bridge.css",
+      "reasons": []
+    }
+
+    No project root found:
+    {
+      "source": "none",
+      "projectRoot": null,
+      "utilitiesDir": "src/styles",
+      "bundlePath": "",
+      "bridgePath": "",
+      "reasons": ["No project root containing react was found."]
+    }
+
+Exit code 0 on success (configured or default), 1 on `none`.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_UTILITIES_DIR = "src/styles"
+
+
+def find_project_root(start: Path) -> Optional[Path]:
+    cur = start.resolve()
+    while True:
+        pkg = cur / "package.json"
+        if pkg.is_file():
+            try:
+                data = json.loads(pkg.read_text(encoding="utf-8"))
+                deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+                if "react" in deps:
+                    return cur
+            except Exception:
+                pass
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+
+
+def read_utilities_dir(root: Path) -> tuple[str, str]:
+    """Return (utilities_dir, source) where source is 'configured' or 'default'."""
+    target = root / ".acss-target.json"
+    if target.is_file():
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+            cd = data.get("utilitiesDir")
+            if isinstance(cd, str) and cd.strip():
+                return cd.strip(), "configured"
+        except Exception:
+            pass
+    return DEFAULT_UTILITIES_DIR, "default"
+
+
+def main() -> int:
+    start = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path.cwd()
+    root = find_project_root(start)
+    if root is None:
+        print(json.dumps({
+            "source": "none",
+            "projectRoot": None,
+            "utilitiesDir": DEFAULT_UTILITIES_DIR,
+            "bundlePath": "",
+            "bridgePath": "",
+            "reasons": ["No project root containing react was found."],
+        }, indent=2))
+        return 1
+
+    utilities_dir, source = read_utilities_dir(root)
+    bundle = f"{utilities_dir}/utilities.css"
+    bridge = f"{utilities_dir}/token-bridge.css"
+
+    print(json.dumps({
+        "source": source,
+        "projectRoot": str(root),
+        "utilitiesDir": utilities_dir,
+        "bundlePath": bundle,
+        "bridgePath": bridge,
+        "reasons": [],
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-utilities/scripts/generate_utilities.py
+++ b/plugins/acss-utilities/scripts/generate_utilities.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+Generate Tailwind-style atomic CSS utilities from a token source-of-truth.
+
+Reads `utilities.tokens.json` (path via --tokens, or stdin if absent) and
+emits CSS. Without --out-dir, writes the concatenated bundle to stdout.
+With --out-dir DIR, writes per-family partials and the concatenated bundle:
+
+    DIR/utilities/<family>.css       per-family partials
+    DIR/utilities.css                concatenated bundle
+
+Usage:
+    python3 generate_utilities.py [--tokens FILE] [--out-dir DIR]
+    python3 generate_utilities.py < utilities.tokens.json
+
+Contract: generator/validator (data on stdout, errors on stderr, exit 0/1/2).
+Stdlib only.
+
+Class conventions match fpkit/acss upstream:
+  - kebab-case selectors, no prefix (`.bg-primary`, `.mt-4`)
+  - responsive variants via escaped colon (`.sm\\:hide`) at breakpoints
+    sm/md/lg/xl from tokens.breakpoints
+  - print:hide for the print media query
+  - !important on display/visibility utilities only (composes elsewhere)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List
+
+# --- Family ordering: stable concatenation order for the bundle ---------
+FAMILY_ORDER = [
+    "color-bg", "color-text", "color-border",
+    "spacing",
+    "display", "flex", "grid",
+    "type",
+    "radius", "shadow",
+    "position", "z-index",
+]
+
+# --- Helpers ------------------------------------------------------------
+
+def _important(family: str) -> str:
+    """Return ' !important' for utilities that should always win."""
+    return " !important" if family == "display" else ""
+
+
+def _bp_keys(tokens: dict) -> List[str]:
+    return list(tokens.get("breakpoints", {}).keys())
+
+
+def _spacing_value(idx: int, baseline: str) -> str:
+    """idx*baseline → CSS calc value. idx=0 → '0'; otherwise '<idx*0.5>rem' style."""
+    if idx == 0:
+        return "0"
+    # baseline is like '0.5rem'; multiply numerically.
+    num_part = "".join(c for c in baseline if c.isdigit() or c == ".")
+    unit = baseline[len(num_part):] or "rem"
+    val = float(num_part) * idx
+    # Normalize: trim trailing zeros after decimal, keep ints clean.
+    if val == int(val):
+        return f"{int(val)}{unit}"
+    return f"{val:g}{unit}"
+
+
+def _section(title: str, body: str) -> str:
+    return f"/* {title} */\n{body}".rstrip() + "\n"
+
+
+def _wrap_responsive(body: str, family: str, tokens: dict, emit_base: Callable[[str], str]) -> str:
+    """Append @media blocks with `.bp\\:<class>` variants for each breakpoint."""
+    parts = [body]
+    for bp in _bp_keys(tokens):
+        width = tokens["breakpoints"][bp]
+        prefixed = emit_base(bp + r"\:")
+        parts.append(f"@media (width >= {width}) {{\n{prefixed}}}")
+    return "\n".join(parts)
+
+
+# --- Family emitters ----------------------------------------------------
+
+def emit_color_bg(tokens: dict) -> str:
+    lines = []
+    for name, var in tokens["colorRoles"].items():
+        lines.append(f".bg-{name} {{ background-color: var({var}, transparent); }}")
+    # state -bg variants (mute success-bg, error-bg, etc.)
+    for name, var in tokens.get("stateBg", {}).items():
+        lines.append(f".bg-{name}-subtle {{ background-color: var({var}, transparent); }}")
+    lines.append(".bg-transparent { background-color: transparent; }")
+    return _section("color-bg utilities", "\n".join(lines))
+
+
+def emit_color_text(tokens: dict) -> str:
+    lines = []
+    for name, var in tokens["colorRoles"].items():
+        lines.append(f".text-{name} {{ color: var({var}, currentColor); }}")
+    return _section("color-text utilities", "\n".join(lines))
+
+
+def emit_color_border(tokens: dict) -> str:
+    lines = []
+    for name, var in tokens["colorRoles"].items():
+        lines.append(f".border-{name} {{ border-color: var({var}, currentColor); }}")
+    return _section("color-border utilities", "\n".join(lines))
+
+
+def emit_spacing(tokens: dict) -> str:
+    spacing = tokens["spacing"]
+    baseline = spacing["baseline"]
+    scale = spacing["scale"]
+    props = spacing["properties"]
+    prop_map = {
+        "m": ("margin",),
+        "mt": ("margin-top",),
+        "mb": ("margin-bottom",),
+        "ml": ("margin-left",),
+        "mr": ("margin-right",),
+        "mx": ("margin-left", "margin-right"),
+        "my": ("margin-top", "margin-bottom"),
+        "p": ("padding",),
+        "pt": ("padding-top",),
+        "pb": ("padding-bottom",),
+        "pl": ("padding-left",),
+        "pr": ("padding-right",),
+        "px": ("padding-left", "padding-right"),
+        "py": ("padding-top", "padding-bottom"),
+        "gap": ("gap",),
+    }
+
+    def block(prefix: str = "") -> str:
+        out: List[str] = []
+        for prop in props:
+            css_props = prop_map[prop]
+            for v in scale:
+                value = _spacing_value(v, baseline)
+                rules = "; ".join(f"{p}: {value}" for p in css_props)
+                out.append(f".{prefix}{prop}-{v} {{ {rules}; }}")
+        return "\n".join(out) + "\n"
+
+    body = block("")
+    if tokens["families"]["spacing"].get("responsive"):
+        body = _wrap_responsive(body, "spacing", tokens, block)
+    return _section("spacing utilities", body)
+
+
+def emit_display(tokens: dict) -> str:
+    imp = _important("display")
+    base_classes = [
+        ("hide",       f"display: none{imp};"),
+        ("show",       f"display: revert{imp};"),
+        ("invisible",  f"visibility: hidden{imp};"),
+    ]
+
+    def block(prefix: str = "") -> str:
+        out = [f".{prefix}{name} {{ {decl} }}" for name, decl in base_classes]
+        return "\n".join(out) + "\n"
+
+    body = block("")
+    # sr-only utilities (no responsive variants — accessibility primitive).
+    body += (
+        ".sr-only {\n"
+        "  position: absolute; width: 1px; height: 1px;\n"
+        "  padding: 0; margin: -1px; overflow: hidden;\n"
+        "  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;\n"
+        "}\n"
+        ".sr-only-focusable {\n"
+        "  position: absolute; width: 1px; height: 1px;\n"
+        "  padding: 0; margin: -1px; overflow: hidden;\n"
+        "  clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;\n"
+        "}\n"
+        ".sr-only-focusable:focus,\n"
+        ".sr-only-focusable:focus-within {\n"
+        "  position: static; width: auto; height: auto;\n"
+        "  padding: 0; margin: 0; overflow: visible;\n"
+        "  clip: auto; white-space: normal;\n"
+        "}\n"
+    )
+
+    if tokens["families"]["display"].get("responsive"):
+        for bp, width in tokens["breakpoints"].items():
+            body += f"@media (width >= {width}) {{\n{block(bp + chr(92) + ':')}}}\n"
+    body += "@media print { .print\\:hide { display: none !important; } }\n"
+    return _section("display utilities", body)
+
+
+def emit_flex(tokens: dict) -> str:
+    base_classes = [
+        ("flex",            "display: flex;"),
+        ("inline-flex",     "display: inline-flex;"),
+        ("flex-row",        "flex-direction: row;"),
+        ("flex-row-reverse","flex-direction: row-reverse;"),
+        ("flex-col",        "flex-direction: column;"),
+        ("flex-col-reverse","flex-direction: column-reverse;"),
+        ("flex-wrap",       "flex-wrap: wrap;"),
+        ("flex-nowrap",     "flex-wrap: nowrap;"),
+        ("flex-1",          "flex: 1 1 0%;"),
+        ("flex-auto",       "flex: 1 1 auto;"),
+        ("flex-none",       "flex: none;"),
+        ("justify-start",   "justify-content: flex-start;"),
+        ("justify-end",     "justify-content: flex-end;"),
+        ("justify-center",  "justify-content: center;"),
+        ("justify-between", "justify-content: space-between;"),
+        ("justify-around",  "justify-content: space-around;"),
+        ("items-start",     "align-items: flex-start;"),
+        ("items-end",       "align-items: flex-end;"),
+        ("items-center",    "align-items: center;"),
+        ("items-baseline",  "align-items: baseline;"),
+        ("items-stretch",   "align-items: stretch;"),
+    ]
+
+    def block(prefix: str = "") -> str:
+        return "\n".join(f".{prefix}{name} {{ {decl} }}" for name, decl in base_classes) + "\n"
+
+    body = block("")
+    if tokens["families"]["flex"].get("responsive"):
+        body = _wrap_responsive(body, "flex", tokens, block)
+    return _section("flex utilities", body)
+
+
+def emit_grid(tokens: dict) -> str:
+    base_classes = [
+        ("grid",        "display: grid;"),
+        ("inline-grid", "display: inline-grid;"),
+    ]
+    base_classes += [
+        (f"grid-cols-{n}", f"grid-template-columns: repeat({n}, minmax(0, 1fr));")
+        for n in range(1, 13)
+    ]
+    base_classes += [
+        (f"grid-rows-{n}", f"grid-template-rows: repeat({n}, minmax(0, 1fr));")
+        for n in range(1, 7)
+    ]
+
+    def block(prefix: str = "") -> str:
+        return "\n".join(f".{prefix}{name} {{ {decl} }}" for name, decl in base_classes) + "\n"
+
+    body = block("")
+    if tokens["families"]["grid"].get("responsive"):
+        body = _wrap_responsive(body, "grid", tokens, block)
+    return _section("grid utilities", body)
+
+
+def emit_type(tokens: dict) -> str:
+    t = tokens["type"]
+    lines: List[str] = []
+    for name, size in t["fontSize"].items():
+        lines.append(f".text-{name} {{ font-size: {size}; }}")
+    for name, weight in t["fontWeight"].items():
+        lines.append(f".font-{name} {{ font-weight: {weight}; }}")
+    for name, lh in t["leading"].items():
+        lines.append(f".leading-{name} {{ line-height: {lh}; }}")
+    for align in t["align"]:
+        lines.append(f".text-{align} {{ text-align: {align}; }}")
+    return _section("type utilities", "\n".join(lines))
+
+
+def emit_radius(tokens: dict) -> str:
+    lines = []
+    for name, value in tokens["radius"].items():
+        if name == "md":
+            # Tailwind convention: bare `.rounded` is the default (md) radius.
+            lines.append(f".rounded {{ border-radius: {value}; }}")
+        lines.append(f".rounded-{name} {{ border-radius: {value}; }}")
+    return _section("radius utilities", "\n".join(lines))
+
+
+def emit_shadow(tokens: dict) -> str:
+    lines = []
+    for name, value in tokens["shadow"].items():
+        if name == "md":
+            lines.append(f".shadow {{ box-shadow: {value}; }}")
+        lines.append(f".shadow-{name} {{ box-shadow: {value}; }}")
+    return _section("shadow utilities", "\n".join(lines))
+
+
+def emit_position(tokens: dict) -> str:
+    lines = [f".{p} {{ position: {p}; }}" for p in tokens["positions"]]
+    return _section("position utilities", "\n".join(lines))
+
+
+def emit_zindex(tokens: dict) -> str:
+    lines = []
+    for v in tokens["zIndex"]:
+        lines.append(f".z-{v} {{ z-index: {v}; }}")
+    return _section("z-index utilities", "\n".join(lines))
+
+
+# --- Dispatcher ---------------------------------------------------------
+
+EMITTERS: Dict[str, Callable[[dict], str]] = {
+    "color-bg":     emit_color_bg,
+    "color-text":   emit_color_text,
+    "color-border": emit_color_border,
+    "spacing":      emit_spacing,
+    "display":      emit_display,
+    "flex":         emit_flex,
+    "grid":         emit_grid,
+    "type":         emit_type,
+    "radius":       emit_radius,
+    "shadow":       emit_shadow,
+    "position":     emit_position,
+    "z-index":      emit_zindex,
+}
+
+
+def emit_family(family: str, tokens: dict) -> str:
+    if family not in EMITTERS:
+        raise KeyError(family)
+    return EMITTERS[family](tokens)
+
+
+def emit_bundle_header(tokens: dict) -> str:
+    return (
+        "/*\n"
+        f" * acss-utilities v{tokens['version']}\n"
+        f" * Generated from utilities.tokens.json\n"
+        f" * Mirrors fpkit upstream: {tokens['fpkitUpstream']}\n"
+        " *\n"
+        " * Do not edit by hand. Regenerate via `generate_utilities.py`.\n"
+        " */\n\n"
+    )
+
+
+def emit_bundle(tokens: dict) -> Dict[str, str]:
+    """Return {family_name: css} plus a synthetic 'bundle' key."""
+    out: Dict[str, str] = {}
+    for fam in FAMILY_ORDER:
+        cfg = tokens["families"].get(fam, {})
+        if not cfg.get("enabled", True):
+            continue
+        out[fam] = emit_family(fam, tokens)
+    bundle_parts = [emit_bundle_header(tokens)]
+    for fam in FAMILY_ORDER:
+        if fam in out:
+            bundle_parts.append(out[fam])
+    out["bundle"] = "\n".join(bundle_parts)
+    return out
+
+
+# --- I/O ----------------------------------------------------------------
+
+def load_tokens(path: str | None) -> dict:
+    if path:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    return json.loads(sys.stdin.read())
+
+
+def write_outputs(out_dir: str, parts: Dict[str, str]) -> List[str]:
+    out_root = Path(out_dir)
+    fam_dir = out_root / "utilities"
+    fam_dir.mkdir(parents=True, exist_ok=True)
+    written: List[str] = []
+    for name, css in parts.items():
+        if name == "bundle":
+            target = out_root / "utilities.css"
+        else:
+            target = fam_dir / f"{name}.css"
+        target.write_text(css, encoding="utf-8")
+        written.append(str(target))
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, add_help=True)
+    parser.add_argument("--tokens", help="Path to utilities.tokens.json (else stdin)")
+    parser.add_argument("--out-dir", help="Write per-family partials + bundle to DIR")
+    args = parser.parse_args()
+
+    try:
+        tokens = load_tokens(args.tokens)
+    except FileNotFoundError as e:
+        print(f"tokens file not found: {e}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as e:
+        print(f"invalid tokens JSON: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        parts = emit_bundle(tokens)
+    except KeyError as e:
+        print(f"unknown family or missing token key: {e}", file=sys.stderr)
+        return 1
+
+    if args.out_dir:
+        written = write_outputs(args.out_dir, parts)
+        for p in written:
+            print(p)
+    else:
+        sys.stdout.write(parts["bundle"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-utilities/scripts/generate_utilities.py
+++ b/plugins/acss-utilities/scripts/generate_utilities.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Callable, Dict, List

--- a/plugins/acss-utilities/scripts/validate_utilities.py
+++ b/plugins/acss-utilities/scripts/validate_utilities.py
@@ -11,7 +11,10 @@ Two modes (auto-detected by filename):
     - No duplicate selectors at the same nesting level.
     - Every responsive variant present at one breakpoint must be present
       at every other breakpoint declared in the file.
-    - Bundle file (`utilities.css`) must not exceed `--max-kb` (default 80).
+    - Bundle file (`utilities.css`) must not exceed the size budget.
+      Resolution order: `--max-kb` flag (explicit) → `bundleSizeBudgetKb`
+      from a `utilities.tokens.json` co-located with the bundle or under
+      the validation target → fallback 80.
 
   Mode B — `token-bridge.css`
     - Every `--alias-name: …;` declaration in `:root` must also appear in
@@ -217,11 +220,34 @@ def collect_files(target: Path) -> List[Path]:
     return files
 
 
+def find_budget_kb(target: Path, bundle: Path | None) -> int | None:
+    """Locate `utilities.tokens.json#bundleSizeBudgetKb` near the bundle or
+    target. Returns the integer budget if found, else None."""
+    candidates: List[Path] = []
+    if bundle is not None:
+        candidates.append(bundle.parent / "utilities.tokens.json")
+        candidates.append(bundle.parent.parent / "utilities.tokens.json")
+    if target.is_dir():
+        candidates.append(target / "utilities.tokens.json")
+    for tokens_path in candidates:
+        if tokens_path.is_file():
+            try:
+                data = json.loads(tokens_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            kb = data.get("bundleSizeBudgetKb")
+            if isinstance(kb, int) and kb > 0:
+                return kb
+    return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, add_help=True)
     parser.add_argument("target", help="File or directory to validate")
-    parser.add_argument("--max-kb", type=int, default=80,
-                        help="Bundle size budget for utilities.css (default 80)")
+    parser.add_argument("--max-kb", type=int, default=None,
+                        help="Bundle size budget for utilities.css. "
+                             "Defaults to bundleSizeBudgetKb from a co-located "
+                             "utilities.tokens.json, or 80 if neither is set.")
     parser.add_argument("--prefixes", default=",".join(DEFAULT_PREFIXES),
                         help="Allowed breakpoint prefixes, comma-separated")
     args = parser.parse_args()
@@ -254,11 +280,15 @@ def main() -> int:
 
     # Bundle-size budget — applies only to the concatenated bundle.
     for f in bundle_files:
+        if args.max_kb is not None:
+            budget_kb = args.max_kb
+        else:
+            budget_kb = find_budget_kb(target, f) or 80
         size = f.stat().st_size
-        if size > args.max_kb * 1024:
+        if size > budget_kb * 1024:
             failures.append(
                 f"{f.name}: bundle size {size} bytes exceeds budget "
-                f"{args.max_kb} KB ({args.max_kb * 1024} bytes)"
+                f"{budget_kb} KB ({budget_kb * 1024} bytes)"
             )
 
     payload = {

--- a/plugins/acss-utilities/scripts/validate_utilities.py
+++ b/plugins/acss-utilities/scripts/validate_utilities.py
@@ -99,18 +99,22 @@ def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
     text = path.read_text(encoding="utf-8")
     rules = tinycss2.parse_stylesheet(text, skip_whitespace=True, skip_comments=True)
 
-    # Walk: (selector, prefix-or-None) → count, plus per-prefix variant set.
-    seen_selectors: Dict[str, int] = defaultdict(int)
+    # Walk: (context, selector) → count, plus per-prefix variant set. The
+    # context key is the empty string at top-level or the serialized media
+    # condition (e.g. "(width >= 30rem)") inside an @media — that way the
+    # same selector can legitimately appear under multiple media queries
+    # without tripping the duplicate check.
+    seen_selectors: Dict[Tuple[str, str], int] = defaultdict(int)
     base_classes: Set[str] = set()
     per_bp_classes: Dict[str, Set[str]] = defaultdict(set)
 
-    def visit_qualified(rule, current_prefix: str | None):
+    def visit_qualified(rule, current_ctx: str):
         body = tinycss2.serialize(rule.content) if rule.content else ""
         for m in VAR_NO_FALLBACK_RE.finditer(body):
             failures.append(f"{path.name}: var() without fallback: {m.group(0)}")
         for sel in _selectors_from_prelude(rule.prelude):
             failures.extend(_validate_selector(sel, prefixes))
-            seen_selectors[(current_prefix or "", sel)] += 1
+            seen_selectors[(current_ctx, sel)] += 1
             sm = SELECTOR_RE.match(sel)
             if not sm:
                 continue
@@ -129,13 +133,14 @@ def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
             failures.append(f"{path.name}: parser error at line {rule.source_line}: {rule.message}")
             continue
         if rule.type == "qualified-rule":
-            visit_qualified(rule, None)
+            visit_qualified(rule, "")
         elif rule.type == "at-rule" and rule.lower_at_keyword == "media":
+            media_ctx = "@media " + tinycss2.serialize(rule.prelude).strip()
             inner_text = tinycss2.serialize(rule.content) if rule.content else ""
             inner = tinycss2.parse_stylesheet(inner_text, skip_whitespace=True, skip_comments=True)
             for inner_rule in inner:
                 if inner_rule.type == "qualified-rule":
-                    visit_qualified(inner_rule, "media")
+                    visit_qualified(inner_rule, media_ctx)
 
     # Duplicate selectors within the same context.
     for (ctx, sel), count in seen_selectors.items():
@@ -211,8 +216,20 @@ def is_utility_path(path: Path) -> bool:
 
 
 def collect_files(target: Path) -> List[Path]:
+    """Return the CSS files this validator knows how to handle.
+
+    For a single file: only return it if its filename matches a utility
+    bundle/partial or a token-bridge — otherwise the validator's two
+    modes don't apply and the caller would get confusing failures (e.g.
+    selector-grammar errors against an unrelated stylesheet). The empty
+    list signals "no recognised files" and `main()` raises a usage error.
+
+    For a directory: walk the tree and collect every matching file.
+    """
     if target.is_file():
-        return [target]
+        if is_bridge_path(target) or is_utility_path(target):
+            return [target]
+        return []
     files: List[Path] = []
     for p in target.rglob("*.css"):
         if is_bridge_path(p) or is_utility_path(p):
@@ -261,6 +278,17 @@ def main() -> int:
     files = collect_files(target)
 
     if not files:
+        if target.is_file():
+            # Unrecognised filename — the validator's two modes (utility CSS,
+            # token-bridge CSS) are auto-detected by name, so a mismatch is
+            # a usage error rather than a contract violation.
+            reason = (
+                f"unrecognised filename: {target.name}. "
+                f"This validator only handles `utilities.css`, "
+                f"`utilities/<family>.css`, or `token-bridge*.css`."
+            )
+            print(json.dumps({"ok": False, "reasons": [reason]}))
+            return 2
         print(json.dumps({
             "ok": False,
             "reasons": [f"no utility CSS files found under {target}"],

--- a/plugins/acss-utilities/scripts/validate_utilities.py
+++ b/plugins/acss-utilities/scripts/validate_utilities.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Validate utility CSS files for the acss-utilities plugin.
+
+Two modes (auto-detected by filename):
+
+  Mode A — utility CSS files (`utilities.css` or `utilities/<family>.css`)
+    - Selectors must be `.kebab-case`, with optional escaped breakpoint
+      prefix (e.g. `.sm\\:hide`) and optional pseudo-class (e.g. `:focus`).
+    - Every `var(--x)` must include a fallback (`var(--x, …)`).
+    - No duplicate selectors at the same nesting level.
+    - Every responsive variant present at one breakpoint must be present
+      at every other breakpoint declared in the file.
+    - Bundle file (`utilities.css`) must not exceed `--max-kb` (default 80).
+
+  Mode B — `token-bridge.css`
+    - Every `--alias-name: …;` declaration in `:root` must also appear in
+      `[data-theme="dark"]`. Dark-mode parity is mandatory; without it,
+      utility colors silently fall back to light values when the page is
+      in dark mode.
+
+Output contract: detector style — JSON to stdout with a `reasons` array.
+Exit 0 on success, 1 on logical failure, 2 on usage / IO errors.
+
+Stdlib + tinycss2 (already a test dependency for `validate_components.py`).
+
+Usage:
+    python3 validate_utilities.py <file-or-dir> [--max-kb N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+try:
+    import tinycss2
+except ImportError:
+    print(json.dumps({
+        "ok": False,
+        "reasons": ["tinycss2 not installed: run `pip3 install --user tinycss2`"],
+    }))
+    sys.exit(2)
+
+
+# Allowed breakpoint-or-media prefix names. Includes `print` and the four
+# responsive breakpoints; if a token file adds new ones, extend this list
+# from the same source.
+DEFAULT_PREFIXES = ("sm", "md", "lg", "xl", "print")
+
+# A utility selector: `.<prefix>\:<name>` or `.<name>`, with optional
+# pseudo-class (e.g. `:focus`, `:focus-within`).
+SELECTOR_RE = re.compile(
+    r"^\."
+    r"(?:(?P<prefix>[a-z][a-z0-9-]*)\\:)?"        # optional escaped prefix
+    r"(?P<name>[a-z][a-z0-9-]*)"
+    r"(?P<pseudo>(?::[a-z-]+)*)$"
+)
+
+# Bare var() with no fallback — same regex as validate_components.py but
+# wider (any custom property prefix). Utility CSS may reference roles
+# from any `--*` namespace.
+VAR_NO_FALLBACK_RE = re.compile(r"var\(\s*--[A-Za-z0-9_-]+\s*\)")
+
+# Inside `[data-theme="dark"]`, this matches every declared property name.
+DECL_NAME_RE = re.compile(r"(?P<name>--[a-z0-9-]+)\s*:", re.IGNORECASE)
+
+
+def _selectors_from_prelude(prelude) -> List[str]:
+    """Extract comma-separated selectors from a tinycss2 prelude."""
+    text = tinycss2.serialize(prelude).strip()
+    return [s.strip() for s in text.split(",") if s.strip()]
+
+
+def _validate_selector(sel: str, prefixes: Tuple[str, ...]) -> List[str]:
+    failures: List[str] = []
+    m = SELECTOR_RE.match(sel)
+    if not m:
+        failures.append(f"selector not in canonical form: {sel}")
+        return failures
+    prefix = m.group("prefix")
+    if prefix and prefix not in prefixes:
+        failures.append(
+            f"selector {sel}: unknown breakpoint prefix '{prefix}' "
+            f"(allowed: {', '.join(prefixes)})"
+        )
+    return failures
+
+
+def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
+    failures: List[str] = []
+    text = path.read_text(encoding="utf-8")
+    rules = tinycss2.parse_stylesheet(text, skip_whitespace=True, skip_comments=True)
+
+    # Walk: (selector, prefix-or-None) → count, plus per-prefix variant set.
+    seen_selectors: Dict[str, int] = defaultdict(int)
+    base_classes: Set[str] = set()
+    per_bp_classes: Dict[str, Set[str]] = defaultdict(set)
+
+    def visit_qualified(rule, current_prefix: str | None):
+        body = tinycss2.serialize(rule.content) if rule.content else ""
+        for m in VAR_NO_FALLBACK_RE.finditer(body):
+            failures.append(f"{path.name}: var() without fallback: {m.group(0)}")
+        for sel in _selectors_from_prelude(rule.prelude):
+            failures.extend(_validate_selector(sel, prefixes))
+            seen_selectors[(current_prefix or "", sel)] += 1
+            sm = SELECTOR_RE.match(sel)
+            if not sm:
+                continue
+            prefix = sm.group("prefix") or ""
+            name = sm.group("name")
+            # Pseudo-classes don't participate in parity checks.
+            if sm.group("pseudo"):
+                continue
+            if not prefix:
+                base_classes.add(name)
+            else:
+                per_bp_classes[prefix].add(name)
+
+    for rule in rules:
+        if rule.type == "error":
+            failures.append(f"{path.name}: parser error at line {rule.source_line}: {rule.message}")
+            continue
+        if rule.type == "qualified-rule":
+            visit_qualified(rule, None)
+        elif rule.type == "at-rule" and rule.lower_at_keyword == "media":
+            inner_text = tinycss2.serialize(rule.content) if rule.content else ""
+            inner = tinycss2.parse_stylesheet(inner_text, skip_whitespace=True, skip_comments=True)
+            for inner_rule in inner:
+                if inner_rule.type == "qualified-rule":
+                    visit_qualified(inner_rule, "media")
+
+    # Duplicate selectors within the same context.
+    for (ctx, sel), count in seen_selectors.items():
+        if count > 1:
+            ctx_label = ctx or "top-level"
+            failures.append(f"{path.name}: duplicate selector {sel} in {ctx_label} ({count}×)")
+
+    # Responsive parity: every base class that appears prefixed at one bp
+    # should appear at every other declared bp (`print` is exempt — fpkit
+    # only ships `.print\:hide`).
+    declared_bps = sorted(b for b in per_bp_classes if b != "print")
+    if declared_bps:
+        for bp in declared_bps:
+            for cls in per_bp_classes[bp]:
+                # If a class has a base form, no parity issue.
+                if cls in base_classes:
+                    continue
+                # Otherwise, every other declared bp should also have it.
+                missing = [other for other in declared_bps if cls not in per_bp_classes[other]]
+                if missing:
+                    failures.append(
+                        f"{path.name}: responsive parity gap — '.{bp}\\:{cls}' "
+                        f"is declared but missing at: {', '.join(missing)}"
+                    )
+
+    return failures
+
+
+def validate_bridge_file(path: Path) -> List[str]:
+    failures: List[str] = []
+    text = path.read_text(encoding="utf-8")
+    rules = tinycss2.parse_stylesheet(text, skip_whitespace=True, skip_comments=True)
+
+    root_decls: Set[str] = set()
+    dark_decls: Set[str] = set()
+
+    for rule in rules:
+        if rule.type == "error":
+            failures.append(f"{path.name}: parser error at line {rule.source_line}: {rule.message}")
+            continue
+        if rule.type != "qualified-rule":
+            continue
+        sel = tinycss2.serialize(rule.prelude).strip()
+        body = tinycss2.serialize(rule.content) if rule.content else ""
+        names = {m.group("name") for m in DECL_NAME_RE.finditer(body)}
+        # Tolerate `:root, :where(...)` and similar compound selectors.
+        if sel == ":root" or sel.startswith(":root"):
+            root_decls.update(names)
+        elif "[data-theme=\"dark\"]" in sel or "[data-theme='dark']" in sel:
+            dark_decls.update(names)
+        # Accept any `var()` references, including ones without fallback,
+        # because the bridge's job is to *define* fallbacks for utilities.
+
+    if not root_decls:
+        failures.append(f"{path.name}: bridge file has no :root declarations")
+    if not dark_decls and root_decls:
+        failures.append(f"{path.name}: bridge file has no [data-theme=\"dark\"] block")
+    missing_in_dark = sorted(root_decls - dark_decls)
+    if missing_in_dark:
+        failures.append(
+            f"{path.name}: bridge dark-mode parity gap — declared in :root "
+            f"but missing in [data-theme=\"dark\"]: {', '.join(missing_in_dark)}"
+        )
+    return failures
+
+
+def is_bridge_path(path: Path) -> bool:
+    return "token-bridge" in path.name
+
+
+def is_utility_path(path: Path) -> bool:
+    return path.name == "utilities.css" or path.parent.name == "utilities"
+
+
+def collect_files(target: Path) -> List[Path]:
+    if target.is_file():
+        return [target]
+    files: List[Path] = []
+    for p in target.rglob("*.css"):
+        if is_bridge_path(p) or is_utility_path(p):
+            files.append(p)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, add_help=True)
+    parser.add_argument("target", help="File or directory to validate")
+    parser.add_argument("--max-kb", type=int, default=80,
+                        help="Bundle size budget for utilities.css (default 80)")
+    parser.add_argument("--prefixes", default=",".join(DEFAULT_PREFIXES),
+                        help="Allowed breakpoint prefixes, comma-separated")
+    args = parser.parse_args()
+
+    target = Path(args.target)
+    if not target.exists():
+        print(json.dumps({"ok": False, "reasons": [f"not found: {target}"]}))
+        return 2
+
+    prefixes = tuple(p.strip() for p in args.prefixes.split(",") if p.strip())
+    files = collect_files(target)
+
+    if not files:
+        print(json.dumps({
+            "ok": False,
+            "reasons": [f"no utility CSS files found under {target}"],
+        }))
+        return 1
+
+    failures: List[str] = []
+    bundle_files: List[Path] = []
+
+    for f in sorted(files):
+        if is_bridge_path(f):
+            failures.extend(validate_bridge_file(f))
+        else:
+            failures.extend(validate_utility_file(f, prefixes))
+            if f.name == "utilities.css":
+                bundle_files.append(f)
+
+    # Bundle-size budget — applies only to the concatenated bundle.
+    for f in bundle_files:
+        size = f.stat().st_size
+        if size > args.max_kb * 1024:
+            failures.append(
+                f"{f.name}: bundle size {size} bytes exceeds budget "
+                f"{args.max_kb} KB ({args.max_kb * 1024} bytes)"
+            )
+
+    payload = {
+        "ok": len(failures) == 0,
+        "filesScanned": len(files),
+        "reasons": failures,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-utilities/skills/utilities/SKILL.md
+++ b/plugins/acss-utilities/skills/utilities/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: utilities
+description: Generate, list, tune, and bridge Tailwind-style atomic CSS utility classes for fpkit/acss projects. Mirrors fpkit upstream conventions (kebab-case, no prefix, responsive `sm:`/`md:`/`lg:`/`xl:` variants). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH role names to fpkit-style names in both light and dark modes. Use when the developer wants to add utility classes to their project, list which utilities are available, adjust the spacing baseline or breakpoints, or regenerate the bridge after a theme change.
+allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
+metadata:
+  version: "0.1.0"
+---
+
+# utilities
+
+Atomic-CSS utility-class generation and management for **fpkit/acss** projects. Routes between four flows depending on which slash command was invoked. Bundles a single `utilities.css` (full atomic suite) and a `token-bridge.css` (acss-kit ↔ fpkit alias layer).
+
+**Naming and class catalogue:** see [`references/utility-catalogue.md`](references/utility-catalogue.md) and [`references/naming-convention.md`](references/naming-convention.md).
+**Breakpoints and responsive syntax:** see [`references/breakpoints.md`](references/breakpoints.md).
+**Token bridge mapping:** see [`references/token-bridge.md`](references/token-bridge.md).
+
+---
+
+## Source-of-truth
+
+The plugin's atomic suite is generated from [`assets/utilities.tokens.json`](../../assets/utilities.tokens.json). Edits to that file (manual or via `/utility-tune`) should be followed by `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_utilities.py --tokens ${CLAUDE_PLUGIN_ROOT}/assets/utilities.tokens.json --out-dir ${CLAUDE_PLUGIN_ROOT}/assets/` to regenerate the committed bundle.
+
+The committed `assets/utilities.css` and `assets/utilities/<family>.css` partials are the **canonical artifacts** — `tests/run.sh` enforces idempotency by regenerating and diffing.
+
+---
+
+## `/utility-add [--target=<dir>] [--families=<list>] [--no-bridge]`
+
+**Purpose:** Copy `utilities.css` (and `token-bridge.css` unless `--no-bridge`) into the user's React project.
+
+### Workflow
+
+1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/detect_utility_target.py`. Capture JSON.
+   - `source: "configured"` or `"default"` → use `utilitiesDir` from result.
+   - `source: "none"` (exit 1) → halt with the reasons array; suggest `--target=<dir>`.
+2. If `--target=<dir>` was passed, override the detected `utilitiesDir`.
+3. If `--families=<list>` was passed:
+   - Parse comma-separated family names. Validate against `assets/utilities/`.
+   - Concatenate the requested family partials in canonical order (the order in `FAMILY_ORDER` in `generate_utilities.py`) plus the bundle header.
+   - Write the concatenated result to `<target>/utilities.css`.
+4. Otherwise copy the prebuilt `${CLAUDE_PLUGIN_ROOT}/assets/utilities.css` verbatim to `<target>/utilities.css`.
+5. Unless `--no-bridge`, copy `${CLAUDE_PLUGIN_ROOT}/assets/token-bridge.css` to `<target>/token-bridge.css`.
+6. Print the import snippet:
+   ```ts
+   import "./styles/token-bridge.css";   // first
+   import "./styles/utilities.css";       // then
+   ```
+7. Print a summary: files written, total bundle size in KB, families included.
+
+### References to load
+
+- `references/utility-catalogue.md` — full family list, every class, every CSS custom property referenced.
+- `references/token-bridge.md` — required when `--no-bridge` is **not** set, so the assistant can explain the bridge's role.
+
+---
+
+## `/utility-list [family]`
+
+**Purpose:** Read-only catalogue printer. No side effects.
+
+### Workflow
+
+#### `/utility-list` (no arguments)
+
+1. Read `assets/utilities.tokens.json` from `${CLAUDE_PLUGIN_ROOT}/`.
+2. Print every family from `families` with its `enabled` and `responsive` status.
+3. Print the spacing scale and breakpoints inline, since they parameterize multiple families.
+4. Suggest `/utility-list <family>` for class-level detail.
+
+#### `/utility-list <family>`
+
+1. Look up the family's per-family partial at `${CLAUDE_PLUGIN_ROOT}/assets/utilities/<family>.css`.
+2. Print every selector and the property it sets (one line per class). For families with token references, also print the `var()` chain — e.g. `.bg-error` → `var(--color-error, transparent)` → resolved via `token-bridge.css` to `var(--color-danger, #dc2626)`.
+3. Print the count of classes and the file size.
+
+### References to load
+
+- `references/utility-catalogue.md`
+
+---
+
+## `/utility-tune <natural-language>`
+
+**Purpose:** Adjust the spacing baseline, breakpoints, or family-enable map via natural language. Edits `assets/utilities.tokens.json`, regenerates the bundle, runs the validator.
+
+### Examples
+
+| Phrase | Effect on tokens.json |
+|---|---|
+| "use a 4px spacing baseline" | `spacing.baseline = "0.25rem"` |
+| "use an 8px spacing baseline" | `spacing.baseline = "0.5rem"` |
+| "add an xs breakpoint at 20rem" | `breakpoints.xs = "20rem"` (validator extends `--prefixes`) |
+| "disable shadow utilities" | `families.shadow.enabled = false` |
+| "drop responsive variants from spacing" | `families.spacing.responsive = false` |
+| "add a 'soft' radius value at 1rem" | `radius.soft = "1rem"` |
+
+### Workflow
+
+1. Parse the natural-language request into one or more concrete edits to `utilities.tokens.json`. If the intent is ambiguous, ask one clarifying question via `AskUserQuestion` before making edits.
+2. Read `${CLAUDE_PLUGIN_ROOT}/assets/utilities.tokens.json`. Apply the edits in memory.
+3. Write the updated tokens back to disk (preserving JSON key order where possible — use a stable serializer).
+4. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/generate_utilities.py --tokens ${CLAUDE_PLUGIN_ROOT}/assets/utilities.tokens.json --out-dir ${CLAUDE_PLUGIN_ROOT}/assets/`.
+5. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_utilities.py ${CLAUDE_PLUGIN_ROOT}/assets/`.
+   - On `ok: false`, print the reasons array and **revert** the tokens.json edit. The committed bundle should never go out of contract.
+6. Print a summary: which fields changed, new bundle size, number of classes added/removed.
+
+### References to load
+
+- `references/utility-catalogue.md`, `references/breakpoints.md`, `references/naming-convention.md`
+
+---
+
+## `/utility-bridge [--theme=<file>]`
+
+**Purpose:** Regenerate `token-bridge.css` aliases against the user's active acss-kit theme. Always emits both `:root` and `[data-theme="dark"]` blocks.
+
+### Workflow
+
+1. If `--theme=<file>` was passed, use that as the source theme. Otherwise look in priority order:
+   - `<projectRoot>/src/styles/theme/light.css` and `dark.css`
+   - `<projectRoot>/src/styles/theme/*.css`
+   - If nothing found, fall back to the bundled `${CLAUDE_PLUGIN_ROOT}/assets/token-bridge.css` defaults and warn the user.
+2. Read the source theme(s) and extract the `--color-danger`, `--color-primary`, `--color-success`, etc. values for both light and dark modes.
+3. Build the bridge file with the fpkit-style aliases — `--color-error: var(--color-danger, <resolved-hex>)`, `--color-error-bg: color-mix(in oklch, var(--color-danger, <hex>) 12%, var(--color-background, <bg-hex>))`, and so on.
+4. Always emit both blocks; if the source theme has no `[data-theme="dark"]`, fall back to the same values for dark (and warn).
+5. Write to `<projectRoot>/<utilitiesDir>/token-bridge.css` (default `src/styles/token-bridge.css`).
+6. Run `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_utilities.py <bridge-file>` to enforce parity.
+7. Print a summary: which roles were aliased, which had explicit fallbacks, dark-mode parity status.
+
+### References to load
+
+- `references/token-bridge.md` — full alias mapping and rationale.
+
+---
+
+## Quality gates (post-flow)
+
+Every flow ends with a contract check. The plugin's hooks and `tests/run.sh` enforce these automatically; the skill should run them locally too:
+
+- **Bundle integrity** — `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/validate_utilities.py ${CLAUDE_PLUGIN_ROOT}/assets/` exits 0.
+- **Idempotency** — regenerating from `utilities.tokens.json` produces the same bytes as the committed `utilities.css`.
+- **Bridge parity** — every alias in `:root` is also defined in `[data-theme="dark"]`.
+
+If any of these fail, the user-visible flow halts and the assistant reports the reasons array verbatim.
+
+---
+
+## Out of scope (deferred to v2)
+
+- Scan-and-emit (JIT / purge) — the bundle is full by default; `--families` provides static filtering.
+- Auto-trigger on natural language ("make this padded") — `/utility-tune` is the explicit invocation.
+- Theme-mode utilities (`dark:bg-primary`, etc.) — fpkit doesn't ship these upstream.
+- Generating React components — `acss-kit` owns components.

--- a/plugins/acss-utilities/skills/utilities/references/breakpoints.md
+++ b/plugins/acss-utilities/skills/utilities/references/breakpoints.md
@@ -1,0 +1,60 @@
+# Breakpoints
+
+Responsive variants are generated for every family with `families.<f>.responsive: true` in [`utilities.tokens.json`](../../../assets/utilities.tokens.json). The breakpoint values match fpkit upstream (`@fpkit/acss@6.5.0`) verbatim.
+
+## Default breakpoints
+
+| Prefix | Min width | Pixel equivalent | Source |
+|---|---|---|---|
+| `sm` | `30rem` | 480 px | `_display.scss` (fpkit) |
+| `md` | `48rem` | 768 px | `_display.scss` (fpkit) |
+| `lg` | `62rem` | 992 px | `_display.scss` (fpkit) |
+| `xl` | `80rem` | 1280 px | `_display.scss` (fpkit) |
+
+The `print` prefix is special — it maps to `@media print` rather than a viewport width. fpkit only ships `.print:hide` upstream; this plugin matches that scope and does not add other `print:` variants.
+
+## Media-query syntax
+
+The generator emits modern range syntax matching fpkit:
+
+```css
+@media (width >= 30rem) {
+  .sm\:hide { display: none !important; }
+  .sm\:show { display: revert !important; }
+  /* … every base class with `responsive: true` */
+}
+```
+
+Not the legacy `@media (min-width: 30rem)` form. Browser support: Chrome 104+, Firefox 102+, Safari 16.4+ (≥ Apr 2023). All evergreen browsers ship it.
+
+## JSX usage
+
+In CSS the colon is escaped (`\:`) because `:` is a pseudo-class delimiter; in JSX `className` strings, write the colon literally:
+
+```tsx
+<div className="hide sm:show">
+  Mobile-only header
+</div>
+
+<button className="bg-primary p-4 md:p-6 lg:p-8">
+  Padded button
+</button>
+```
+
+## Adding a custom breakpoint
+
+`/utility-tune "add an xs breakpoint at 20rem"` will:
+
+1. Edit `breakpoints.xs` in `utilities.tokens.json`.
+2. Regenerate the bundle — every family with `responsive: true` will get `.xs:` variants.
+3. Run `validate_utilities.py` with `--prefixes=sm,md,lg,xl,xs,print` so the new prefix is accepted.
+
+Breakpoint **removal** is also supported but bundle size will drop and any project consuming `.<removed>:` classes will fall through to the base. Always communicate the removal to consumers.
+
+## Responsive-parity check
+
+The validator enforces that every responsive class declared at one breakpoint is declared at every other declared breakpoint. So if your tokens.json enables `responsive: true` for `flex`, every `.flex-*` class must appear at `sm:`, `md:`, `lg:`, *and* `xl:` — partial declarations fail the contract.
+
+This guard prevents the silent pattern where a developer writes `.md:flex-row` in source, but the bundle only emits `.sm:flex-row` (so the class disappears at md+ and the row falls back to whatever the base value is). Generators that loop over breakpoints are the safe path; hand-authored CSS within a per-family partial must mirror across all breakpoints declared in the file.
+
+`print` is exempt from the parity check (it's a single-purpose prefix, not part of the responsive family).

--- a/plugins/acss-utilities/skills/utilities/references/naming-convention.md
+++ b/plugins/acss-utilities/skills/utilities/references/naming-convention.md
@@ -1,0 +1,72 @@
+# Naming convention
+
+Class names mirror **fpkit/acss upstream** (`@fpkit/acss@6.5.0`) verbatim where present, and follow the same kebab-case pattern for families this plugin extends beyond upstream. See [ATTRIBUTION.md](../../../ATTRIBUTION.md) for the upstream/extended split.
+
+## Selector form
+
+```text
+.<prefix>\:<name><pseudo?>
+```
+
+- **`<prefix>`** — *optional*. One of `sm`, `md`, `lg`, `xl`, `print`. The `:` separator is escaped to `\:` in CSS but written as `:` in JSX (`<div className="sm:hide">…`).
+- **`<name>`** — kebab-case; lowercase letters, digits, and hyphens. Starts with a letter. Examples: `bg-primary`, `mt-4`, `flex-col-reverse`, `grid-cols-12`.
+- **`<pseudo>`** — *optional*. Any standard CSS pseudo-class (`:focus`, `:focus-within`, `:hover`). Used by `sr-only-focusable`.
+
+The validator (`scripts/validate_utilities.py`) enforces this form. PascalCase, snake_case, and unrecognized prefixes (`xxl:`, `desktop:`) all fail.
+
+## Family-name conventions
+
+| Family | Prefix | Property |
+|---|---|---|
+| `color-bg` | `bg-` | `background-color` |
+| `color-text` | `text-` | `color` (when value is a role) |
+| `color-border` | `border-` | `border-color` |
+| `spacing` | `m-/mt-/mb-/ml-/mr-/mx-/my-/p-/pt-/pb-/pl-/pr-/px-/py-/gap-` | `margin*`, `padding*`, `gap` |
+| `display` | `hide`, `show`, `invisible`, `sr-only`, `sr-only-focusable`, `print:hide` | `display`, `visibility` |
+| `flex` | `flex`, `flex-*`, `justify-*`, `items-*` | `display`, `flex-*`, `justify-content`, `align-items` |
+| `grid` | `grid`, `grid-cols-*`, `grid-rows-*`, `inline-grid` | `display`, `grid-template-*` |
+| `type` | `text-{xs,sm,…}`, `font-*`, `leading-*`, `text-{left,center,right,justify}` | `font-size`, `font-weight`, `line-height`, `text-align` |
+| `radius` | `rounded`, `rounded-*` | `border-radius` |
+| `shadow` | `shadow`, `shadow-*` | `box-shadow` |
+| `position` | `static`/`relative`/`absolute`/`fixed`/`sticky` | `position` |
+| `z-index` | `z-{0,10,20,30,40,50,auto}` | `z-index` |
+
+## `text-` prefix collision
+
+Both color and size use `.text-`:
+
+- `.text-primary`, `.text-error` — color (resolves to `var(--color-{role})`)
+- `.text-xs`, `.text-sm`, `.text-base`, `.text-lg` — font-size (literal value)
+
+This collision is intentional — fpkit and Tailwind both ship it. The names don't overlap in practice (`primary`/`error`/etc. vs `xs`/`sm`/`base`/etc.), and the family-level partition keeps them in separate per-family files.
+
+## `!important` policy
+
+Only **display / visibility** utilities use `!important`:
+
+- `.hide`, `.show`, `.invisible`, all `.<bp>:hide` variants, `.print:hide`
+
+Rationale: utilities that change layout intent (showing or hiding a block) must defeat any component-level `display:` rules. Color / spacing / typography utilities are **composable** and should not use `!important` — they layer on top of component CSS through the cascade.
+
+## CSS custom property fallbacks
+
+Every `var()` reference inside a utility class **must include a fallback**. The validator enforces this contract:
+
+```css
+/* OK */
+.bg-primary { background-color: var(--color-primary, transparent); }
+
+/* Rejected — no fallback */
+.bg-primary { background-color: var(--color-primary); }
+```
+
+The fallback's purpose: utility classes should produce a sensible result even when the host project's theme CSS hasn't loaded yet, or when running outside acss-kit. The validator's same-shape check is shared with `acss-kit`'s `validate_components.py` (the SCSS contract harness).
+
+## Source-of-truth
+
+Class generation is fully driven by `assets/utilities.tokens.json`. Naming changes therefore have two surfaces:
+
+1. **Token data** — adding a new role/value/family in `tokens.json`.
+2. **Emitter logic** — `generate_utilities.py` decides how a token becomes a class name. New families need a new emitter function and an entry in `EMITTERS` / `FAMILY_ORDER`.
+
+For maintainer workflows, see [`.claude/skills/utility-author/`](../../../../../.claude/skills/utility-author/SKILL.md).

--- a/plugins/acss-utilities/skills/utilities/references/token-bridge.md
+++ b/plugins/acss-utilities/skills/utilities/references/token-bridge.md
@@ -1,0 +1,74 @@
+# Token bridge
+
+`utilities.css` references **fpkit-style token names** that don't all exist in acss-kit's role catalogue. The bridge translates between the two namespaces in both light and dark modes.
+
+## The naming gap
+
+| Used by utilities (fpkit-style) | Defined by acss-kit | Status |
+|---|---|---|
+| `--color-primary` | `--color-primary` | ✓ same name — no alias needed |
+| `--color-success` | `--color-success` | ✓ |
+| `--color-warning` | `--color-warning` | ✓ |
+| `--color-info` | `--color-info` | ✓ |
+| `--color-text` | `--color-text` | ✓ |
+| `--color-text-muted` | `--color-text-muted` | ✓ |
+| `--color-surface` | `--color-surface` | ✓ |
+| `--color-error` | `--color-danger` | ✗ — bridge required |
+| `--color-error-bg` | *(not defined)* | ✗ — bridge synthesizes via `color-mix` |
+| `--color-success-bg` | *(not defined)* | ✗ — bridge synthesizes |
+| `--color-warning-bg` | *(not defined)* | ✗ — bridge synthesizes |
+| `--color-info-bg` | *(not defined)* | ✗ — bridge synthesizes |
+| `--color-primary-light` | *(not defined)* | ✗ — bridge synthesizes |
+| `--color-secondary` | *(not defined)* | ✗ — bridge falls back to `--color-primary` |
+| `--color-surface-secondary` | `--color-surface-raised` | ✗ — bridge aliases |
+
+## Bridge contract
+
+1. Every alias defined in `:root` **must** also be defined in `[data-theme="dark"]`. The validator (`validate_utilities.py`) enforces parity. Without the dark block, every color utility resolves to its light-mode value when the page is in dark mode.
+2. Every alias **must** have a hex fallback embedded in its `var()` chain or `color-mix` arguments. So if acss-kit isn't installed, the bridge still resolves to a sensible color.
+3. Mix ratios are tuned for each mode: `12%` mix on `var(--color-{role}) → var(--color-background)` produces a subtle "subtle" background in light mode; `18%` produces a slightly stronger one in dark mode (background luminance is lower so the chip needs more saturation).
+
+## Synthesized values via `color-mix`
+
+The bridge uses CSS-native `color-mix(in oklch, …)` to synthesize `-bg` and `-light` variants:
+
+```css
+:root {
+  --color-error-bg: color-mix(in oklch, var(--color-danger, #dc2626) 12%, var(--color-background, #ffffff));
+}
+```
+
+Browser support for `color-mix(in oklch, …)`: Chrome 111+, Firefox 113+, Safari 16.2+ (≥ early 2023). For older browsers the embedded hex fallback resolves only the base role — `--color-error-bg` would fall back to `transparent` (the value declared in `.bg-error-subtle`'s `var()` fallback).
+
+## Regenerating the bridge
+
+`/utility-bridge` reads the user's active theme and rewrites the bridge to match. The defaults shipped at `assets/token-bridge.css` are appropriate for any acss-kit theme that follows the canonical role catalogue. Custom themes (extra roles, renamed roles) will need a re-run.
+
+## Standalone use (without acss-kit)
+
+If acss-kit is not installed, the bridge's hex fallbacks resolve to fpkit-default-ish values (`#dc2626` for error, `#16a34a` for success, etc.). Users who want their own color identity can either:
+
+1. Author their own theme CSS that defines `--color-danger`, `--color-success`, … under `:root` and `[data-theme="dark"]`. The bridge composes on top.
+2. Write a custom `token-bridge.css` that hard-codes their colors directly (skip the `var()` chain). Run `/utility-add --no-bridge` to skip the default bridge.
+
+## Validator checks
+
+`validate_utilities.py` recognizes `token-bridge*.css` by filename and runs the parity check:
+
+```bash
+python3 scripts/validate_utilities.py assets/token-bridge.css
+```
+
+Failures look like:
+
+```json
+{
+  "ok": false,
+  "filesScanned": 1,
+  "reasons": [
+    "token-bridge.css: bridge dark-mode parity gap — declared in :root but missing in [data-theme=\"dark\"]: --color-error-bg, --color-primary-light"
+  ]
+}
+```
+
+Fix by adding the missing aliases to the `[data-theme="dark"]` block, then re-run.

--- a/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
+++ b/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
@@ -1,0 +1,165 @@
+# Utility catalogue
+
+Every family the plugin emits in v1, every class within it, and the CSS custom property the class references. The canonical source-of-truth is [`assets/utilities.tokens.json`](../../../assets/utilities.tokens.json); this document mirrors it for human review.
+
+## Family inventory
+
+| Family | Responsive | Class count* | Token namespace |
+|---|---|---|---|
+| `color-bg` | no | 16 (11 roles + 4 `-subtle` + `-transparent`) | `--color-*`, `--color-*-bg` |
+| `color-text` | no | 11 | `--color-*`, `--color-text-*` |
+| `color-border` | no | 11 | `--color-*` |
+| `spacing` | yes (sm/md/lg/xl) | ~210 base × 4 bps = ~1050 | none — literal rem values |
+| `display` | yes (sm/md/lg/xl/print) | 5 base + 5 × 4 bps + `print:hide` + sr-only x2 | none |
+| `flex` | yes (sm/md/lg/xl) | 21 base × 5 = 105 | none |
+| `grid` | yes (sm/md/lg/xl) | 20 base × 5 = 100 | none |
+| `type` | no | 19 | none — literal values from `tokens.type` |
+| `radius` | no | 7 (incl. bare `.rounded`) | none |
+| `shadow` | no | 6 (incl. bare `.shadow`) | none |
+| `position` | no | 5 | none |
+| `z-index` | no | 7 | none |
+
+\* Approximate; exact counts depend on `utilities.tokens.json#families.<f>.enabled` and `responsive`.
+
+## color-bg
+
+Every class sets `background-color`. Roles map to `tokens.colorRoles[<name>]`; `-subtle` variants map to `tokens.stateBg[<name>]`.
+
+| Class | Sets | Reads |
+|---|---|---|
+| `.bg-primary` | background-color | `var(--color-primary, transparent)` |
+| `.bg-primary-light` | background-color | `var(--color-primary-light, transparent)` |
+| `.bg-secondary` | background-color | `var(--color-secondary, transparent)` |
+| `.bg-success` | background-color | `var(--color-success, transparent)` |
+| `.bg-error` | background-color | `var(--color-error, transparent)` |
+| `.bg-warning` | background-color | `var(--color-warning, transparent)` |
+| `.bg-info` | background-color | `var(--color-info, transparent)` |
+| `.bg-text` | background-color | `var(--color-text, transparent)` |
+| `.bg-muted` | background-color | `var(--color-text-muted, transparent)` |
+| `.bg-surface` | background-color | `var(--color-surface, transparent)` |
+| `.bg-surface-secondary` | background-color | `var(--color-surface-secondary, transparent)` |
+| `.bg-success-subtle` | background-color | `var(--color-success-bg, transparent)` |
+| `.bg-error-subtle` | background-color | `var(--color-error-bg, transparent)` |
+| `.bg-warning-subtle` | background-color | `var(--color-warning-bg, transparent)` |
+| `.bg-info-subtle` | background-color | `var(--color-info-bg, transparent)` |
+| `.bg-transparent` | background-color | literal `transparent` |
+
+`--color-error`, `--color-error-bg`, `--color-primary-light`, etc. are not present in acss-kit's role catalogue. The plugin's [`token-bridge.css`](../../../assets/token-bridge.css) aliases them to acss-kit's `--color-danger`, `--color-primary`, etc. — see [`token-bridge.md`](token-bridge.md).
+
+## color-text
+
+Every class sets `color`. Same role list as `color-bg` (without `-subtle` variants).
+
+| Class | Reads |
+|---|---|
+| `.text-primary` … `.text-surface-secondary` | `var(--color-{role}, currentColor)` |
+
+## color-border
+
+Every class sets `border-color`. Same role list.
+
+| Class | Reads |
+|---|---|
+| `.border-primary` … `.border-surface-secondary` | `var(--color-{role}, currentColor)` |
+
+## spacing
+
+Generated from `tokens.spacing.{baseline, scale, properties}`. Each (property, scale-step) pair becomes a class.
+
+- **Properties**: `m`, `mt`, `mb`, `ml`, `mr`, `mx`, `my`, `p`, `pt`, `pb`, `pl`, `pr`, `px`, `py`, `gap`
+- **Scale**: `[0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32]`
+- **Baseline**: `0.25rem` (so `.m-4 = 1rem`, `.p-8 = 2rem`)
+- **Responsive**: yes — every class has `.sm:`, `.md:`, `.lg:`, `.xl:` variants
+
+Examples:
+
+| Class | Sets |
+|---|---|
+| `.m-0` | `margin: 0` |
+| `.m-4` | `margin: 1rem` |
+| `.mt-2` | `margin-top: 0.5rem` |
+| `.px-6` | `margin-left: 1.5rem; margin-right: 1.5rem` |
+| `.gap-3` | `gap: 0.75rem` |
+| `.sm:p-4` | wrapped in `@media (width >= 30rem)` |
+
+## display
+
+Layout / visibility primitives.
+
+| Class | Sets | Note |
+|---|---|---|
+| `.hide` | `display: none !important` | wins over component styles by design |
+| `.show` | `display: revert !important` | resets `.hide` |
+| `.invisible` | `visibility: hidden !important` | preserves layout |
+| `.sr-only` | absolute clip rect | screen-reader-only utility |
+| `.sr-only-focusable` | absolute clip rect, becomes static on focus | skip-link pattern |
+| `.print:hide` | `display: none !important` inside `@media print` | print-specific |
+| `.sm:hide` etc. | `display: none !important` inside `@media (width >= …)` | responsive |
+
+`.sr-only` and `.sr-only-focusable` are not responsive — they're accessibility primitives that should always be active regardless of viewport.
+
+## flex
+
+| Class | Sets |
+|---|---|
+| `.flex`, `.inline-flex` | `display: flex` / `inline-flex` |
+| `.flex-row`, `.flex-row-reverse`, `.flex-col`, `.flex-col-reverse` | `flex-direction: …` |
+| `.flex-wrap`, `.flex-nowrap` | `flex-wrap: …` |
+| `.flex-1` | `flex: 1 1 0%` |
+| `.flex-auto` | `flex: 1 1 auto` |
+| `.flex-none` | `flex: none` |
+| `.justify-start/end/center/between/around` | `justify-content: …` |
+| `.items-start/end/center/baseline/stretch` | `align-items: …` |
+
+All have responsive variants.
+
+## grid
+
+| Class | Sets |
+|---|---|
+| `.grid`, `.inline-grid` | `display: grid` / `inline-grid` |
+| `.grid-cols-1` … `.grid-cols-12` | `grid-template-columns: repeat(N, minmax(0, 1fr))` |
+| `.grid-rows-1` … `.grid-rows-6` | `grid-template-rows: repeat(N, minmax(0, 1fr))` |
+
+All have responsive variants.
+
+## type
+
+| Class | Sets |
+|---|---|
+| `.text-xs/sm/base/lg/xl/2xl/3xl/4xl` | `font-size: <size>` |
+| `.font-normal/medium/semibold/bold` | `font-weight: <400-700>` |
+| `.leading-tight/normal/loose` | `line-height: <ratio>` |
+| `.text-left/center/right/justify` | `text-align: …` |
+
+Note: `.text-{role}` (color) and `.text-{size}` (size) share the `.text-` prefix but resolve different CSS properties. fpkit upstream uses the same pattern; the validator allows both since selector parsing only checks form.
+
+## radius
+
+| Class | Sets |
+|---|---|
+| `.rounded` | `border-radius: 0.375rem` (alias of `rounded-md`) |
+| `.rounded-none/sm/md/lg/xl/full` | `border-radius: <value>` |
+
+## shadow
+
+| Class | Sets |
+|---|---|
+| `.shadow` | `box-shadow: <md value>` (alias of `shadow-md`) |
+| `.shadow-none/sm/md/lg/xl` | `box-shadow: <value>` |
+
+## position
+
+| Class | Sets |
+|---|---|
+| `.static`, `.relative`, `.absolute`, `.fixed`, `.sticky` | `position: <value>` |
+
+## z-index
+
+| Class | Sets |
+|---|---|
+| `.z-0`, `.z-10`, `.z-20`, `.z-30`, `.z-40`, `.z-50`, `.z-auto` | `z-index: <value>` |
+
+## Adding a family
+
+See [`.claude/skills/utility-author/SKILL.md`](../../../../../.claude/skills/utility-author/SKILL.md) for the maintainer workflow. In short: edit `tokens.families`, register an emitter in `generate_utilities.py`, regenerate, validate.

--- a/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
+++ b/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
@@ -9,8 +9,8 @@ Every family the plugin emits in v1, every class within it, and the CSS custom p
 | `color-bg` | no | 16 (11 roles + 4 `-subtle` + `-transparent`) | `--color-*`, `--color-*-bg` |
 | `color-text` | no | 11 | `--color-*`, `--color-text-*` |
 | `color-border` | no | 11 | `--color-*` |
-| `spacing` | yes (sm/md/lg/xl) | ~210 base × 4 bps = ~1050 | none — literal rem values |
-| `display` | yes (sm/md/lg/xl/print) | 5 base + 5 × 4 bps + `print:hide` + sr-only x2 | none |
+| `spacing` | yes (sm/md/lg/xl) | 210 base + 210 × 4 bps = 1050 | none — literal rem values |
+| `display` | yes (sm/md/lg/xl/print) | 3 responsive base (`hide`/`show`/`invisible`) + 3 × 4 bps + `print:hide` + sr-only ×2 = 18 | none |
 | `flex` | yes (sm/md/lg/xl) | 21 base × 5 = 105 | none |
 | `grid` | yes (sm/md/lg/xl) | 20 base × 5 = 100 | none |
 | `type` | no | 19 | none — literal values from `tokens.type` |
@@ -78,7 +78,7 @@ Examples:
 | `.m-0` | `margin: 0` |
 | `.m-4` | `margin: 1rem` |
 | `.mt-2` | `margin-top: 0.5rem` |
-| `.px-6` | `margin-left: 1.5rem; margin-right: 1.5rem` |
+| `.px-6` | `padding-left: 1.5rem; padding-right: 1.5rem` |
 | `.gap-3` | `gap: 0.75rem` |
 | `.sm:p-4` | wrapped in `@media (width >= 30rem)` |
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,6 +14,12 @@
 #   5. Manifest / structure replication of verify-plugins.
 #   6. Known-bad self-tests: confirm the validators catch their own
 #      contract violations.
+#   7. detect_package_manager.py --self-test.
+#   8. acss-utilities validator over plugins/acss-utilities/assets/
+#      (selector grammar, var() fallbacks, bridge dark-mode parity,
+#      bundle-size budget).
+#   9. acss-utilities idempotency: regenerate from utilities.tokens.json
+#      and diff against the committed bundle + per-family partials.
 #
 # Why syntax-only TSX validation: the reference docs split TSX across
 # multiple Key Pattern sections containing illustrative JSX or
@@ -151,6 +157,54 @@ else
   red "detect_package_manager self-test FAILED:"
   cat "$DPM_LOG"
   exit 1
+fi
+
+# Step 8
+section "8. acss-utilities validator"
+UTIL_DIR="$REPO_ROOT/plugins/acss-utilities/assets"
+if [ -d "$UTIL_DIR" ]; then
+  UTIL_LOG="$TMP_ROOT/utilities-validate.log"
+  if python3 "$REPO_ROOT/plugins/acss-utilities/scripts/validate_utilities.py" "$UTIL_DIR" >"$UTIL_LOG"; then
+    green "acss-utilities validator OK"
+  else
+    red "acss-utilities validator failed:"
+    cat "$UTIL_LOG"
+    exit 1
+  fi
+else
+  yellow "no plugins/acss-utilities/assets — skipping utilities validator"
+fi
+
+# Step 9
+section "9. acss-utilities idempotency"
+if [ -f "$UTIL_DIR/utilities.tokens.json" ]; then
+  UTIL_REGEN_DIR="$TMP_ROOT/utilities-regen"
+  mkdir -p "$UTIL_REGEN_DIR"
+  REGEN_LOG="$TMP_ROOT/utilities-regen.log"
+  if ! python3 "$REPO_ROOT/plugins/acss-utilities/scripts/generate_utilities.py" \
+         --tokens "$UTIL_DIR/utilities.tokens.json" \
+         --out-dir "$UTIL_REGEN_DIR" >"$REGEN_LOG" 2>&1; then
+    red "acss-utilities generator failed:"
+    cat "$REGEN_LOG"
+    exit 1
+  fi
+  IDEMPOTENT=1
+  if ! diff -q "$UTIL_DIR/utilities.css" "$UTIL_REGEN_DIR/utilities.css" >/dev/null; then
+    IDEMPOTENT=0
+  fi
+  if ! diff -qr "$UTIL_DIR/utilities/" "$UTIL_REGEN_DIR/utilities/" >/dev/null; then
+    IDEMPOTENT=0
+  fi
+  if [ "$IDEMPOTENT" -eq 0 ]; then
+    red "acss-utilities idempotency check failed — regenerated bundle diverges from the committed copy."
+    red "Run \`python3 plugins/acss-utilities/scripts/generate_utilities.py --tokens \\"
+    red "  plugins/acss-utilities/assets/utilities.tokens.json --out-dir plugins/acss-utilities/assets/\` and commit."
+    diff "$UTIL_DIR/utilities.css" "$UTIL_REGEN_DIR/utilities.css" | head -40 || true
+    exit 1
+  fi
+  green "acss-utilities idempotency OK"
+else
+  yellow "no plugins/acss-utilities/assets/utilities.tokens.json — skipping idempotency check"
 fi
 
 section "ALL STEPS GREEN"


### PR DESCRIPTION
## Summary

Introduces the `acss-utilities` plugin, a new Claude Code plugin that generates Tailwind-style atomic CSS utility classes for fpkit/acss projects. The plugin provides a complete utility-class layer (`.bg-primary`, `.mt-4`, `.sm:hide`, etc.) generated from a token source-of-truth, paired with a token-bridge that aliases acss-kit's OKLCH color roles to fpkit-style names in both light and dark modes.

## Key Changes

- **Generated utility bundle** (`utilities.css`): ~1,436 lines of atomic CSS covering 11 families (color-bg, color-text, color-border, spacing, display, flex, grid, type, radius, shadow, position, z-index) with responsive variants at sm/md/lg/xl breakpoints
- **Token bridge** (`token-bridge.css`): Aliases acss-kit's role names to fpkit-style names with mandatory dark-mode parity
- **Generation scripts**:
  - `generate_utilities.py`: Reads `utilities.tokens.json` and emits CSS (bundle + per-family partials)
  - `validate_utilities.py`: Validates utility CSS for selector naming, var() fallbacks, responsive parity, and bundle size
  - `detect_utility_target.py`: Detects target directory for bundle installation (configured via `.acss-target.json` or defaults to `src/styles/`)
- **Token source-of-truth** (`utilities.tokens.json`): Defines breakpoints, color roles, state backgrounds, and family configuration
- **Four slash commands**:
  - `/utility-add`: Copy prebuilt bundle into target React project
  - `/utility-list`: List utility families and their classes
  - `/utility-tune`: Adjust tokens (spacing baseline, breakpoints, family enables) via natural language
  - `/utility-bridge`: Regenerate token-bridge against active acss-kit theme
- **Documentation**: Comprehensive README, skill definition, naming conventions, breakpoints reference, token-bridge mapping, and utility catalogue
- **Attribution**: Tracks fpkit/acss@6.5.0 upstream pin and documents naming parity

## Implementation Details

- Class naming mirrors fpkit upstream verbatim (kebab-case, no prefix, escaped breakpoint prefixes like `.sm\:hide`)
- Responsive variants use `@media (width >= <breakpoint>)` queries with escaped colon syntax
- Color utilities reference CSS custom properties with fallbacks (`var(--color-primary, transparent)`)
- Spacing utilities use literal rem values (0.25rem baseline, 0–32 scale)
- Display/visibility utilities include `!important` to ensure they always win
- Token bridge validates dark-mode parity: every property in `:root` must also appear in `[data-theme="dark"]`
- Bundle size budget: 80 KB (configurable in tokens)
- Python scripts follow stdlib-only contract with JSON output and exit codes (0=success, 1=logical failure, 2=usage/IO error)

## Plugin Integration

- Registered in marketplace.json as part of agentic-acss-plugins
- Pairs with acss-kit but can be used standalone with hand-written themes
- Decoupled ownership: acss-kit owns components/themes, acss-utilities owns utility classes

https://claude.ai/code/session_01HCjUZKNkSWu7ofa3CFp2wo