### PR TITLE
feat(acss-utilities): kebab-case responsive variants (0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "acss-utilities",
       "source": "./plugins/acss-utilities",
-      "description": "Tailwind-style atomic CSS utility classes for fpkit/acss projects, mirroring @fpkit/acss@6.5.0 conventions (.bg-primary, .mt-4, .sm:hide, etc.). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH roles to fpkit-style names in both light and dark modes. Run /utility-add to drop the bundle into your project.",
+      "description": "Tailwind-style atomic CSS utility classes for fpkit/acss projects (.bg-primary, .mt-4, .sm-hide). Hyphen-prefix responsive variants — no CSS escaping needed. Pairs with acss-kit via a token-bridge. Run /utility-add to drop the bundle into your project.",
       "category": "development",
       "tags": [
         "utility-classes",

--- a/docs/plans/kebab-case-responsive-variants.md
+++ b/docs/plans/kebab-case-responsive-variants.md
@@ -1,0 +1,75 @@
+# Plan — kebab-case responsive class names
+
+## Context
+
+`acss-utilities` currently emits responsive variants using fpkit upstream's escaped-colon convention (`.sm\:hide`, `.md\:p-6`, `.print\:hide`). The user wants all `:`-bearing utility class names converted to plain kebab-case so JSX `className` strings, validators, and tooling don't have to deal with the colon.
+
+**Decisions confirmed with user (2026-04-29):**
+
+- Separator: **single hyphen** — `.sm-hide`, `.md-p-6`, `.print-hide`. No collision today (no base utility starts with `sm-`/`md-`/`lg-`/`xl-`/`print-`).
+- fpkit parity claim: **drop entirely** for class naming. Token names, breakpoint values, and modern range media-query syntax still mirror fpkit; class-name divergence is now a documented design decision.
+- Migration mode: **clean break in 0.2.0**, no dual-emit shim. Pre-1.0 semver allows breaking changes on minor bumps.
+- Print collision-guard: **structural** — validator uses tinycss2 to detect `@media print { ... }` context; `.print-*` selectors only allowed inside that block.
+- Validator strictness scope: **bundle only** (`assets/utilities.css` + family partials). Consumer-supplied CSS files are not subject to the new base-existence and collision-guard checks.
+- Consumer migration script (`scripts/migrate_classnames.py`): **in-scope for 0.2.0** — see step 7.
+- This is a breaking change for any consumer who already imported the bundle. Bump `plugin.json` to `0.2.0` and document migration.
+
+## Status
+
+**IMPLEMENTED** (2026-04-29). All steps completed and `tests/run.sh` is green.
+
+## Steps
+
+### 0. Pre-edit grep enumeration ✅
+
+Grep confirmed colon-syntax only in the scripts and generated assets; acss-kit cross-plugin check was clean.
+
+### 1. Validator redesign — `plugins/acss-utilities/scripts/validate_utilities.py` ✅
+
+New `SELECTOR_RE`: matches `.<body>(:pseudo)*` without the prefix group. Stage B prefix detection done in `validate_utility_file` by checking if body starts with `<bp>-`.
+
+New checks added:
+- **Check 1 — base-class-existence:** every `.sm-foo` must have a base `.foo` in the same file.
+- **Check 2 — collision guard:** selectors starting with a breakpoint prefix are only valid inside the matching `@media` block.
+- **Reserved prefix names:** bare prefix names (`sm`, `md`, `lg`, `xl`, `print`) rejected as class bodies to catch old colon syntax (`.sm:hide` parsed as body=`sm`, pseudo=`:hide`).
+- **Check 3 — parity message updated:** `'.{bp}-{cls}'` (was `'.{bp}\\:{cls}'`).
+
+### 2. Generator emission — `plugins/acss-utilities/scripts/generate_utilities.py` ✅
+
+- `_wrap_responsive`: `bp + r"\:"` → `bp + "-"`
+- `emit_display`: `block(bp + chr(92) + ':')` → `block(bp + '-')`, `print\\:hide` → `print-hide`
+- Docstring updated.
+
+### 3. Regenerate the canonical artifacts ✅
+
+All CSS partials regenerated. Validator passes with exit 0.
+
+### 4. Update SKILL/reference docs ✅
+
+- `SKILL.md` description updated, version bumped to `0.2.0`
+- `breakpoints.md`: media-query block and JSX examples updated
+- `naming-convention.md`: selector form, prefix-allowlist rule, collision guard documented
+- `utility-catalogue.md`: all `.sm:` → `.sm-` forms updated
+
+### 5. Update plugin docs and ATTRIBUTION ✅
+
+- `README.md`: class examples, responsive variants subsection with migration notes
+- `CHANGELOG.md`: `[0.2.0]` entry with breaking change, new validator checks, migration guide
+- `ATTRIBUTION.md`: class-name divergence documented
+- `docs/tutorial.md`, `docs/concepts.md`, `docs/troubleshooting.md`: updated
+
+### 6. Bump version + marketplace description + plan rename ✅
+
+- `plugin.json`: `0.1.0` → `0.2.0`
+- `marketplace.json`: description updated
+- This plan file renamed from auto-generated stub
+
+### 7. Consumer migration script — `plugins/acss-utilities/scripts/migrate_classnames.py` ✅
+
+Stdlib-only. Dry-run by default; `--write` to apply. Covers JSX/TSX, TS/JS (clsx/classnames), HTML/Svelte/Vue/Astro (`class=`/`className=` only), CSS/SCSS (`@apply` + escaped selectors). 7 fixtures passing with idempotency. Integrated into `tests/run.sh` Step 10.
+
+## Next Steps (out of scope)
+
+- `/utility-migrate` slash command wrapping `migrate_classnames.py` if consumers ask for a one-key invocation.
+- Lint rule / pre-commit hook flagging literal `\bsm:hide` patterns in JSX strings inside consumer projects.
+- Revisit `token-bridge.css` aliases now that fpkit class-name parity has been dropped (token-name parity is independent and stays).

--- a/plugins/acss-utilities/.claude-plugin/plugin.json
+++ b/plugins/acss-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-utilities",
-  "description": "CSS utility-class plugin for fpkit/acss projects. Tailwind-style atomic classes (.bg-primary, .mt-4, .sm:hide) generated from a token source-of-truth, with a token-bridge that aliases acss-kit's OKLCH roles to fpkit-style names.",
-  "version": "0.1.0",
+  "description": "CSS utility-class plugin for fpkit/acss projects. Tailwind-style atomic classes (.bg-primary, .mt-4, .sm-hide) generated from a token source-of-truth, with a token-bridge that aliases acss-kit's OKLCH roles to fpkit-style names.",
+  "version": "0.2.0",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-utilities/ATTRIBUTION.md
+++ b/plugins/acss-utilities/ATTRIBUTION.md
@@ -8,9 +8,12 @@ The plugin tracks **`@fpkit/acss@6.5.0`** (the same pin used by `acss-kit`'s com
 
 ## What we mirror verbatim
 
-- **Class names** for color (`.bg-*`, `.text-*`, `.border-*`), display (`.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`), responsive variants (`.sm:hide`, `.md:show`, `.lg:invisible`, `.xl:hide`, `.print:hide`), and the `:` separator (escaped as `\:` in CSS).
+- **Class names** for color (`.bg-*`, `.text-*`, `.border-*`), display (`.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`), and responsive variant base names (`hide`, `show`, `invisible`).
 - **Breakpoints**: `sm: 30rem`, `md: 48rem`, `lg: 62rem`, `xl: 80rem`. Identical to `_display.scss` in upstream.
+- **Modern range-query syntax** (`@media (width >= …)`) matching fpkit's generated CSS.
 - **`!important` policy** for display/visibility utilities (matches `_display.scss`).
+
+**Class-name divergence (intentional):** fpkit upstream uses escaped-colon responsive variants (`.sm\:hide` in CSS, `sm:hide` in JSX). This plugin uses plain hyphen-prefix variants (`.sm-hide` in both). Token values, breakpoints, and media-query syntax remain aligned with fpkit; only the responsive class-name separator differs.
 
 Per-family upstream sources (when applicable):
 

--- a/plugins/acss-utilities/CHANGELOG.md
+++ b/plugins/acss-utilities/CHANGELOG.md
@@ -4,10 +4,21 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
+### Changed
+
+- **Breaking: responsive variant class names now use a plain hyphen separator.** `.sm\:hide` (CSS) / `sm:hide` (JSX) → `.sm-hide` / `sm-hide` in both. Applies to all four viewport breakpoints (`sm`, `md`, `lg`, `xl`) and the print variant (`print:hide` → `print-hide`). No CSS escaping is needed in stylesheets or `className` strings.
+- **Validator: new base-class-existence check.** Every responsive variant (e.g. `.sm-foo`) must have a matching base class (`.foo`) in the same file. Violations are reported as `responsive variant '.sm-foo' has no base class '.foo'`. This enforces a soundness property that the old escaped-colon scheme provided implicitly.
+- **Validator: new collision guard.** Any selector whose body starts with a breakpoint prefix (`sm-`, `md-`, `lg-`, `xl-`, `print-`) is only valid inside the matching `@media` block. A top-level `.sm-foo` fails with `base class '.sm-foo' collides with breakpoint prefix — rename`.
+- **Validator: reserved prefix names.** `sm`, `md`, `lg`, `xl`, and `print` are reserved as class-body strings. A selector like `.sm:hide` (old colon syntax) is rejected as `selector not in canonical form`.
+- **fpkit class-name parity claim dropped.** Token values, breakpoints, and modern range-query media syntax still mirror fpkit upstream (`@fpkit/acss@6.5.0`); responsive class names now diverge deliberately. See `ATTRIBUTION.md` for the upstream/plugin split.
+
 ### Added
 
+- **`scripts/migrate_classnames.py`** — dry-run migration script that rewrites old colon-based class names to the new hyphen form. Accepts files or directories; `--write` to apply in-place. Covers JSX/TSX, TS/JS (clsx/classnames), HTML (`class=`/`className=` attributes), and CSS/SCSS `@apply` directives. Migration: `sm:` → `sm-`, `md:` → `md-`, `lg:` → `lg-`, `xl:` → `xl-`, `print:` → `print-`. Automated path: `python3 scripts/migrate_classnames.py src/ --write`.
 - **`docs/`** — developer guide tree mirroring `acss-kit/docs/`: `README.md`, `tutorial.md`, `concepts.md`, `commands.md`, `recipes.md`, `troubleshooting.md`, `architecture.md`. `visual-guide.md` deferred.
-- **`tests/run.sh` integration** — Step 8 runs `validate_utilities.py` over `plugins/acss-utilities/assets/`; Step 9 regenerates the bundle from `utilities.tokens.json` and diffs against the committed copy (idempotency check). Both steps no-op gracefully if the plugin tree is missing. Bad-fixture self-tests are still deferred.
+- **`tests/run.sh` integration** — Step 8 runs `validate_utilities.py` over `plugins/acss-utilities/assets/`; Step 9 regenerates the bundle from `utilities.tokens.json` and diffs against the committed copy (idempotency check); Step 10 runs `migrate_classnames.py` fixture round-trip and idempotency tests.
 
 ### Fixed
 
@@ -17,8 +28,7 @@ All notable changes to the `acss-utilities` plugin are documented here. Format f
 - **`detect_utility_target.py`:** only honor `.acss-target.json#utilitiesDir` when `(projectRoot / utilitiesDir)` actually exists; otherwise fall back to `src/styles`.
 - **`utilities.tokens.json`:** drop the dangling `$schema: "./utilities.tokens.schema.json"` pointer — the schema file does not ship in the plugin.
 - **`validate_utilities.py`:** read `bundleSizeBudgetKb` from a co-located `utilities.tokens.json` when `--max-kb` is not passed, so the token field is no longer dead. CLI flag still wins.
-- **`validate_utilities.py`:** distinct context per `@media` condition for the duplicate-selector check, so a class can legitimately appear under two different breakpoints; reject unrecognised single-file targets with a usage error (exit 2) instead of running the validator against an unrelated stylesheet; correct the `seen_selectors` type annotation to `Dict[Tuple[str, str], int]`.
-- **`generate_utilities.py`:** drop unused `os` import.
+- **`validate_utilities.py`:** distinct context per `@media` condition for the duplicate-selector check, so a class can legitimately appear under two different breakpoints; reject unrecognised single-file targets with a usage error (exit 2) instead of running the validator against an unrelated stylesheet.
 
 ## [0.1.0] - 2026-04-28
 

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -11,7 +11,7 @@ This plugin is designed to sit alongside `acss-kit`. `acss-kit` owns components 
 | Plugin | Owns |
 |---|---|
 | [`acss-kit`](../acss-kit) | Components, themes (light/dark/brand), OKLCH role catalogue |
-| `acss-utilities` (this) | Utility classes (`.bg-primary`, `.mt-4`, `.sm:hide`), token-bridge |
+| `acss-utilities` (this) | Utility classes (`.bg-primary`, `.mt-4`, `.sm-hide`), token-bridge |
 
 ## Why utility classes
 
@@ -96,7 +96,7 @@ Mirroring fpkit upstream where present, plus standard atomic-CSS additions (see 
 | `color-bg` | `.bg-primary`, `.bg-success`, `.bg-error`, `.bg-surface`, `.bg-transparent` | no |
 | `color-text` | `.text-primary`, `.text-error`, `.text-muted` | no |
 | `color-border` | `.border-primary`, `.border-error`, `.border-muted` | no |
-| `display` | `.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`, `.print:hide` | yes |
+| `display` | `.hide`, `.show`, `.invisible`, `.sr-only`, `.sr-only-focusable`, `.print-hide` | yes |
 | `spacing` | `.m-4`, `.mt-2`, `.px-6`, `.gap-3` | yes |
 | `flex` | `.flex`, `.flex-col`, `.justify-center`, `.items-center` | yes |
 | `grid` | `.grid`, `.grid-cols-2`, `.grid-cols-12` | yes |
@@ -106,7 +106,13 @@ Mirroring fpkit upstream where present, plus standard atomic-CSS additions (see 
 | `position` | `.relative`, `.absolute`, `.fixed`, `.sticky` | no |
 | `z-index` | `.z-10`, `.z-20`, `.z-50`, `.z-auto` | no |
 
-Responsive variants use the `:` separator escaped to `\:` in CSS — e.g. `.sm:hide` is written as `.sm\:hide` in the stylesheet but used as `<div className="sm:hide">…` in JSX. Breakpoints: `sm: 30rem`, `md: 48rem`, `lg: 62rem`, `xl: 80rem`.
+Responsive variants use a plain hyphen prefix — `.sm-hide`, `.md-p-6`, `.lg-flex-row`. No CSS escaping needed in the stylesheet or JSX `className` strings. Breakpoints: `sm: 30rem`, `md: 48rem`, `lg: 62rem`, `xl: 80rem`.
+
+### Responsive variants
+
+This plugin diverges from fpkit upstream class naming: instead of the escaped-colon form (`.sm\:hide` / `className="sm:hide"`), all responsive variants use a single hyphen separator (`.sm-hide` / `className="sm-hide"`). Token values, breakpoint widths, and media-query range syntax still mirror fpkit.
+
+**Migrating from 0.1.0:** search-and-replace in JSX `className` strings and CSS `@apply` directives — `sm:` → `sm-`, `md:` → `md-`, `lg:` → `lg-`, `xl:` → `xl-`, `print:` → `print-`. Use `scripts/migrate_classnames.py` for an automated dry-run.
 
 ## Token bridge
 

--- a/plugins/acss-utilities/assets/utilities.css
+++ b/plugins/acss-utilities/assets/utilities.css
@@ -264,852 +264,852 @@
 .gap-32 { gap: 8rem; }
 
 @media (width >= 30rem) {
-.sm\:m-0 { margin: 0; }
-.sm\:m-1 { margin: 0.25rem; }
-.sm\:m-2 { margin: 0.5rem; }
-.sm\:m-3 { margin: 0.75rem; }
-.sm\:m-4 { margin: 1rem; }
-.sm\:m-5 { margin: 1.25rem; }
-.sm\:m-6 { margin: 1.5rem; }
-.sm\:m-8 { margin: 2rem; }
-.sm\:m-10 { margin: 2.5rem; }
-.sm\:m-12 { margin: 3rem; }
-.sm\:m-16 { margin: 4rem; }
-.sm\:m-20 { margin: 5rem; }
-.sm\:m-24 { margin: 6rem; }
-.sm\:m-32 { margin: 8rem; }
-.sm\:mt-0 { margin-top: 0; }
-.sm\:mt-1 { margin-top: 0.25rem; }
-.sm\:mt-2 { margin-top: 0.5rem; }
-.sm\:mt-3 { margin-top: 0.75rem; }
-.sm\:mt-4 { margin-top: 1rem; }
-.sm\:mt-5 { margin-top: 1.25rem; }
-.sm\:mt-6 { margin-top: 1.5rem; }
-.sm\:mt-8 { margin-top: 2rem; }
-.sm\:mt-10 { margin-top: 2.5rem; }
-.sm\:mt-12 { margin-top: 3rem; }
-.sm\:mt-16 { margin-top: 4rem; }
-.sm\:mt-20 { margin-top: 5rem; }
-.sm\:mt-24 { margin-top: 6rem; }
-.sm\:mt-32 { margin-top: 8rem; }
-.sm\:mb-0 { margin-bottom: 0; }
-.sm\:mb-1 { margin-bottom: 0.25rem; }
-.sm\:mb-2 { margin-bottom: 0.5rem; }
-.sm\:mb-3 { margin-bottom: 0.75rem; }
-.sm\:mb-4 { margin-bottom: 1rem; }
-.sm\:mb-5 { margin-bottom: 1.25rem; }
-.sm\:mb-6 { margin-bottom: 1.5rem; }
-.sm\:mb-8 { margin-bottom: 2rem; }
-.sm\:mb-10 { margin-bottom: 2.5rem; }
-.sm\:mb-12 { margin-bottom: 3rem; }
-.sm\:mb-16 { margin-bottom: 4rem; }
-.sm\:mb-20 { margin-bottom: 5rem; }
-.sm\:mb-24 { margin-bottom: 6rem; }
-.sm\:mb-32 { margin-bottom: 8rem; }
-.sm\:ml-0 { margin-left: 0; }
-.sm\:ml-1 { margin-left: 0.25rem; }
-.sm\:ml-2 { margin-left: 0.5rem; }
-.sm\:ml-3 { margin-left: 0.75rem; }
-.sm\:ml-4 { margin-left: 1rem; }
-.sm\:ml-5 { margin-left: 1.25rem; }
-.sm\:ml-6 { margin-left: 1.5rem; }
-.sm\:ml-8 { margin-left: 2rem; }
-.sm\:ml-10 { margin-left: 2.5rem; }
-.sm\:ml-12 { margin-left: 3rem; }
-.sm\:ml-16 { margin-left: 4rem; }
-.sm\:ml-20 { margin-left: 5rem; }
-.sm\:ml-24 { margin-left: 6rem; }
-.sm\:ml-32 { margin-left: 8rem; }
-.sm\:mr-0 { margin-right: 0; }
-.sm\:mr-1 { margin-right: 0.25rem; }
-.sm\:mr-2 { margin-right: 0.5rem; }
-.sm\:mr-3 { margin-right: 0.75rem; }
-.sm\:mr-4 { margin-right: 1rem; }
-.sm\:mr-5 { margin-right: 1.25rem; }
-.sm\:mr-6 { margin-right: 1.5rem; }
-.sm\:mr-8 { margin-right: 2rem; }
-.sm\:mr-10 { margin-right: 2.5rem; }
-.sm\:mr-12 { margin-right: 3rem; }
-.sm\:mr-16 { margin-right: 4rem; }
-.sm\:mr-20 { margin-right: 5rem; }
-.sm\:mr-24 { margin-right: 6rem; }
-.sm\:mr-32 { margin-right: 8rem; }
-.sm\:mx-0 { margin-left: 0; margin-right: 0; }
-.sm\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.sm\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.sm\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.sm\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.sm\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.sm\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.sm\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.sm\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.sm\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.sm\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.sm\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.sm\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.sm\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.sm\:my-0 { margin-top: 0; margin-bottom: 0; }
-.sm\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.sm\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.sm\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.sm\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.sm\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.sm\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.sm\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.sm\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.sm\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.sm\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.sm\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.sm\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.sm\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.sm\:p-0 { padding: 0; }
-.sm\:p-1 { padding: 0.25rem; }
-.sm\:p-2 { padding: 0.5rem; }
-.sm\:p-3 { padding: 0.75rem; }
-.sm\:p-4 { padding: 1rem; }
-.sm\:p-5 { padding: 1.25rem; }
-.sm\:p-6 { padding: 1.5rem; }
-.sm\:p-8 { padding: 2rem; }
-.sm\:p-10 { padding: 2.5rem; }
-.sm\:p-12 { padding: 3rem; }
-.sm\:p-16 { padding: 4rem; }
-.sm\:p-20 { padding: 5rem; }
-.sm\:p-24 { padding: 6rem; }
-.sm\:p-32 { padding: 8rem; }
-.sm\:pt-0 { padding-top: 0; }
-.sm\:pt-1 { padding-top: 0.25rem; }
-.sm\:pt-2 { padding-top: 0.5rem; }
-.sm\:pt-3 { padding-top: 0.75rem; }
-.sm\:pt-4 { padding-top: 1rem; }
-.sm\:pt-5 { padding-top: 1.25rem; }
-.sm\:pt-6 { padding-top: 1.5rem; }
-.sm\:pt-8 { padding-top: 2rem; }
-.sm\:pt-10 { padding-top: 2.5rem; }
-.sm\:pt-12 { padding-top: 3rem; }
-.sm\:pt-16 { padding-top: 4rem; }
-.sm\:pt-20 { padding-top: 5rem; }
-.sm\:pt-24 { padding-top: 6rem; }
-.sm\:pt-32 { padding-top: 8rem; }
-.sm\:pb-0 { padding-bottom: 0; }
-.sm\:pb-1 { padding-bottom: 0.25rem; }
-.sm\:pb-2 { padding-bottom: 0.5rem; }
-.sm\:pb-3 { padding-bottom: 0.75rem; }
-.sm\:pb-4 { padding-bottom: 1rem; }
-.sm\:pb-5 { padding-bottom: 1.25rem; }
-.sm\:pb-6 { padding-bottom: 1.5rem; }
-.sm\:pb-8 { padding-bottom: 2rem; }
-.sm\:pb-10 { padding-bottom: 2.5rem; }
-.sm\:pb-12 { padding-bottom: 3rem; }
-.sm\:pb-16 { padding-bottom: 4rem; }
-.sm\:pb-20 { padding-bottom: 5rem; }
-.sm\:pb-24 { padding-bottom: 6rem; }
-.sm\:pb-32 { padding-bottom: 8rem; }
-.sm\:pl-0 { padding-left: 0; }
-.sm\:pl-1 { padding-left: 0.25rem; }
-.sm\:pl-2 { padding-left: 0.5rem; }
-.sm\:pl-3 { padding-left: 0.75rem; }
-.sm\:pl-4 { padding-left: 1rem; }
-.sm\:pl-5 { padding-left: 1.25rem; }
-.sm\:pl-6 { padding-left: 1.5rem; }
-.sm\:pl-8 { padding-left: 2rem; }
-.sm\:pl-10 { padding-left: 2.5rem; }
-.sm\:pl-12 { padding-left: 3rem; }
-.sm\:pl-16 { padding-left: 4rem; }
-.sm\:pl-20 { padding-left: 5rem; }
-.sm\:pl-24 { padding-left: 6rem; }
-.sm\:pl-32 { padding-left: 8rem; }
-.sm\:pr-0 { padding-right: 0; }
-.sm\:pr-1 { padding-right: 0.25rem; }
-.sm\:pr-2 { padding-right: 0.5rem; }
-.sm\:pr-3 { padding-right: 0.75rem; }
-.sm\:pr-4 { padding-right: 1rem; }
-.sm\:pr-5 { padding-right: 1.25rem; }
-.sm\:pr-6 { padding-right: 1.5rem; }
-.sm\:pr-8 { padding-right: 2rem; }
-.sm\:pr-10 { padding-right: 2.5rem; }
-.sm\:pr-12 { padding-right: 3rem; }
-.sm\:pr-16 { padding-right: 4rem; }
-.sm\:pr-20 { padding-right: 5rem; }
-.sm\:pr-24 { padding-right: 6rem; }
-.sm\:pr-32 { padding-right: 8rem; }
-.sm\:px-0 { padding-left: 0; padding-right: 0; }
-.sm\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.sm\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.sm\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.sm\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.sm\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.sm\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.sm\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.sm\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.sm\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.sm\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.sm\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.sm\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.sm\:py-0 { padding-top: 0; padding-bottom: 0; }
-.sm\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.sm\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.sm\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.sm\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.sm\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.sm\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.sm\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.sm\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.sm\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.sm\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.sm\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.sm\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.sm\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.sm\:gap-0 { gap: 0; }
-.sm\:gap-1 { gap: 0.25rem; }
-.sm\:gap-2 { gap: 0.5rem; }
-.sm\:gap-3 { gap: 0.75rem; }
-.sm\:gap-4 { gap: 1rem; }
-.sm\:gap-5 { gap: 1.25rem; }
-.sm\:gap-6 { gap: 1.5rem; }
-.sm\:gap-8 { gap: 2rem; }
-.sm\:gap-10 { gap: 2.5rem; }
-.sm\:gap-12 { gap: 3rem; }
-.sm\:gap-16 { gap: 4rem; }
-.sm\:gap-20 { gap: 5rem; }
-.sm\:gap-24 { gap: 6rem; }
-.sm\:gap-32 { gap: 8rem; }
+.sm-m-0 { margin: 0; }
+.sm-m-1 { margin: 0.25rem; }
+.sm-m-2 { margin: 0.5rem; }
+.sm-m-3 { margin: 0.75rem; }
+.sm-m-4 { margin: 1rem; }
+.sm-m-5 { margin: 1.25rem; }
+.sm-m-6 { margin: 1.5rem; }
+.sm-m-8 { margin: 2rem; }
+.sm-m-10 { margin: 2.5rem; }
+.sm-m-12 { margin: 3rem; }
+.sm-m-16 { margin: 4rem; }
+.sm-m-20 { margin: 5rem; }
+.sm-m-24 { margin: 6rem; }
+.sm-m-32 { margin: 8rem; }
+.sm-mt-0 { margin-top: 0; }
+.sm-mt-1 { margin-top: 0.25rem; }
+.sm-mt-2 { margin-top: 0.5rem; }
+.sm-mt-3 { margin-top: 0.75rem; }
+.sm-mt-4 { margin-top: 1rem; }
+.sm-mt-5 { margin-top: 1.25rem; }
+.sm-mt-6 { margin-top: 1.5rem; }
+.sm-mt-8 { margin-top: 2rem; }
+.sm-mt-10 { margin-top: 2.5rem; }
+.sm-mt-12 { margin-top: 3rem; }
+.sm-mt-16 { margin-top: 4rem; }
+.sm-mt-20 { margin-top: 5rem; }
+.sm-mt-24 { margin-top: 6rem; }
+.sm-mt-32 { margin-top: 8rem; }
+.sm-mb-0 { margin-bottom: 0; }
+.sm-mb-1 { margin-bottom: 0.25rem; }
+.sm-mb-2 { margin-bottom: 0.5rem; }
+.sm-mb-3 { margin-bottom: 0.75rem; }
+.sm-mb-4 { margin-bottom: 1rem; }
+.sm-mb-5 { margin-bottom: 1.25rem; }
+.sm-mb-6 { margin-bottom: 1.5rem; }
+.sm-mb-8 { margin-bottom: 2rem; }
+.sm-mb-10 { margin-bottom: 2.5rem; }
+.sm-mb-12 { margin-bottom: 3rem; }
+.sm-mb-16 { margin-bottom: 4rem; }
+.sm-mb-20 { margin-bottom: 5rem; }
+.sm-mb-24 { margin-bottom: 6rem; }
+.sm-mb-32 { margin-bottom: 8rem; }
+.sm-ml-0 { margin-left: 0; }
+.sm-ml-1 { margin-left: 0.25rem; }
+.sm-ml-2 { margin-left: 0.5rem; }
+.sm-ml-3 { margin-left: 0.75rem; }
+.sm-ml-4 { margin-left: 1rem; }
+.sm-ml-5 { margin-left: 1.25rem; }
+.sm-ml-6 { margin-left: 1.5rem; }
+.sm-ml-8 { margin-left: 2rem; }
+.sm-ml-10 { margin-left: 2.5rem; }
+.sm-ml-12 { margin-left: 3rem; }
+.sm-ml-16 { margin-left: 4rem; }
+.sm-ml-20 { margin-left: 5rem; }
+.sm-ml-24 { margin-left: 6rem; }
+.sm-ml-32 { margin-left: 8rem; }
+.sm-mr-0 { margin-right: 0; }
+.sm-mr-1 { margin-right: 0.25rem; }
+.sm-mr-2 { margin-right: 0.5rem; }
+.sm-mr-3 { margin-right: 0.75rem; }
+.sm-mr-4 { margin-right: 1rem; }
+.sm-mr-5 { margin-right: 1.25rem; }
+.sm-mr-6 { margin-right: 1.5rem; }
+.sm-mr-8 { margin-right: 2rem; }
+.sm-mr-10 { margin-right: 2.5rem; }
+.sm-mr-12 { margin-right: 3rem; }
+.sm-mr-16 { margin-right: 4rem; }
+.sm-mr-20 { margin-right: 5rem; }
+.sm-mr-24 { margin-right: 6rem; }
+.sm-mr-32 { margin-right: 8rem; }
+.sm-mx-0 { margin-left: 0; margin-right: 0; }
+.sm-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.sm-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.sm-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.sm-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.sm-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.sm-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.sm-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.sm-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.sm-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.sm-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.sm-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.sm-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.sm-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.sm-my-0 { margin-top: 0; margin-bottom: 0; }
+.sm-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.sm-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.sm-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.sm-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.sm-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.sm-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.sm-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.sm-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.sm-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.sm-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.sm-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.sm-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.sm-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.sm-p-0 { padding: 0; }
+.sm-p-1 { padding: 0.25rem; }
+.sm-p-2 { padding: 0.5rem; }
+.sm-p-3 { padding: 0.75rem; }
+.sm-p-4 { padding: 1rem; }
+.sm-p-5 { padding: 1.25rem; }
+.sm-p-6 { padding: 1.5rem; }
+.sm-p-8 { padding: 2rem; }
+.sm-p-10 { padding: 2.5rem; }
+.sm-p-12 { padding: 3rem; }
+.sm-p-16 { padding: 4rem; }
+.sm-p-20 { padding: 5rem; }
+.sm-p-24 { padding: 6rem; }
+.sm-p-32 { padding: 8rem; }
+.sm-pt-0 { padding-top: 0; }
+.sm-pt-1 { padding-top: 0.25rem; }
+.sm-pt-2 { padding-top: 0.5rem; }
+.sm-pt-3 { padding-top: 0.75rem; }
+.sm-pt-4 { padding-top: 1rem; }
+.sm-pt-5 { padding-top: 1.25rem; }
+.sm-pt-6 { padding-top: 1.5rem; }
+.sm-pt-8 { padding-top: 2rem; }
+.sm-pt-10 { padding-top: 2.5rem; }
+.sm-pt-12 { padding-top: 3rem; }
+.sm-pt-16 { padding-top: 4rem; }
+.sm-pt-20 { padding-top: 5rem; }
+.sm-pt-24 { padding-top: 6rem; }
+.sm-pt-32 { padding-top: 8rem; }
+.sm-pb-0 { padding-bottom: 0; }
+.sm-pb-1 { padding-bottom: 0.25rem; }
+.sm-pb-2 { padding-bottom: 0.5rem; }
+.sm-pb-3 { padding-bottom: 0.75rem; }
+.sm-pb-4 { padding-bottom: 1rem; }
+.sm-pb-5 { padding-bottom: 1.25rem; }
+.sm-pb-6 { padding-bottom: 1.5rem; }
+.sm-pb-8 { padding-bottom: 2rem; }
+.sm-pb-10 { padding-bottom: 2.5rem; }
+.sm-pb-12 { padding-bottom: 3rem; }
+.sm-pb-16 { padding-bottom: 4rem; }
+.sm-pb-20 { padding-bottom: 5rem; }
+.sm-pb-24 { padding-bottom: 6rem; }
+.sm-pb-32 { padding-bottom: 8rem; }
+.sm-pl-0 { padding-left: 0; }
+.sm-pl-1 { padding-left: 0.25rem; }
+.sm-pl-2 { padding-left: 0.5rem; }
+.sm-pl-3 { padding-left: 0.75rem; }
+.sm-pl-4 { padding-left: 1rem; }
+.sm-pl-5 { padding-left: 1.25rem; }
+.sm-pl-6 { padding-left: 1.5rem; }
+.sm-pl-8 { padding-left: 2rem; }
+.sm-pl-10 { padding-left: 2.5rem; }
+.sm-pl-12 { padding-left: 3rem; }
+.sm-pl-16 { padding-left: 4rem; }
+.sm-pl-20 { padding-left: 5rem; }
+.sm-pl-24 { padding-left: 6rem; }
+.sm-pl-32 { padding-left: 8rem; }
+.sm-pr-0 { padding-right: 0; }
+.sm-pr-1 { padding-right: 0.25rem; }
+.sm-pr-2 { padding-right: 0.5rem; }
+.sm-pr-3 { padding-right: 0.75rem; }
+.sm-pr-4 { padding-right: 1rem; }
+.sm-pr-5 { padding-right: 1.25rem; }
+.sm-pr-6 { padding-right: 1.5rem; }
+.sm-pr-8 { padding-right: 2rem; }
+.sm-pr-10 { padding-right: 2.5rem; }
+.sm-pr-12 { padding-right: 3rem; }
+.sm-pr-16 { padding-right: 4rem; }
+.sm-pr-20 { padding-right: 5rem; }
+.sm-pr-24 { padding-right: 6rem; }
+.sm-pr-32 { padding-right: 8rem; }
+.sm-px-0 { padding-left: 0; padding-right: 0; }
+.sm-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.sm-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.sm-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.sm-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.sm-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.sm-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.sm-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.sm-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.sm-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.sm-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.sm-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.sm-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.sm-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.sm-py-0 { padding-top: 0; padding-bottom: 0; }
+.sm-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.sm-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.sm-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.sm-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.sm-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.sm-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.sm-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.sm-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.sm-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.sm-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.sm-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.sm-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.sm-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.sm-gap-0 { gap: 0; }
+.sm-gap-1 { gap: 0.25rem; }
+.sm-gap-2 { gap: 0.5rem; }
+.sm-gap-3 { gap: 0.75rem; }
+.sm-gap-4 { gap: 1rem; }
+.sm-gap-5 { gap: 1.25rem; }
+.sm-gap-6 { gap: 1.5rem; }
+.sm-gap-8 { gap: 2rem; }
+.sm-gap-10 { gap: 2.5rem; }
+.sm-gap-12 { gap: 3rem; }
+.sm-gap-16 { gap: 4rem; }
+.sm-gap-20 { gap: 5rem; }
+.sm-gap-24 { gap: 6rem; }
+.sm-gap-32 { gap: 8rem; }
 }
 @media (width >= 48rem) {
-.md\:m-0 { margin: 0; }
-.md\:m-1 { margin: 0.25rem; }
-.md\:m-2 { margin: 0.5rem; }
-.md\:m-3 { margin: 0.75rem; }
-.md\:m-4 { margin: 1rem; }
-.md\:m-5 { margin: 1.25rem; }
-.md\:m-6 { margin: 1.5rem; }
-.md\:m-8 { margin: 2rem; }
-.md\:m-10 { margin: 2.5rem; }
-.md\:m-12 { margin: 3rem; }
-.md\:m-16 { margin: 4rem; }
-.md\:m-20 { margin: 5rem; }
-.md\:m-24 { margin: 6rem; }
-.md\:m-32 { margin: 8rem; }
-.md\:mt-0 { margin-top: 0; }
-.md\:mt-1 { margin-top: 0.25rem; }
-.md\:mt-2 { margin-top: 0.5rem; }
-.md\:mt-3 { margin-top: 0.75rem; }
-.md\:mt-4 { margin-top: 1rem; }
-.md\:mt-5 { margin-top: 1.25rem; }
-.md\:mt-6 { margin-top: 1.5rem; }
-.md\:mt-8 { margin-top: 2rem; }
-.md\:mt-10 { margin-top: 2.5rem; }
-.md\:mt-12 { margin-top: 3rem; }
-.md\:mt-16 { margin-top: 4rem; }
-.md\:mt-20 { margin-top: 5rem; }
-.md\:mt-24 { margin-top: 6rem; }
-.md\:mt-32 { margin-top: 8rem; }
-.md\:mb-0 { margin-bottom: 0; }
-.md\:mb-1 { margin-bottom: 0.25rem; }
-.md\:mb-2 { margin-bottom: 0.5rem; }
-.md\:mb-3 { margin-bottom: 0.75rem; }
-.md\:mb-4 { margin-bottom: 1rem; }
-.md\:mb-5 { margin-bottom: 1.25rem; }
-.md\:mb-6 { margin-bottom: 1.5rem; }
-.md\:mb-8 { margin-bottom: 2rem; }
-.md\:mb-10 { margin-bottom: 2.5rem; }
-.md\:mb-12 { margin-bottom: 3rem; }
-.md\:mb-16 { margin-bottom: 4rem; }
-.md\:mb-20 { margin-bottom: 5rem; }
-.md\:mb-24 { margin-bottom: 6rem; }
-.md\:mb-32 { margin-bottom: 8rem; }
-.md\:ml-0 { margin-left: 0; }
-.md\:ml-1 { margin-left: 0.25rem; }
-.md\:ml-2 { margin-left: 0.5rem; }
-.md\:ml-3 { margin-left: 0.75rem; }
-.md\:ml-4 { margin-left: 1rem; }
-.md\:ml-5 { margin-left: 1.25rem; }
-.md\:ml-6 { margin-left: 1.5rem; }
-.md\:ml-8 { margin-left: 2rem; }
-.md\:ml-10 { margin-left: 2.5rem; }
-.md\:ml-12 { margin-left: 3rem; }
-.md\:ml-16 { margin-left: 4rem; }
-.md\:ml-20 { margin-left: 5rem; }
-.md\:ml-24 { margin-left: 6rem; }
-.md\:ml-32 { margin-left: 8rem; }
-.md\:mr-0 { margin-right: 0; }
-.md\:mr-1 { margin-right: 0.25rem; }
-.md\:mr-2 { margin-right: 0.5rem; }
-.md\:mr-3 { margin-right: 0.75rem; }
-.md\:mr-4 { margin-right: 1rem; }
-.md\:mr-5 { margin-right: 1.25rem; }
-.md\:mr-6 { margin-right: 1.5rem; }
-.md\:mr-8 { margin-right: 2rem; }
-.md\:mr-10 { margin-right: 2.5rem; }
-.md\:mr-12 { margin-right: 3rem; }
-.md\:mr-16 { margin-right: 4rem; }
-.md\:mr-20 { margin-right: 5rem; }
-.md\:mr-24 { margin-right: 6rem; }
-.md\:mr-32 { margin-right: 8rem; }
-.md\:mx-0 { margin-left: 0; margin-right: 0; }
-.md\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.md\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.md\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.md\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.md\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.md\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.md\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.md\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.md\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.md\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.md\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.md\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.md\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.md\:my-0 { margin-top: 0; margin-bottom: 0; }
-.md\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.md\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.md\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.md\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.md\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.md\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.md\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.md\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.md\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.md\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.md\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.md\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.md\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.md\:p-0 { padding: 0; }
-.md\:p-1 { padding: 0.25rem; }
-.md\:p-2 { padding: 0.5rem; }
-.md\:p-3 { padding: 0.75rem; }
-.md\:p-4 { padding: 1rem; }
-.md\:p-5 { padding: 1.25rem; }
-.md\:p-6 { padding: 1.5rem; }
-.md\:p-8 { padding: 2rem; }
-.md\:p-10 { padding: 2.5rem; }
-.md\:p-12 { padding: 3rem; }
-.md\:p-16 { padding: 4rem; }
-.md\:p-20 { padding: 5rem; }
-.md\:p-24 { padding: 6rem; }
-.md\:p-32 { padding: 8rem; }
-.md\:pt-0 { padding-top: 0; }
-.md\:pt-1 { padding-top: 0.25rem; }
-.md\:pt-2 { padding-top: 0.5rem; }
-.md\:pt-3 { padding-top: 0.75rem; }
-.md\:pt-4 { padding-top: 1rem; }
-.md\:pt-5 { padding-top: 1.25rem; }
-.md\:pt-6 { padding-top: 1.5rem; }
-.md\:pt-8 { padding-top: 2rem; }
-.md\:pt-10 { padding-top: 2.5rem; }
-.md\:pt-12 { padding-top: 3rem; }
-.md\:pt-16 { padding-top: 4rem; }
-.md\:pt-20 { padding-top: 5rem; }
-.md\:pt-24 { padding-top: 6rem; }
-.md\:pt-32 { padding-top: 8rem; }
-.md\:pb-0 { padding-bottom: 0; }
-.md\:pb-1 { padding-bottom: 0.25rem; }
-.md\:pb-2 { padding-bottom: 0.5rem; }
-.md\:pb-3 { padding-bottom: 0.75rem; }
-.md\:pb-4 { padding-bottom: 1rem; }
-.md\:pb-5 { padding-bottom: 1.25rem; }
-.md\:pb-6 { padding-bottom: 1.5rem; }
-.md\:pb-8 { padding-bottom: 2rem; }
-.md\:pb-10 { padding-bottom: 2.5rem; }
-.md\:pb-12 { padding-bottom: 3rem; }
-.md\:pb-16 { padding-bottom: 4rem; }
-.md\:pb-20 { padding-bottom: 5rem; }
-.md\:pb-24 { padding-bottom: 6rem; }
-.md\:pb-32 { padding-bottom: 8rem; }
-.md\:pl-0 { padding-left: 0; }
-.md\:pl-1 { padding-left: 0.25rem; }
-.md\:pl-2 { padding-left: 0.5rem; }
-.md\:pl-3 { padding-left: 0.75rem; }
-.md\:pl-4 { padding-left: 1rem; }
-.md\:pl-5 { padding-left: 1.25rem; }
-.md\:pl-6 { padding-left: 1.5rem; }
-.md\:pl-8 { padding-left: 2rem; }
-.md\:pl-10 { padding-left: 2.5rem; }
-.md\:pl-12 { padding-left: 3rem; }
-.md\:pl-16 { padding-left: 4rem; }
-.md\:pl-20 { padding-left: 5rem; }
-.md\:pl-24 { padding-left: 6rem; }
-.md\:pl-32 { padding-left: 8rem; }
-.md\:pr-0 { padding-right: 0; }
-.md\:pr-1 { padding-right: 0.25rem; }
-.md\:pr-2 { padding-right: 0.5rem; }
-.md\:pr-3 { padding-right: 0.75rem; }
-.md\:pr-4 { padding-right: 1rem; }
-.md\:pr-5 { padding-right: 1.25rem; }
-.md\:pr-6 { padding-right: 1.5rem; }
-.md\:pr-8 { padding-right: 2rem; }
-.md\:pr-10 { padding-right: 2.5rem; }
-.md\:pr-12 { padding-right: 3rem; }
-.md\:pr-16 { padding-right: 4rem; }
-.md\:pr-20 { padding-right: 5rem; }
-.md\:pr-24 { padding-right: 6rem; }
-.md\:pr-32 { padding-right: 8rem; }
-.md\:px-0 { padding-left: 0; padding-right: 0; }
-.md\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.md\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.md\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.md\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.md\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.md\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.md\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.md\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.md\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.md\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.md\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.md\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.md\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.md\:py-0 { padding-top: 0; padding-bottom: 0; }
-.md\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.md\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.md\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.md\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.md\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.md\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.md\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.md\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.md\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.md\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.md\:gap-0 { gap: 0; }
-.md\:gap-1 { gap: 0.25rem; }
-.md\:gap-2 { gap: 0.5rem; }
-.md\:gap-3 { gap: 0.75rem; }
-.md\:gap-4 { gap: 1rem; }
-.md\:gap-5 { gap: 1.25rem; }
-.md\:gap-6 { gap: 1.5rem; }
-.md\:gap-8 { gap: 2rem; }
-.md\:gap-10 { gap: 2.5rem; }
-.md\:gap-12 { gap: 3rem; }
-.md\:gap-16 { gap: 4rem; }
-.md\:gap-20 { gap: 5rem; }
-.md\:gap-24 { gap: 6rem; }
-.md\:gap-32 { gap: 8rem; }
+.md-m-0 { margin: 0; }
+.md-m-1 { margin: 0.25rem; }
+.md-m-2 { margin: 0.5rem; }
+.md-m-3 { margin: 0.75rem; }
+.md-m-4 { margin: 1rem; }
+.md-m-5 { margin: 1.25rem; }
+.md-m-6 { margin: 1.5rem; }
+.md-m-8 { margin: 2rem; }
+.md-m-10 { margin: 2.5rem; }
+.md-m-12 { margin: 3rem; }
+.md-m-16 { margin: 4rem; }
+.md-m-20 { margin: 5rem; }
+.md-m-24 { margin: 6rem; }
+.md-m-32 { margin: 8rem; }
+.md-mt-0 { margin-top: 0; }
+.md-mt-1 { margin-top: 0.25rem; }
+.md-mt-2 { margin-top: 0.5rem; }
+.md-mt-3 { margin-top: 0.75rem; }
+.md-mt-4 { margin-top: 1rem; }
+.md-mt-5 { margin-top: 1.25rem; }
+.md-mt-6 { margin-top: 1.5rem; }
+.md-mt-8 { margin-top: 2rem; }
+.md-mt-10 { margin-top: 2.5rem; }
+.md-mt-12 { margin-top: 3rem; }
+.md-mt-16 { margin-top: 4rem; }
+.md-mt-20 { margin-top: 5rem; }
+.md-mt-24 { margin-top: 6rem; }
+.md-mt-32 { margin-top: 8rem; }
+.md-mb-0 { margin-bottom: 0; }
+.md-mb-1 { margin-bottom: 0.25rem; }
+.md-mb-2 { margin-bottom: 0.5rem; }
+.md-mb-3 { margin-bottom: 0.75rem; }
+.md-mb-4 { margin-bottom: 1rem; }
+.md-mb-5 { margin-bottom: 1.25rem; }
+.md-mb-6 { margin-bottom: 1.5rem; }
+.md-mb-8 { margin-bottom: 2rem; }
+.md-mb-10 { margin-bottom: 2.5rem; }
+.md-mb-12 { margin-bottom: 3rem; }
+.md-mb-16 { margin-bottom: 4rem; }
+.md-mb-20 { margin-bottom: 5rem; }
+.md-mb-24 { margin-bottom: 6rem; }
+.md-mb-32 { margin-bottom: 8rem; }
+.md-ml-0 { margin-left: 0; }
+.md-ml-1 { margin-left: 0.25rem; }
+.md-ml-2 { margin-left: 0.5rem; }
+.md-ml-3 { margin-left: 0.75rem; }
+.md-ml-4 { margin-left: 1rem; }
+.md-ml-5 { margin-left: 1.25rem; }
+.md-ml-6 { margin-left: 1.5rem; }
+.md-ml-8 { margin-left: 2rem; }
+.md-ml-10 { margin-left: 2.5rem; }
+.md-ml-12 { margin-left: 3rem; }
+.md-ml-16 { margin-left: 4rem; }
+.md-ml-20 { margin-left: 5rem; }
+.md-ml-24 { margin-left: 6rem; }
+.md-ml-32 { margin-left: 8rem; }
+.md-mr-0 { margin-right: 0; }
+.md-mr-1 { margin-right: 0.25rem; }
+.md-mr-2 { margin-right: 0.5rem; }
+.md-mr-3 { margin-right: 0.75rem; }
+.md-mr-4 { margin-right: 1rem; }
+.md-mr-5 { margin-right: 1.25rem; }
+.md-mr-6 { margin-right: 1.5rem; }
+.md-mr-8 { margin-right: 2rem; }
+.md-mr-10 { margin-right: 2.5rem; }
+.md-mr-12 { margin-right: 3rem; }
+.md-mr-16 { margin-right: 4rem; }
+.md-mr-20 { margin-right: 5rem; }
+.md-mr-24 { margin-right: 6rem; }
+.md-mr-32 { margin-right: 8rem; }
+.md-mx-0 { margin-left: 0; margin-right: 0; }
+.md-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.md-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.md-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.md-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.md-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.md-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.md-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.md-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.md-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.md-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.md-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.md-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.md-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.md-my-0 { margin-top: 0; margin-bottom: 0; }
+.md-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.md-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.md-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.md-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.md-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.md-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.md-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.md-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.md-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.md-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.md-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.md-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.md-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.md-p-0 { padding: 0; }
+.md-p-1 { padding: 0.25rem; }
+.md-p-2 { padding: 0.5rem; }
+.md-p-3 { padding: 0.75rem; }
+.md-p-4 { padding: 1rem; }
+.md-p-5 { padding: 1.25rem; }
+.md-p-6 { padding: 1.5rem; }
+.md-p-8 { padding: 2rem; }
+.md-p-10 { padding: 2.5rem; }
+.md-p-12 { padding: 3rem; }
+.md-p-16 { padding: 4rem; }
+.md-p-20 { padding: 5rem; }
+.md-p-24 { padding: 6rem; }
+.md-p-32 { padding: 8rem; }
+.md-pt-0 { padding-top: 0; }
+.md-pt-1 { padding-top: 0.25rem; }
+.md-pt-2 { padding-top: 0.5rem; }
+.md-pt-3 { padding-top: 0.75rem; }
+.md-pt-4 { padding-top: 1rem; }
+.md-pt-5 { padding-top: 1.25rem; }
+.md-pt-6 { padding-top: 1.5rem; }
+.md-pt-8 { padding-top: 2rem; }
+.md-pt-10 { padding-top: 2.5rem; }
+.md-pt-12 { padding-top: 3rem; }
+.md-pt-16 { padding-top: 4rem; }
+.md-pt-20 { padding-top: 5rem; }
+.md-pt-24 { padding-top: 6rem; }
+.md-pt-32 { padding-top: 8rem; }
+.md-pb-0 { padding-bottom: 0; }
+.md-pb-1 { padding-bottom: 0.25rem; }
+.md-pb-2 { padding-bottom: 0.5rem; }
+.md-pb-3 { padding-bottom: 0.75rem; }
+.md-pb-4 { padding-bottom: 1rem; }
+.md-pb-5 { padding-bottom: 1.25rem; }
+.md-pb-6 { padding-bottom: 1.5rem; }
+.md-pb-8 { padding-bottom: 2rem; }
+.md-pb-10 { padding-bottom: 2.5rem; }
+.md-pb-12 { padding-bottom: 3rem; }
+.md-pb-16 { padding-bottom: 4rem; }
+.md-pb-20 { padding-bottom: 5rem; }
+.md-pb-24 { padding-bottom: 6rem; }
+.md-pb-32 { padding-bottom: 8rem; }
+.md-pl-0 { padding-left: 0; }
+.md-pl-1 { padding-left: 0.25rem; }
+.md-pl-2 { padding-left: 0.5rem; }
+.md-pl-3 { padding-left: 0.75rem; }
+.md-pl-4 { padding-left: 1rem; }
+.md-pl-5 { padding-left: 1.25rem; }
+.md-pl-6 { padding-left: 1.5rem; }
+.md-pl-8 { padding-left: 2rem; }
+.md-pl-10 { padding-left: 2.5rem; }
+.md-pl-12 { padding-left: 3rem; }
+.md-pl-16 { padding-left: 4rem; }
+.md-pl-20 { padding-left: 5rem; }
+.md-pl-24 { padding-left: 6rem; }
+.md-pl-32 { padding-left: 8rem; }
+.md-pr-0 { padding-right: 0; }
+.md-pr-1 { padding-right: 0.25rem; }
+.md-pr-2 { padding-right: 0.5rem; }
+.md-pr-3 { padding-right: 0.75rem; }
+.md-pr-4 { padding-right: 1rem; }
+.md-pr-5 { padding-right: 1.25rem; }
+.md-pr-6 { padding-right: 1.5rem; }
+.md-pr-8 { padding-right: 2rem; }
+.md-pr-10 { padding-right: 2.5rem; }
+.md-pr-12 { padding-right: 3rem; }
+.md-pr-16 { padding-right: 4rem; }
+.md-pr-20 { padding-right: 5rem; }
+.md-pr-24 { padding-right: 6rem; }
+.md-pr-32 { padding-right: 8rem; }
+.md-px-0 { padding-left: 0; padding-right: 0; }
+.md-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.md-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.md-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.md-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.md-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.md-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.md-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.md-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.md-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.md-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.md-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.md-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.md-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.md-py-0 { padding-top: 0; padding-bottom: 0; }
+.md-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.md-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.md-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.md-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.md-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.md-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.md-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.md-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.md-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.md-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.md-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.md-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.md-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.md-gap-0 { gap: 0; }
+.md-gap-1 { gap: 0.25rem; }
+.md-gap-2 { gap: 0.5rem; }
+.md-gap-3 { gap: 0.75rem; }
+.md-gap-4 { gap: 1rem; }
+.md-gap-5 { gap: 1.25rem; }
+.md-gap-6 { gap: 1.5rem; }
+.md-gap-8 { gap: 2rem; }
+.md-gap-10 { gap: 2.5rem; }
+.md-gap-12 { gap: 3rem; }
+.md-gap-16 { gap: 4rem; }
+.md-gap-20 { gap: 5rem; }
+.md-gap-24 { gap: 6rem; }
+.md-gap-32 { gap: 8rem; }
 }
 @media (width >= 62rem) {
-.lg\:m-0 { margin: 0; }
-.lg\:m-1 { margin: 0.25rem; }
-.lg\:m-2 { margin: 0.5rem; }
-.lg\:m-3 { margin: 0.75rem; }
-.lg\:m-4 { margin: 1rem; }
-.lg\:m-5 { margin: 1.25rem; }
-.lg\:m-6 { margin: 1.5rem; }
-.lg\:m-8 { margin: 2rem; }
-.lg\:m-10 { margin: 2.5rem; }
-.lg\:m-12 { margin: 3rem; }
-.lg\:m-16 { margin: 4rem; }
-.lg\:m-20 { margin: 5rem; }
-.lg\:m-24 { margin: 6rem; }
-.lg\:m-32 { margin: 8rem; }
-.lg\:mt-0 { margin-top: 0; }
-.lg\:mt-1 { margin-top: 0.25rem; }
-.lg\:mt-2 { margin-top: 0.5rem; }
-.lg\:mt-3 { margin-top: 0.75rem; }
-.lg\:mt-4 { margin-top: 1rem; }
-.lg\:mt-5 { margin-top: 1.25rem; }
-.lg\:mt-6 { margin-top: 1.5rem; }
-.lg\:mt-8 { margin-top: 2rem; }
-.lg\:mt-10 { margin-top: 2.5rem; }
-.lg\:mt-12 { margin-top: 3rem; }
-.lg\:mt-16 { margin-top: 4rem; }
-.lg\:mt-20 { margin-top: 5rem; }
-.lg\:mt-24 { margin-top: 6rem; }
-.lg\:mt-32 { margin-top: 8rem; }
-.lg\:mb-0 { margin-bottom: 0; }
-.lg\:mb-1 { margin-bottom: 0.25rem; }
-.lg\:mb-2 { margin-bottom: 0.5rem; }
-.lg\:mb-3 { margin-bottom: 0.75rem; }
-.lg\:mb-4 { margin-bottom: 1rem; }
-.lg\:mb-5 { margin-bottom: 1.25rem; }
-.lg\:mb-6 { margin-bottom: 1.5rem; }
-.lg\:mb-8 { margin-bottom: 2rem; }
-.lg\:mb-10 { margin-bottom: 2.5rem; }
-.lg\:mb-12 { margin-bottom: 3rem; }
-.lg\:mb-16 { margin-bottom: 4rem; }
-.lg\:mb-20 { margin-bottom: 5rem; }
-.lg\:mb-24 { margin-bottom: 6rem; }
-.lg\:mb-32 { margin-bottom: 8rem; }
-.lg\:ml-0 { margin-left: 0; }
-.lg\:ml-1 { margin-left: 0.25rem; }
-.lg\:ml-2 { margin-left: 0.5rem; }
-.lg\:ml-3 { margin-left: 0.75rem; }
-.lg\:ml-4 { margin-left: 1rem; }
-.lg\:ml-5 { margin-left: 1.25rem; }
-.lg\:ml-6 { margin-left: 1.5rem; }
-.lg\:ml-8 { margin-left: 2rem; }
-.lg\:ml-10 { margin-left: 2.5rem; }
-.lg\:ml-12 { margin-left: 3rem; }
-.lg\:ml-16 { margin-left: 4rem; }
-.lg\:ml-20 { margin-left: 5rem; }
-.lg\:ml-24 { margin-left: 6rem; }
-.lg\:ml-32 { margin-left: 8rem; }
-.lg\:mr-0 { margin-right: 0; }
-.lg\:mr-1 { margin-right: 0.25rem; }
-.lg\:mr-2 { margin-right: 0.5rem; }
-.lg\:mr-3 { margin-right: 0.75rem; }
-.lg\:mr-4 { margin-right: 1rem; }
-.lg\:mr-5 { margin-right: 1.25rem; }
-.lg\:mr-6 { margin-right: 1.5rem; }
-.lg\:mr-8 { margin-right: 2rem; }
-.lg\:mr-10 { margin-right: 2.5rem; }
-.lg\:mr-12 { margin-right: 3rem; }
-.lg\:mr-16 { margin-right: 4rem; }
-.lg\:mr-20 { margin-right: 5rem; }
-.lg\:mr-24 { margin-right: 6rem; }
-.lg\:mr-32 { margin-right: 8rem; }
-.lg\:mx-0 { margin-left: 0; margin-right: 0; }
-.lg\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.lg\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.lg\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.lg\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.lg\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.lg\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.lg\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.lg\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.lg\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.lg\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.lg\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.lg\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.lg\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.lg\:my-0 { margin-top: 0; margin-bottom: 0; }
-.lg\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.lg\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.lg\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.lg\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.lg\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.lg\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.lg\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.lg\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.lg\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.lg\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.lg\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.lg\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.lg\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.lg\:p-0 { padding: 0; }
-.lg\:p-1 { padding: 0.25rem; }
-.lg\:p-2 { padding: 0.5rem; }
-.lg\:p-3 { padding: 0.75rem; }
-.lg\:p-4 { padding: 1rem; }
-.lg\:p-5 { padding: 1.25rem; }
-.lg\:p-6 { padding: 1.5rem; }
-.lg\:p-8 { padding: 2rem; }
-.lg\:p-10 { padding: 2.5rem; }
-.lg\:p-12 { padding: 3rem; }
-.lg\:p-16 { padding: 4rem; }
-.lg\:p-20 { padding: 5rem; }
-.lg\:p-24 { padding: 6rem; }
-.lg\:p-32 { padding: 8rem; }
-.lg\:pt-0 { padding-top: 0; }
-.lg\:pt-1 { padding-top: 0.25rem; }
-.lg\:pt-2 { padding-top: 0.5rem; }
-.lg\:pt-3 { padding-top: 0.75rem; }
-.lg\:pt-4 { padding-top: 1rem; }
-.lg\:pt-5 { padding-top: 1.25rem; }
-.lg\:pt-6 { padding-top: 1.5rem; }
-.lg\:pt-8 { padding-top: 2rem; }
-.lg\:pt-10 { padding-top: 2.5rem; }
-.lg\:pt-12 { padding-top: 3rem; }
-.lg\:pt-16 { padding-top: 4rem; }
-.lg\:pt-20 { padding-top: 5rem; }
-.lg\:pt-24 { padding-top: 6rem; }
-.lg\:pt-32 { padding-top: 8rem; }
-.lg\:pb-0 { padding-bottom: 0; }
-.lg\:pb-1 { padding-bottom: 0.25rem; }
-.lg\:pb-2 { padding-bottom: 0.5rem; }
-.lg\:pb-3 { padding-bottom: 0.75rem; }
-.lg\:pb-4 { padding-bottom: 1rem; }
-.lg\:pb-5 { padding-bottom: 1.25rem; }
-.lg\:pb-6 { padding-bottom: 1.5rem; }
-.lg\:pb-8 { padding-bottom: 2rem; }
-.lg\:pb-10 { padding-bottom: 2.5rem; }
-.lg\:pb-12 { padding-bottom: 3rem; }
-.lg\:pb-16 { padding-bottom: 4rem; }
-.lg\:pb-20 { padding-bottom: 5rem; }
-.lg\:pb-24 { padding-bottom: 6rem; }
-.lg\:pb-32 { padding-bottom: 8rem; }
-.lg\:pl-0 { padding-left: 0; }
-.lg\:pl-1 { padding-left: 0.25rem; }
-.lg\:pl-2 { padding-left: 0.5rem; }
-.lg\:pl-3 { padding-left: 0.75rem; }
-.lg\:pl-4 { padding-left: 1rem; }
-.lg\:pl-5 { padding-left: 1.25rem; }
-.lg\:pl-6 { padding-left: 1.5rem; }
-.lg\:pl-8 { padding-left: 2rem; }
-.lg\:pl-10 { padding-left: 2.5rem; }
-.lg\:pl-12 { padding-left: 3rem; }
-.lg\:pl-16 { padding-left: 4rem; }
-.lg\:pl-20 { padding-left: 5rem; }
-.lg\:pl-24 { padding-left: 6rem; }
-.lg\:pl-32 { padding-left: 8rem; }
-.lg\:pr-0 { padding-right: 0; }
-.lg\:pr-1 { padding-right: 0.25rem; }
-.lg\:pr-2 { padding-right: 0.5rem; }
-.lg\:pr-3 { padding-right: 0.75rem; }
-.lg\:pr-4 { padding-right: 1rem; }
-.lg\:pr-5 { padding-right: 1.25rem; }
-.lg\:pr-6 { padding-right: 1.5rem; }
-.lg\:pr-8 { padding-right: 2rem; }
-.lg\:pr-10 { padding-right: 2.5rem; }
-.lg\:pr-12 { padding-right: 3rem; }
-.lg\:pr-16 { padding-right: 4rem; }
-.lg\:pr-20 { padding-right: 5rem; }
-.lg\:pr-24 { padding-right: 6rem; }
-.lg\:pr-32 { padding-right: 8rem; }
-.lg\:px-0 { padding-left: 0; padding-right: 0; }
-.lg\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.lg\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.lg\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.lg\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.lg\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.lg\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.lg\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.lg\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.lg\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.lg\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.lg\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.lg\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.lg\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.lg\:py-0 { padding-top: 0; padding-bottom: 0; }
-.lg\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.lg\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.lg\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.lg\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.lg\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.lg\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.lg\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.lg\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.lg\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.lg\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.lg\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.lg\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.lg\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.lg\:gap-0 { gap: 0; }
-.lg\:gap-1 { gap: 0.25rem; }
-.lg\:gap-2 { gap: 0.5rem; }
-.lg\:gap-3 { gap: 0.75rem; }
-.lg\:gap-4 { gap: 1rem; }
-.lg\:gap-5 { gap: 1.25rem; }
-.lg\:gap-6 { gap: 1.5rem; }
-.lg\:gap-8 { gap: 2rem; }
-.lg\:gap-10 { gap: 2.5rem; }
-.lg\:gap-12 { gap: 3rem; }
-.lg\:gap-16 { gap: 4rem; }
-.lg\:gap-20 { gap: 5rem; }
-.lg\:gap-24 { gap: 6rem; }
-.lg\:gap-32 { gap: 8rem; }
+.lg-m-0 { margin: 0; }
+.lg-m-1 { margin: 0.25rem; }
+.lg-m-2 { margin: 0.5rem; }
+.lg-m-3 { margin: 0.75rem; }
+.lg-m-4 { margin: 1rem; }
+.lg-m-5 { margin: 1.25rem; }
+.lg-m-6 { margin: 1.5rem; }
+.lg-m-8 { margin: 2rem; }
+.lg-m-10 { margin: 2.5rem; }
+.lg-m-12 { margin: 3rem; }
+.lg-m-16 { margin: 4rem; }
+.lg-m-20 { margin: 5rem; }
+.lg-m-24 { margin: 6rem; }
+.lg-m-32 { margin: 8rem; }
+.lg-mt-0 { margin-top: 0; }
+.lg-mt-1 { margin-top: 0.25rem; }
+.lg-mt-2 { margin-top: 0.5rem; }
+.lg-mt-3 { margin-top: 0.75rem; }
+.lg-mt-4 { margin-top: 1rem; }
+.lg-mt-5 { margin-top: 1.25rem; }
+.lg-mt-6 { margin-top: 1.5rem; }
+.lg-mt-8 { margin-top: 2rem; }
+.lg-mt-10 { margin-top: 2.5rem; }
+.lg-mt-12 { margin-top: 3rem; }
+.lg-mt-16 { margin-top: 4rem; }
+.lg-mt-20 { margin-top: 5rem; }
+.lg-mt-24 { margin-top: 6rem; }
+.lg-mt-32 { margin-top: 8rem; }
+.lg-mb-0 { margin-bottom: 0; }
+.lg-mb-1 { margin-bottom: 0.25rem; }
+.lg-mb-2 { margin-bottom: 0.5rem; }
+.lg-mb-3 { margin-bottom: 0.75rem; }
+.lg-mb-4 { margin-bottom: 1rem; }
+.lg-mb-5 { margin-bottom: 1.25rem; }
+.lg-mb-6 { margin-bottom: 1.5rem; }
+.lg-mb-8 { margin-bottom: 2rem; }
+.lg-mb-10 { margin-bottom: 2.5rem; }
+.lg-mb-12 { margin-bottom: 3rem; }
+.lg-mb-16 { margin-bottom: 4rem; }
+.lg-mb-20 { margin-bottom: 5rem; }
+.lg-mb-24 { margin-bottom: 6rem; }
+.lg-mb-32 { margin-bottom: 8rem; }
+.lg-ml-0 { margin-left: 0; }
+.lg-ml-1 { margin-left: 0.25rem; }
+.lg-ml-2 { margin-left: 0.5rem; }
+.lg-ml-3 { margin-left: 0.75rem; }
+.lg-ml-4 { margin-left: 1rem; }
+.lg-ml-5 { margin-left: 1.25rem; }
+.lg-ml-6 { margin-left: 1.5rem; }
+.lg-ml-8 { margin-left: 2rem; }
+.lg-ml-10 { margin-left: 2.5rem; }
+.lg-ml-12 { margin-left: 3rem; }
+.lg-ml-16 { margin-left: 4rem; }
+.lg-ml-20 { margin-left: 5rem; }
+.lg-ml-24 { margin-left: 6rem; }
+.lg-ml-32 { margin-left: 8rem; }
+.lg-mr-0 { margin-right: 0; }
+.lg-mr-1 { margin-right: 0.25rem; }
+.lg-mr-2 { margin-right: 0.5rem; }
+.lg-mr-3 { margin-right: 0.75rem; }
+.lg-mr-4 { margin-right: 1rem; }
+.lg-mr-5 { margin-right: 1.25rem; }
+.lg-mr-6 { margin-right: 1.5rem; }
+.lg-mr-8 { margin-right: 2rem; }
+.lg-mr-10 { margin-right: 2.5rem; }
+.lg-mr-12 { margin-right: 3rem; }
+.lg-mr-16 { margin-right: 4rem; }
+.lg-mr-20 { margin-right: 5rem; }
+.lg-mr-24 { margin-right: 6rem; }
+.lg-mr-32 { margin-right: 8rem; }
+.lg-mx-0 { margin-left: 0; margin-right: 0; }
+.lg-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.lg-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.lg-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.lg-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.lg-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.lg-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.lg-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.lg-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.lg-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.lg-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.lg-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.lg-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.lg-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.lg-my-0 { margin-top: 0; margin-bottom: 0; }
+.lg-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.lg-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.lg-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.lg-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.lg-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.lg-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.lg-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.lg-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.lg-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.lg-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.lg-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.lg-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.lg-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.lg-p-0 { padding: 0; }
+.lg-p-1 { padding: 0.25rem; }
+.lg-p-2 { padding: 0.5rem; }
+.lg-p-3 { padding: 0.75rem; }
+.lg-p-4 { padding: 1rem; }
+.lg-p-5 { padding: 1.25rem; }
+.lg-p-6 { padding: 1.5rem; }
+.lg-p-8 { padding: 2rem; }
+.lg-p-10 { padding: 2.5rem; }
+.lg-p-12 { padding: 3rem; }
+.lg-p-16 { padding: 4rem; }
+.lg-p-20 { padding: 5rem; }
+.lg-p-24 { padding: 6rem; }
+.lg-p-32 { padding: 8rem; }
+.lg-pt-0 { padding-top: 0; }
+.lg-pt-1 { padding-top: 0.25rem; }
+.lg-pt-2 { padding-top: 0.5rem; }
+.lg-pt-3 { padding-top: 0.75rem; }
+.lg-pt-4 { padding-top: 1rem; }
+.lg-pt-5 { padding-top: 1.25rem; }
+.lg-pt-6 { padding-top: 1.5rem; }
+.lg-pt-8 { padding-top: 2rem; }
+.lg-pt-10 { padding-top: 2.5rem; }
+.lg-pt-12 { padding-top: 3rem; }
+.lg-pt-16 { padding-top: 4rem; }
+.lg-pt-20 { padding-top: 5rem; }
+.lg-pt-24 { padding-top: 6rem; }
+.lg-pt-32 { padding-top: 8rem; }
+.lg-pb-0 { padding-bottom: 0; }
+.lg-pb-1 { padding-bottom: 0.25rem; }
+.lg-pb-2 { padding-bottom: 0.5rem; }
+.lg-pb-3 { padding-bottom: 0.75rem; }
+.lg-pb-4 { padding-bottom: 1rem; }
+.lg-pb-5 { padding-bottom: 1.25rem; }
+.lg-pb-6 { padding-bottom: 1.5rem; }
+.lg-pb-8 { padding-bottom: 2rem; }
+.lg-pb-10 { padding-bottom: 2.5rem; }
+.lg-pb-12 { padding-bottom: 3rem; }
+.lg-pb-16 { padding-bottom: 4rem; }
+.lg-pb-20 { padding-bottom: 5rem; }
+.lg-pb-24 { padding-bottom: 6rem; }
+.lg-pb-32 { padding-bottom: 8rem; }
+.lg-pl-0 { padding-left: 0; }
+.lg-pl-1 { padding-left: 0.25rem; }
+.lg-pl-2 { padding-left: 0.5rem; }
+.lg-pl-3 { padding-left: 0.75rem; }
+.lg-pl-4 { padding-left: 1rem; }
+.lg-pl-5 { padding-left: 1.25rem; }
+.lg-pl-6 { padding-left: 1.5rem; }
+.lg-pl-8 { padding-left: 2rem; }
+.lg-pl-10 { padding-left: 2.5rem; }
+.lg-pl-12 { padding-left: 3rem; }
+.lg-pl-16 { padding-left: 4rem; }
+.lg-pl-20 { padding-left: 5rem; }
+.lg-pl-24 { padding-left: 6rem; }
+.lg-pl-32 { padding-left: 8rem; }
+.lg-pr-0 { padding-right: 0; }
+.lg-pr-1 { padding-right: 0.25rem; }
+.lg-pr-2 { padding-right: 0.5rem; }
+.lg-pr-3 { padding-right: 0.75rem; }
+.lg-pr-4 { padding-right: 1rem; }
+.lg-pr-5 { padding-right: 1.25rem; }
+.lg-pr-6 { padding-right: 1.5rem; }
+.lg-pr-8 { padding-right: 2rem; }
+.lg-pr-10 { padding-right: 2.5rem; }
+.lg-pr-12 { padding-right: 3rem; }
+.lg-pr-16 { padding-right: 4rem; }
+.lg-pr-20 { padding-right: 5rem; }
+.lg-pr-24 { padding-right: 6rem; }
+.lg-pr-32 { padding-right: 8rem; }
+.lg-px-0 { padding-left: 0; padding-right: 0; }
+.lg-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.lg-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.lg-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.lg-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.lg-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.lg-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.lg-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.lg-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.lg-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.lg-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.lg-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.lg-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.lg-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.lg-py-0 { padding-top: 0; padding-bottom: 0; }
+.lg-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.lg-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.lg-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.lg-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.lg-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.lg-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.lg-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.lg-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.lg-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.lg-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.lg-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.lg-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.lg-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.lg-gap-0 { gap: 0; }
+.lg-gap-1 { gap: 0.25rem; }
+.lg-gap-2 { gap: 0.5rem; }
+.lg-gap-3 { gap: 0.75rem; }
+.lg-gap-4 { gap: 1rem; }
+.lg-gap-5 { gap: 1.25rem; }
+.lg-gap-6 { gap: 1.5rem; }
+.lg-gap-8 { gap: 2rem; }
+.lg-gap-10 { gap: 2.5rem; }
+.lg-gap-12 { gap: 3rem; }
+.lg-gap-16 { gap: 4rem; }
+.lg-gap-20 { gap: 5rem; }
+.lg-gap-24 { gap: 6rem; }
+.lg-gap-32 { gap: 8rem; }
 }
 @media (width >= 80rem) {
-.xl\:m-0 { margin: 0; }
-.xl\:m-1 { margin: 0.25rem; }
-.xl\:m-2 { margin: 0.5rem; }
-.xl\:m-3 { margin: 0.75rem; }
-.xl\:m-4 { margin: 1rem; }
-.xl\:m-5 { margin: 1.25rem; }
-.xl\:m-6 { margin: 1.5rem; }
-.xl\:m-8 { margin: 2rem; }
-.xl\:m-10 { margin: 2.5rem; }
-.xl\:m-12 { margin: 3rem; }
-.xl\:m-16 { margin: 4rem; }
-.xl\:m-20 { margin: 5rem; }
-.xl\:m-24 { margin: 6rem; }
-.xl\:m-32 { margin: 8rem; }
-.xl\:mt-0 { margin-top: 0; }
-.xl\:mt-1 { margin-top: 0.25rem; }
-.xl\:mt-2 { margin-top: 0.5rem; }
-.xl\:mt-3 { margin-top: 0.75rem; }
-.xl\:mt-4 { margin-top: 1rem; }
-.xl\:mt-5 { margin-top: 1.25rem; }
-.xl\:mt-6 { margin-top: 1.5rem; }
-.xl\:mt-8 { margin-top: 2rem; }
-.xl\:mt-10 { margin-top: 2.5rem; }
-.xl\:mt-12 { margin-top: 3rem; }
-.xl\:mt-16 { margin-top: 4rem; }
-.xl\:mt-20 { margin-top: 5rem; }
-.xl\:mt-24 { margin-top: 6rem; }
-.xl\:mt-32 { margin-top: 8rem; }
-.xl\:mb-0 { margin-bottom: 0; }
-.xl\:mb-1 { margin-bottom: 0.25rem; }
-.xl\:mb-2 { margin-bottom: 0.5rem; }
-.xl\:mb-3 { margin-bottom: 0.75rem; }
-.xl\:mb-4 { margin-bottom: 1rem; }
-.xl\:mb-5 { margin-bottom: 1.25rem; }
-.xl\:mb-6 { margin-bottom: 1.5rem; }
-.xl\:mb-8 { margin-bottom: 2rem; }
-.xl\:mb-10 { margin-bottom: 2.5rem; }
-.xl\:mb-12 { margin-bottom: 3rem; }
-.xl\:mb-16 { margin-bottom: 4rem; }
-.xl\:mb-20 { margin-bottom: 5rem; }
-.xl\:mb-24 { margin-bottom: 6rem; }
-.xl\:mb-32 { margin-bottom: 8rem; }
-.xl\:ml-0 { margin-left: 0; }
-.xl\:ml-1 { margin-left: 0.25rem; }
-.xl\:ml-2 { margin-left: 0.5rem; }
-.xl\:ml-3 { margin-left: 0.75rem; }
-.xl\:ml-4 { margin-left: 1rem; }
-.xl\:ml-5 { margin-left: 1.25rem; }
-.xl\:ml-6 { margin-left: 1.5rem; }
-.xl\:ml-8 { margin-left: 2rem; }
-.xl\:ml-10 { margin-left: 2.5rem; }
-.xl\:ml-12 { margin-left: 3rem; }
-.xl\:ml-16 { margin-left: 4rem; }
-.xl\:ml-20 { margin-left: 5rem; }
-.xl\:ml-24 { margin-left: 6rem; }
-.xl\:ml-32 { margin-left: 8rem; }
-.xl\:mr-0 { margin-right: 0; }
-.xl\:mr-1 { margin-right: 0.25rem; }
-.xl\:mr-2 { margin-right: 0.5rem; }
-.xl\:mr-3 { margin-right: 0.75rem; }
-.xl\:mr-4 { margin-right: 1rem; }
-.xl\:mr-5 { margin-right: 1.25rem; }
-.xl\:mr-6 { margin-right: 1.5rem; }
-.xl\:mr-8 { margin-right: 2rem; }
-.xl\:mr-10 { margin-right: 2.5rem; }
-.xl\:mr-12 { margin-right: 3rem; }
-.xl\:mr-16 { margin-right: 4rem; }
-.xl\:mr-20 { margin-right: 5rem; }
-.xl\:mr-24 { margin-right: 6rem; }
-.xl\:mr-32 { margin-right: 8rem; }
-.xl\:mx-0 { margin-left: 0; margin-right: 0; }
-.xl\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.xl\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.xl\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.xl\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.xl\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.xl\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.xl\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.xl\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.xl\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.xl\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.xl\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.xl\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.xl\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.xl\:my-0 { margin-top: 0; margin-bottom: 0; }
-.xl\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.xl\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.xl\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.xl\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.xl\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.xl\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.xl\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.xl\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.xl\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.xl\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.xl\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.xl\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.xl\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.xl\:p-0 { padding: 0; }
-.xl\:p-1 { padding: 0.25rem; }
-.xl\:p-2 { padding: 0.5rem; }
-.xl\:p-3 { padding: 0.75rem; }
-.xl\:p-4 { padding: 1rem; }
-.xl\:p-5 { padding: 1.25rem; }
-.xl\:p-6 { padding: 1.5rem; }
-.xl\:p-8 { padding: 2rem; }
-.xl\:p-10 { padding: 2.5rem; }
-.xl\:p-12 { padding: 3rem; }
-.xl\:p-16 { padding: 4rem; }
-.xl\:p-20 { padding: 5rem; }
-.xl\:p-24 { padding: 6rem; }
-.xl\:p-32 { padding: 8rem; }
-.xl\:pt-0 { padding-top: 0; }
-.xl\:pt-1 { padding-top: 0.25rem; }
-.xl\:pt-2 { padding-top: 0.5rem; }
-.xl\:pt-3 { padding-top: 0.75rem; }
-.xl\:pt-4 { padding-top: 1rem; }
-.xl\:pt-5 { padding-top: 1.25rem; }
-.xl\:pt-6 { padding-top: 1.5rem; }
-.xl\:pt-8 { padding-top: 2rem; }
-.xl\:pt-10 { padding-top: 2.5rem; }
-.xl\:pt-12 { padding-top: 3rem; }
-.xl\:pt-16 { padding-top: 4rem; }
-.xl\:pt-20 { padding-top: 5rem; }
-.xl\:pt-24 { padding-top: 6rem; }
-.xl\:pt-32 { padding-top: 8rem; }
-.xl\:pb-0 { padding-bottom: 0; }
-.xl\:pb-1 { padding-bottom: 0.25rem; }
-.xl\:pb-2 { padding-bottom: 0.5rem; }
-.xl\:pb-3 { padding-bottom: 0.75rem; }
-.xl\:pb-4 { padding-bottom: 1rem; }
-.xl\:pb-5 { padding-bottom: 1.25rem; }
-.xl\:pb-6 { padding-bottom: 1.5rem; }
-.xl\:pb-8 { padding-bottom: 2rem; }
-.xl\:pb-10 { padding-bottom: 2.5rem; }
-.xl\:pb-12 { padding-bottom: 3rem; }
-.xl\:pb-16 { padding-bottom: 4rem; }
-.xl\:pb-20 { padding-bottom: 5rem; }
-.xl\:pb-24 { padding-bottom: 6rem; }
-.xl\:pb-32 { padding-bottom: 8rem; }
-.xl\:pl-0 { padding-left: 0; }
-.xl\:pl-1 { padding-left: 0.25rem; }
-.xl\:pl-2 { padding-left: 0.5rem; }
-.xl\:pl-3 { padding-left: 0.75rem; }
-.xl\:pl-4 { padding-left: 1rem; }
-.xl\:pl-5 { padding-left: 1.25rem; }
-.xl\:pl-6 { padding-left: 1.5rem; }
-.xl\:pl-8 { padding-left: 2rem; }
-.xl\:pl-10 { padding-left: 2.5rem; }
-.xl\:pl-12 { padding-left: 3rem; }
-.xl\:pl-16 { padding-left: 4rem; }
-.xl\:pl-20 { padding-left: 5rem; }
-.xl\:pl-24 { padding-left: 6rem; }
-.xl\:pl-32 { padding-left: 8rem; }
-.xl\:pr-0 { padding-right: 0; }
-.xl\:pr-1 { padding-right: 0.25rem; }
-.xl\:pr-2 { padding-right: 0.5rem; }
-.xl\:pr-3 { padding-right: 0.75rem; }
-.xl\:pr-4 { padding-right: 1rem; }
-.xl\:pr-5 { padding-right: 1.25rem; }
-.xl\:pr-6 { padding-right: 1.5rem; }
-.xl\:pr-8 { padding-right: 2rem; }
-.xl\:pr-10 { padding-right: 2.5rem; }
-.xl\:pr-12 { padding-right: 3rem; }
-.xl\:pr-16 { padding-right: 4rem; }
-.xl\:pr-20 { padding-right: 5rem; }
-.xl\:pr-24 { padding-right: 6rem; }
-.xl\:pr-32 { padding-right: 8rem; }
-.xl\:px-0 { padding-left: 0; padding-right: 0; }
-.xl\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.xl\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.xl\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.xl\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.xl\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.xl\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.xl\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.xl\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.xl\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.xl\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.xl\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.xl\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.xl\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.xl\:py-0 { padding-top: 0; padding-bottom: 0; }
-.xl\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.xl\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.xl\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.xl\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.xl\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.xl\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.xl\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.xl\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.xl\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.xl\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.xl\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.xl\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.xl\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.xl\:gap-0 { gap: 0; }
-.xl\:gap-1 { gap: 0.25rem; }
-.xl\:gap-2 { gap: 0.5rem; }
-.xl\:gap-3 { gap: 0.75rem; }
-.xl\:gap-4 { gap: 1rem; }
-.xl\:gap-5 { gap: 1.25rem; }
-.xl\:gap-6 { gap: 1.5rem; }
-.xl\:gap-8 { gap: 2rem; }
-.xl\:gap-10 { gap: 2.5rem; }
-.xl\:gap-12 { gap: 3rem; }
-.xl\:gap-16 { gap: 4rem; }
-.xl\:gap-20 { gap: 5rem; }
-.xl\:gap-24 { gap: 6rem; }
-.xl\:gap-32 { gap: 8rem; }
+.xl-m-0 { margin: 0; }
+.xl-m-1 { margin: 0.25rem; }
+.xl-m-2 { margin: 0.5rem; }
+.xl-m-3 { margin: 0.75rem; }
+.xl-m-4 { margin: 1rem; }
+.xl-m-5 { margin: 1.25rem; }
+.xl-m-6 { margin: 1.5rem; }
+.xl-m-8 { margin: 2rem; }
+.xl-m-10 { margin: 2.5rem; }
+.xl-m-12 { margin: 3rem; }
+.xl-m-16 { margin: 4rem; }
+.xl-m-20 { margin: 5rem; }
+.xl-m-24 { margin: 6rem; }
+.xl-m-32 { margin: 8rem; }
+.xl-mt-0 { margin-top: 0; }
+.xl-mt-1 { margin-top: 0.25rem; }
+.xl-mt-2 { margin-top: 0.5rem; }
+.xl-mt-3 { margin-top: 0.75rem; }
+.xl-mt-4 { margin-top: 1rem; }
+.xl-mt-5 { margin-top: 1.25rem; }
+.xl-mt-6 { margin-top: 1.5rem; }
+.xl-mt-8 { margin-top: 2rem; }
+.xl-mt-10 { margin-top: 2.5rem; }
+.xl-mt-12 { margin-top: 3rem; }
+.xl-mt-16 { margin-top: 4rem; }
+.xl-mt-20 { margin-top: 5rem; }
+.xl-mt-24 { margin-top: 6rem; }
+.xl-mt-32 { margin-top: 8rem; }
+.xl-mb-0 { margin-bottom: 0; }
+.xl-mb-1 { margin-bottom: 0.25rem; }
+.xl-mb-2 { margin-bottom: 0.5rem; }
+.xl-mb-3 { margin-bottom: 0.75rem; }
+.xl-mb-4 { margin-bottom: 1rem; }
+.xl-mb-5 { margin-bottom: 1.25rem; }
+.xl-mb-6 { margin-bottom: 1.5rem; }
+.xl-mb-8 { margin-bottom: 2rem; }
+.xl-mb-10 { margin-bottom: 2.5rem; }
+.xl-mb-12 { margin-bottom: 3rem; }
+.xl-mb-16 { margin-bottom: 4rem; }
+.xl-mb-20 { margin-bottom: 5rem; }
+.xl-mb-24 { margin-bottom: 6rem; }
+.xl-mb-32 { margin-bottom: 8rem; }
+.xl-ml-0 { margin-left: 0; }
+.xl-ml-1 { margin-left: 0.25rem; }
+.xl-ml-2 { margin-left: 0.5rem; }
+.xl-ml-3 { margin-left: 0.75rem; }
+.xl-ml-4 { margin-left: 1rem; }
+.xl-ml-5 { margin-left: 1.25rem; }
+.xl-ml-6 { margin-left: 1.5rem; }
+.xl-ml-8 { margin-left: 2rem; }
+.xl-ml-10 { margin-left: 2.5rem; }
+.xl-ml-12 { margin-left: 3rem; }
+.xl-ml-16 { margin-left: 4rem; }
+.xl-ml-20 { margin-left: 5rem; }
+.xl-ml-24 { margin-left: 6rem; }
+.xl-ml-32 { margin-left: 8rem; }
+.xl-mr-0 { margin-right: 0; }
+.xl-mr-1 { margin-right: 0.25rem; }
+.xl-mr-2 { margin-right: 0.5rem; }
+.xl-mr-3 { margin-right: 0.75rem; }
+.xl-mr-4 { margin-right: 1rem; }
+.xl-mr-5 { margin-right: 1.25rem; }
+.xl-mr-6 { margin-right: 1.5rem; }
+.xl-mr-8 { margin-right: 2rem; }
+.xl-mr-10 { margin-right: 2.5rem; }
+.xl-mr-12 { margin-right: 3rem; }
+.xl-mr-16 { margin-right: 4rem; }
+.xl-mr-20 { margin-right: 5rem; }
+.xl-mr-24 { margin-right: 6rem; }
+.xl-mr-32 { margin-right: 8rem; }
+.xl-mx-0 { margin-left: 0; margin-right: 0; }
+.xl-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.xl-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.xl-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.xl-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.xl-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.xl-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.xl-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.xl-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.xl-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.xl-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.xl-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.xl-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.xl-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.xl-my-0 { margin-top: 0; margin-bottom: 0; }
+.xl-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.xl-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.xl-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.xl-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.xl-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.xl-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.xl-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.xl-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.xl-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.xl-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.xl-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.xl-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.xl-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.xl-p-0 { padding: 0; }
+.xl-p-1 { padding: 0.25rem; }
+.xl-p-2 { padding: 0.5rem; }
+.xl-p-3 { padding: 0.75rem; }
+.xl-p-4 { padding: 1rem; }
+.xl-p-5 { padding: 1.25rem; }
+.xl-p-6 { padding: 1.5rem; }
+.xl-p-8 { padding: 2rem; }
+.xl-p-10 { padding: 2.5rem; }
+.xl-p-12 { padding: 3rem; }
+.xl-p-16 { padding: 4rem; }
+.xl-p-20 { padding: 5rem; }
+.xl-p-24 { padding: 6rem; }
+.xl-p-32 { padding: 8rem; }
+.xl-pt-0 { padding-top: 0; }
+.xl-pt-1 { padding-top: 0.25rem; }
+.xl-pt-2 { padding-top: 0.5rem; }
+.xl-pt-3 { padding-top: 0.75rem; }
+.xl-pt-4 { padding-top: 1rem; }
+.xl-pt-5 { padding-top: 1.25rem; }
+.xl-pt-6 { padding-top: 1.5rem; }
+.xl-pt-8 { padding-top: 2rem; }
+.xl-pt-10 { padding-top: 2.5rem; }
+.xl-pt-12 { padding-top: 3rem; }
+.xl-pt-16 { padding-top: 4rem; }
+.xl-pt-20 { padding-top: 5rem; }
+.xl-pt-24 { padding-top: 6rem; }
+.xl-pt-32 { padding-top: 8rem; }
+.xl-pb-0 { padding-bottom: 0; }
+.xl-pb-1 { padding-bottom: 0.25rem; }
+.xl-pb-2 { padding-bottom: 0.5rem; }
+.xl-pb-3 { padding-bottom: 0.75rem; }
+.xl-pb-4 { padding-bottom: 1rem; }
+.xl-pb-5 { padding-bottom: 1.25rem; }
+.xl-pb-6 { padding-bottom: 1.5rem; }
+.xl-pb-8 { padding-bottom: 2rem; }
+.xl-pb-10 { padding-bottom: 2.5rem; }
+.xl-pb-12 { padding-bottom: 3rem; }
+.xl-pb-16 { padding-bottom: 4rem; }
+.xl-pb-20 { padding-bottom: 5rem; }
+.xl-pb-24 { padding-bottom: 6rem; }
+.xl-pb-32 { padding-bottom: 8rem; }
+.xl-pl-0 { padding-left: 0; }
+.xl-pl-1 { padding-left: 0.25rem; }
+.xl-pl-2 { padding-left: 0.5rem; }
+.xl-pl-3 { padding-left: 0.75rem; }
+.xl-pl-4 { padding-left: 1rem; }
+.xl-pl-5 { padding-left: 1.25rem; }
+.xl-pl-6 { padding-left: 1.5rem; }
+.xl-pl-8 { padding-left: 2rem; }
+.xl-pl-10 { padding-left: 2.5rem; }
+.xl-pl-12 { padding-left: 3rem; }
+.xl-pl-16 { padding-left: 4rem; }
+.xl-pl-20 { padding-left: 5rem; }
+.xl-pl-24 { padding-left: 6rem; }
+.xl-pl-32 { padding-left: 8rem; }
+.xl-pr-0 { padding-right: 0; }
+.xl-pr-1 { padding-right: 0.25rem; }
+.xl-pr-2 { padding-right: 0.5rem; }
+.xl-pr-3 { padding-right: 0.75rem; }
+.xl-pr-4 { padding-right: 1rem; }
+.xl-pr-5 { padding-right: 1.25rem; }
+.xl-pr-6 { padding-right: 1.5rem; }
+.xl-pr-8 { padding-right: 2rem; }
+.xl-pr-10 { padding-right: 2.5rem; }
+.xl-pr-12 { padding-right: 3rem; }
+.xl-pr-16 { padding-right: 4rem; }
+.xl-pr-20 { padding-right: 5rem; }
+.xl-pr-24 { padding-right: 6rem; }
+.xl-pr-32 { padding-right: 8rem; }
+.xl-px-0 { padding-left: 0; padding-right: 0; }
+.xl-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.xl-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.xl-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.xl-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.xl-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.xl-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.xl-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.xl-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.xl-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.xl-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.xl-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.xl-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.xl-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.xl-py-0 { padding-top: 0; padding-bottom: 0; }
+.xl-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.xl-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.xl-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.xl-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.xl-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.xl-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.xl-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.xl-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.xl-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.xl-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.xl-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.xl-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.xl-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.xl-gap-0 { gap: 0; }
+.xl-gap-1 { gap: 0.25rem; }
+.xl-gap-2 { gap: 0.5rem; }
+.xl-gap-3 { gap: 0.75rem; }
+.xl-gap-4 { gap: 1rem; }
+.xl-gap-5 { gap: 1.25rem; }
+.xl-gap-6 { gap: 1.5rem; }
+.xl-gap-8 { gap: 2rem; }
+.xl-gap-10 { gap: 2.5rem; }
+.xl-gap-12 { gap: 3rem; }
+.xl-gap-16 { gap: 4rem; }
+.xl-gap-20 { gap: 5rem; }
+.xl-gap-24 { gap: 6rem; }
+.xl-gap-32 { gap: 8rem; }
 }
 
 /* display utilities */
@@ -1133,26 +1133,26 @@
   clip: auto; white-space: normal;
 }
 @media (width >= 30rem) {
-.sm\:hide { display: none !important; }
-.sm\:show { display: revert !important; }
-.sm\:invisible { visibility: hidden !important; }
+.sm-hide { display: none !important; }
+.sm-show { display: revert !important; }
+.sm-invisible { visibility: hidden !important; }
 }
 @media (width >= 48rem) {
-.md\:hide { display: none !important; }
-.md\:show { display: revert !important; }
-.md\:invisible { visibility: hidden !important; }
+.md-hide { display: none !important; }
+.md-show { display: revert !important; }
+.md-invisible { visibility: hidden !important; }
 }
 @media (width >= 62rem) {
-.lg\:hide { display: none !important; }
-.lg\:show { display: revert !important; }
-.lg\:invisible { visibility: hidden !important; }
+.lg-hide { display: none !important; }
+.lg-show { display: revert !important; }
+.lg-invisible { visibility: hidden !important; }
 }
 @media (width >= 80rem) {
-.xl\:hide { display: none !important; }
-.xl\:show { display: revert !important; }
-.xl\:invisible { visibility: hidden !important; }
+.xl-hide { display: none !important; }
+.xl-show { display: revert !important; }
+.xl-invisible { visibility: hidden !important; }
 }
-@media print { .print\:hide { display: none !important; } }
+@media print { .print-hide { display: none !important; } }
 
 /* flex utilities */
 .flex { display: flex; }
@@ -1178,96 +1178,96 @@
 .items-stretch { align-items: stretch; }
 
 @media (width >= 30rem) {
-.sm\:flex { display: flex; }
-.sm\:inline-flex { display: inline-flex; }
-.sm\:flex-row { flex-direction: row; }
-.sm\:flex-row-reverse { flex-direction: row-reverse; }
-.sm\:flex-col { flex-direction: column; }
-.sm\:flex-col-reverse { flex-direction: column-reverse; }
-.sm\:flex-wrap { flex-wrap: wrap; }
-.sm\:flex-nowrap { flex-wrap: nowrap; }
-.sm\:flex-1 { flex: 1 1 0%; }
-.sm\:flex-auto { flex: 1 1 auto; }
-.sm\:flex-none { flex: none; }
-.sm\:justify-start { justify-content: flex-start; }
-.sm\:justify-end { justify-content: flex-end; }
-.sm\:justify-center { justify-content: center; }
-.sm\:justify-between { justify-content: space-between; }
-.sm\:justify-around { justify-content: space-around; }
-.sm\:items-start { align-items: flex-start; }
-.sm\:items-end { align-items: flex-end; }
-.sm\:items-center { align-items: center; }
-.sm\:items-baseline { align-items: baseline; }
-.sm\:items-stretch { align-items: stretch; }
+.sm-flex { display: flex; }
+.sm-inline-flex { display: inline-flex; }
+.sm-flex-row { flex-direction: row; }
+.sm-flex-row-reverse { flex-direction: row-reverse; }
+.sm-flex-col { flex-direction: column; }
+.sm-flex-col-reverse { flex-direction: column-reverse; }
+.sm-flex-wrap { flex-wrap: wrap; }
+.sm-flex-nowrap { flex-wrap: nowrap; }
+.sm-flex-1 { flex: 1 1 0%; }
+.sm-flex-auto { flex: 1 1 auto; }
+.sm-flex-none { flex: none; }
+.sm-justify-start { justify-content: flex-start; }
+.sm-justify-end { justify-content: flex-end; }
+.sm-justify-center { justify-content: center; }
+.sm-justify-between { justify-content: space-between; }
+.sm-justify-around { justify-content: space-around; }
+.sm-items-start { align-items: flex-start; }
+.sm-items-end { align-items: flex-end; }
+.sm-items-center { align-items: center; }
+.sm-items-baseline { align-items: baseline; }
+.sm-items-stretch { align-items: stretch; }
 }
 @media (width >= 48rem) {
-.md\:flex { display: flex; }
-.md\:inline-flex { display: inline-flex; }
-.md\:flex-row { flex-direction: row; }
-.md\:flex-row-reverse { flex-direction: row-reverse; }
-.md\:flex-col { flex-direction: column; }
-.md\:flex-col-reverse { flex-direction: column-reverse; }
-.md\:flex-wrap { flex-wrap: wrap; }
-.md\:flex-nowrap { flex-wrap: nowrap; }
-.md\:flex-1 { flex: 1 1 0%; }
-.md\:flex-auto { flex: 1 1 auto; }
-.md\:flex-none { flex: none; }
-.md\:justify-start { justify-content: flex-start; }
-.md\:justify-end { justify-content: flex-end; }
-.md\:justify-center { justify-content: center; }
-.md\:justify-between { justify-content: space-between; }
-.md\:justify-around { justify-content: space-around; }
-.md\:items-start { align-items: flex-start; }
-.md\:items-end { align-items: flex-end; }
-.md\:items-center { align-items: center; }
-.md\:items-baseline { align-items: baseline; }
-.md\:items-stretch { align-items: stretch; }
+.md-flex { display: flex; }
+.md-inline-flex { display: inline-flex; }
+.md-flex-row { flex-direction: row; }
+.md-flex-row-reverse { flex-direction: row-reverse; }
+.md-flex-col { flex-direction: column; }
+.md-flex-col-reverse { flex-direction: column-reverse; }
+.md-flex-wrap { flex-wrap: wrap; }
+.md-flex-nowrap { flex-wrap: nowrap; }
+.md-flex-1 { flex: 1 1 0%; }
+.md-flex-auto { flex: 1 1 auto; }
+.md-flex-none { flex: none; }
+.md-justify-start { justify-content: flex-start; }
+.md-justify-end { justify-content: flex-end; }
+.md-justify-center { justify-content: center; }
+.md-justify-between { justify-content: space-between; }
+.md-justify-around { justify-content: space-around; }
+.md-items-start { align-items: flex-start; }
+.md-items-end { align-items: flex-end; }
+.md-items-center { align-items: center; }
+.md-items-baseline { align-items: baseline; }
+.md-items-stretch { align-items: stretch; }
 }
 @media (width >= 62rem) {
-.lg\:flex { display: flex; }
-.lg\:inline-flex { display: inline-flex; }
-.lg\:flex-row { flex-direction: row; }
-.lg\:flex-row-reverse { flex-direction: row-reverse; }
-.lg\:flex-col { flex-direction: column; }
-.lg\:flex-col-reverse { flex-direction: column-reverse; }
-.lg\:flex-wrap { flex-wrap: wrap; }
-.lg\:flex-nowrap { flex-wrap: nowrap; }
-.lg\:flex-1 { flex: 1 1 0%; }
-.lg\:flex-auto { flex: 1 1 auto; }
-.lg\:flex-none { flex: none; }
-.lg\:justify-start { justify-content: flex-start; }
-.lg\:justify-end { justify-content: flex-end; }
-.lg\:justify-center { justify-content: center; }
-.lg\:justify-between { justify-content: space-between; }
-.lg\:justify-around { justify-content: space-around; }
-.lg\:items-start { align-items: flex-start; }
-.lg\:items-end { align-items: flex-end; }
-.lg\:items-center { align-items: center; }
-.lg\:items-baseline { align-items: baseline; }
-.lg\:items-stretch { align-items: stretch; }
+.lg-flex { display: flex; }
+.lg-inline-flex { display: inline-flex; }
+.lg-flex-row { flex-direction: row; }
+.lg-flex-row-reverse { flex-direction: row-reverse; }
+.lg-flex-col { flex-direction: column; }
+.lg-flex-col-reverse { flex-direction: column-reverse; }
+.lg-flex-wrap { flex-wrap: wrap; }
+.lg-flex-nowrap { flex-wrap: nowrap; }
+.lg-flex-1 { flex: 1 1 0%; }
+.lg-flex-auto { flex: 1 1 auto; }
+.lg-flex-none { flex: none; }
+.lg-justify-start { justify-content: flex-start; }
+.lg-justify-end { justify-content: flex-end; }
+.lg-justify-center { justify-content: center; }
+.lg-justify-between { justify-content: space-between; }
+.lg-justify-around { justify-content: space-around; }
+.lg-items-start { align-items: flex-start; }
+.lg-items-end { align-items: flex-end; }
+.lg-items-center { align-items: center; }
+.lg-items-baseline { align-items: baseline; }
+.lg-items-stretch { align-items: stretch; }
 }
 @media (width >= 80rem) {
-.xl\:flex { display: flex; }
-.xl\:inline-flex { display: inline-flex; }
-.xl\:flex-row { flex-direction: row; }
-.xl\:flex-row-reverse { flex-direction: row-reverse; }
-.xl\:flex-col { flex-direction: column; }
-.xl\:flex-col-reverse { flex-direction: column-reverse; }
-.xl\:flex-wrap { flex-wrap: wrap; }
-.xl\:flex-nowrap { flex-wrap: nowrap; }
-.xl\:flex-1 { flex: 1 1 0%; }
-.xl\:flex-auto { flex: 1 1 auto; }
-.xl\:flex-none { flex: none; }
-.xl\:justify-start { justify-content: flex-start; }
-.xl\:justify-end { justify-content: flex-end; }
-.xl\:justify-center { justify-content: center; }
-.xl\:justify-between { justify-content: space-between; }
-.xl\:justify-around { justify-content: space-around; }
-.xl\:items-start { align-items: flex-start; }
-.xl\:items-end { align-items: flex-end; }
-.xl\:items-center { align-items: center; }
-.xl\:items-baseline { align-items: baseline; }
-.xl\:items-stretch { align-items: stretch; }
+.xl-flex { display: flex; }
+.xl-inline-flex { display: inline-flex; }
+.xl-flex-row { flex-direction: row; }
+.xl-flex-row-reverse { flex-direction: row-reverse; }
+.xl-flex-col { flex-direction: column; }
+.xl-flex-col-reverse { flex-direction: column-reverse; }
+.xl-flex-wrap { flex-wrap: wrap; }
+.xl-flex-nowrap { flex-wrap: nowrap; }
+.xl-flex-1 { flex: 1 1 0%; }
+.xl-flex-auto { flex: 1 1 auto; }
+.xl-flex-none { flex: none; }
+.xl-justify-start { justify-content: flex-start; }
+.xl-justify-end { justify-content: flex-end; }
+.xl-justify-center { justify-content: center; }
+.xl-justify-between { justify-content: space-between; }
+.xl-justify-around { justify-content: space-around; }
+.xl-items-start { align-items: flex-start; }
+.xl-items-end { align-items: flex-end; }
+.xl-items-center { align-items: center; }
+.xl-items-baseline { align-items: baseline; }
+.xl-items-stretch { align-items: stretch; }
 }
 
 /* grid utilities */
@@ -1293,92 +1293,92 @@
 .grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 
 @media (width >= 30rem) {
-.sm\:grid { display: grid; }
-.sm\:inline-grid { display: inline-grid; }
-.sm\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.sm\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.sm\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.sm\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.sm\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.sm\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.sm\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.sm\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.sm\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.sm\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.sm\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.sm\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.sm\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.sm\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.sm\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.sm\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.sm\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.sm-grid { display: grid; }
+.sm-inline-grid { display: inline-grid; }
+.sm-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.sm-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.sm-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.sm-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.sm-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.sm-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.sm-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.sm-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.sm-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.sm-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.sm-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.sm-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.sm-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.sm-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.sm-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.sm-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.sm-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.sm-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 48rem) {
-.md\:grid { display: grid; }
-.md\:inline-grid { display: inline-grid; }
-.md\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.md\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.md\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.md\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.md\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.md\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.md\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.md\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.md\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.md\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.md\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.md\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.md\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.md\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.md\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.md-grid { display: grid; }
+.md-inline-grid { display: inline-grid; }
+.md-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.md-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.md-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.md-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.md-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.md-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.md-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.md-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.md-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.md-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.md-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.md-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.md-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.md-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.md-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.md-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.md-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 62rem) {
-.lg\:grid { display: grid; }
-.lg\:inline-grid { display: inline-grid; }
-.lg\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.lg\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.lg\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.lg\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.lg\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.lg\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.lg\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.lg\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.lg\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.lg\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.lg\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.lg\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.lg\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.lg\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.lg\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.lg-grid { display: grid; }
+.lg-inline-grid { display: inline-grid; }
+.lg-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.lg-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.lg-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.lg-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.lg-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.lg-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.lg-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.lg-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.lg-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.lg-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.lg-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.lg-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.lg-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.lg-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.lg-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.lg-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.lg-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 80rem) {
-.xl\:grid { display: grid; }
-.xl\:inline-grid { display: inline-grid; }
-.xl\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.xl\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.xl\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.xl\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.xl\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.xl\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.xl\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.xl\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.xl\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.xl\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.xl\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.xl\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.xl\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.xl\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.xl\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.xl\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.xl\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.xl\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.xl-grid { display: grid; }
+.xl-inline-grid { display: inline-grid; }
+.xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.xl-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.xl-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.xl-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.xl-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.xl-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.xl-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.xl-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.xl-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.xl-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.xl-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.xl-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.xl-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.xl-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.xl-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 
 /* type utilities */

--- a/plugins/acss-utilities/assets/utilities/display.css
+++ b/plugins/acss-utilities/assets/utilities/display.css
@@ -19,23 +19,23 @@
   clip: auto; white-space: normal;
 }
 @media (width >= 30rem) {
-.sm\:hide { display: none !important; }
-.sm\:show { display: revert !important; }
-.sm\:invisible { visibility: hidden !important; }
+.sm-hide { display: none !important; }
+.sm-show { display: revert !important; }
+.sm-invisible { visibility: hidden !important; }
 }
 @media (width >= 48rem) {
-.md\:hide { display: none !important; }
-.md\:show { display: revert !important; }
-.md\:invisible { visibility: hidden !important; }
+.md-hide { display: none !important; }
+.md-show { display: revert !important; }
+.md-invisible { visibility: hidden !important; }
 }
 @media (width >= 62rem) {
-.lg\:hide { display: none !important; }
-.lg\:show { display: revert !important; }
-.lg\:invisible { visibility: hidden !important; }
+.lg-hide { display: none !important; }
+.lg-show { display: revert !important; }
+.lg-invisible { visibility: hidden !important; }
 }
 @media (width >= 80rem) {
-.xl\:hide { display: none !important; }
-.xl\:show { display: revert !important; }
-.xl\:invisible { visibility: hidden !important; }
+.xl-hide { display: none !important; }
+.xl-show { display: revert !important; }
+.xl-invisible { visibility: hidden !important; }
 }
-@media print { .print\:hide { display: none !important; } }
+@media print { .print-hide { display: none !important; } }

--- a/plugins/acss-utilities/assets/utilities/flex.css
+++ b/plugins/acss-utilities/assets/utilities/flex.css
@@ -22,94 +22,94 @@
 .items-stretch { align-items: stretch; }
 
 @media (width >= 30rem) {
-.sm\:flex { display: flex; }
-.sm\:inline-flex { display: inline-flex; }
-.sm\:flex-row { flex-direction: row; }
-.sm\:flex-row-reverse { flex-direction: row-reverse; }
-.sm\:flex-col { flex-direction: column; }
-.sm\:flex-col-reverse { flex-direction: column-reverse; }
-.sm\:flex-wrap { flex-wrap: wrap; }
-.sm\:flex-nowrap { flex-wrap: nowrap; }
-.sm\:flex-1 { flex: 1 1 0%; }
-.sm\:flex-auto { flex: 1 1 auto; }
-.sm\:flex-none { flex: none; }
-.sm\:justify-start { justify-content: flex-start; }
-.sm\:justify-end { justify-content: flex-end; }
-.sm\:justify-center { justify-content: center; }
-.sm\:justify-between { justify-content: space-between; }
-.sm\:justify-around { justify-content: space-around; }
-.sm\:items-start { align-items: flex-start; }
-.sm\:items-end { align-items: flex-end; }
-.sm\:items-center { align-items: center; }
-.sm\:items-baseline { align-items: baseline; }
-.sm\:items-stretch { align-items: stretch; }
+.sm-flex { display: flex; }
+.sm-inline-flex { display: inline-flex; }
+.sm-flex-row { flex-direction: row; }
+.sm-flex-row-reverse { flex-direction: row-reverse; }
+.sm-flex-col { flex-direction: column; }
+.sm-flex-col-reverse { flex-direction: column-reverse; }
+.sm-flex-wrap { flex-wrap: wrap; }
+.sm-flex-nowrap { flex-wrap: nowrap; }
+.sm-flex-1 { flex: 1 1 0%; }
+.sm-flex-auto { flex: 1 1 auto; }
+.sm-flex-none { flex: none; }
+.sm-justify-start { justify-content: flex-start; }
+.sm-justify-end { justify-content: flex-end; }
+.sm-justify-center { justify-content: center; }
+.sm-justify-between { justify-content: space-between; }
+.sm-justify-around { justify-content: space-around; }
+.sm-items-start { align-items: flex-start; }
+.sm-items-end { align-items: flex-end; }
+.sm-items-center { align-items: center; }
+.sm-items-baseline { align-items: baseline; }
+.sm-items-stretch { align-items: stretch; }
 }
 @media (width >= 48rem) {
-.md\:flex { display: flex; }
-.md\:inline-flex { display: inline-flex; }
-.md\:flex-row { flex-direction: row; }
-.md\:flex-row-reverse { flex-direction: row-reverse; }
-.md\:flex-col { flex-direction: column; }
-.md\:flex-col-reverse { flex-direction: column-reverse; }
-.md\:flex-wrap { flex-wrap: wrap; }
-.md\:flex-nowrap { flex-wrap: nowrap; }
-.md\:flex-1 { flex: 1 1 0%; }
-.md\:flex-auto { flex: 1 1 auto; }
-.md\:flex-none { flex: none; }
-.md\:justify-start { justify-content: flex-start; }
-.md\:justify-end { justify-content: flex-end; }
-.md\:justify-center { justify-content: center; }
-.md\:justify-between { justify-content: space-between; }
-.md\:justify-around { justify-content: space-around; }
-.md\:items-start { align-items: flex-start; }
-.md\:items-end { align-items: flex-end; }
-.md\:items-center { align-items: center; }
-.md\:items-baseline { align-items: baseline; }
-.md\:items-stretch { align-items: stretch; }
+.md-flex { display: flex; }
+.md-inline-flex { display: inline-flex; }
+.md-flex-row { flex-direction: row; }
+.md-flex-row-reverse { flex-direction: row-reverse; }
+.md-flex-col { flex-direction: column; }
+.md-flex-col-reverse { flex-direction: column-reverse; }
+.md-flex-wrap { flex-wrap: wrap; }
+.md-flex-nowrap { flex-wrap: nowrap; }
+.md-flex-1 { flex: 1 1 0%; }
+.md-flex-auto { flex: 1 1 auto; }
+.md-flex-none { flex: none; }
+.md-justify-start { justify-content: flex-start; }
+.md-justify-end { justify-content: flex-end; }
+.md-justify-center { justify-content: center; }
+.md-justify-between { justify-content: space-between; }
+.md-justify-around { justify-content: space-around; }
+.md-items-start { align-items: flex-start; }
+.md-items-end { align-items: flex-end; }
+.md-items-center { align-items: center; }
+.md-items-baseline { align-items: baseline; }
+.md-items-stretch { align-items: stretch; }
 }
 @media (width >= 62rem) {
-.lg\:flex { display: flex; }
-.lg\:inline-flex { display: inline-flex; }
-.lg\:flex-row { flex-direction: row; }
-.lg\:flex-row-reverse { flex-direction: row-reverse; }
-.lg\:flex-col { flex-direction: column; }
-.lg\:flex-col-reverse { flex-direction: column-reverse; }
-.lg\:flex-wrap { flex-wrap: wrap; }
-.lg\:flex-nowrap { flex-wrap: nowrap; }
-.lg\:flex-1 { flex: 1 1 0%; }
-.lg\:flex-auto { flex: 1 1 auto; }
-.lg\:flex-none { flex: none; }
-.lg\:justify-start { justify-content: flex-start; }
-.lg\:justify-end { justify-content: flex-end; }
-.lg\:justify-center { justify-content: center; }
-.lg\:justify-between { justify-content: space-between; }
-.lg\:justify-around { justify-content: space-around; }
-.lg\:items-start { align-items: flex-start; }
-.lg\:items-end { align-items: flex-end; }
-.lg\:items-center { align-items: center; }
-.lg\:items-baseline { align-items: baseline; }
-.lg\:items-stretch { align-items: stretch; }
+.lg-flex { display: flex; }
+.lg-inline-flex { display: inline-flex; }
+.lg-flex-row { flex-direction: row; }
+.lg-flex-row-reverse { flex-direction: row-reverse; }
+.lg-flex-col { flex-direction: column; }
+.lg-flex-col-reverse { flex-direction: column-reverse; }
+.lg-flex-wrap { flex-wrap: wrap; }
+.lg-flex-nowrap { flex-wrap: nowrap; }
+.lg-flex-1 { flex: 1 1 0%; }
+.lg-flex-auto { flex: 1 1 auto; }
+.lg-flex-none { flex: none; }
+.lg-justify-start { justify-content: flex-start; }
+.lg-justify-end { justify-content: flex-end; }
+.lg-justify-center { justify-content: center; }
+.lg-justify-between { justify-content: space-between; }
+.lg-justify-around { justify-content: space-around; }
+.lg-items-start { align-items: flex-start; }
+.lg-items-end { align-items: flex-end; }
+.lg-items-center { align-items: center; }
+.lg-items-baseline { align-items: baseline; }
+.lg-items-stretch { align-items: stretch; }
 }
 @media (width >= 80rem) {
-.xl\:flex { display: flex; }
-.xl\:inline-flex { display: inline-flex; }
-.xl\:flex-row { flex-direction: row; }
-.xl\:flex-row-reverse { flex-direction: row-reverse; }
-.xl\:flex-col { flex-direction: column; }
-.xl\:flex-col-reverse { flex-direction: column-reverse; }
-.xl\:flex-wrap { flex-wrap: wrap; }
-.xl\:flex-nowrap { flex-wrap: nowrap; }
-.xl\:flex-1 { flex: 1 1 0%; }
-.xl\:flex-auto { flex: 1 1 auto; }
-.xl\:flex-none { flex: none; }
-.xl\:justify-start { justify-content: flex-start; }
-.xl\:justify-end { justify-content: flex-end; }
-.xl\:justify-center { justify-content: center; }
-.xl\:justify-between { justify-content: space-between; }
-.xl\:justify-around { justify-content: space-around; }
-.xl\:items-start { align-items: flex-start; }
-.xl\:items-end { align-items: flex-end; }
-.xl\:items-center { align-items: center; }
-.xl\:items-baseline { align-items: baseline; }
-.xl\:items-stretch { align-items: stretch; }
+.xl-flex { display: flex; }
+.xl-inline-flex { display: inline-flex; }
+.xl-flex-row { flex-direction: row; }
+.xl-flex-row-reverse { flex-direction: row-reverse; }
+.xl-flex-col { flex-direction: column; }
+.xl-flex-col-reverse { flex-direction: column-reverse; }
+.xl-flex-wrap { flex-wrap: wrap; }
+.xl-flex-nowrap { flex-wrap: nowrap; }
+.xl-flex-1 { flex: 1 1 0%; }
+.xl-flex-auto { flex: 1 1 auto; }
+.xl-flex-none { flex: none; }
+.xl-justify-start { justify-content: flex-start; }
+.xl-justify-end { justify-content: flex-end; }
+.xl-justify-center { justify-content: center; }
+.xl-justify-between { justify-content: space-between; }
+.xl-justify-around { justify-content: space-around; }
+.xl-items-start { align-items: flex-start; }
+.xl-items-end { align-items: flex-end; }
+.xl-items-center { align-items: center; }
+.xl-items-baseline { align-items: baseline; }
+.xl-items-stretch { align-items: stretch; }
 }

--- a/plugins/acss-utilities/assets/utilities/grid.css
+++ b/plugins/acss-utilities/assets/utilities/grid.css
@@ -21,90 +21,90 @@
 .grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 
 @media (width >= 30rem) {
-.sm\:grid { display: grid; }
-.sm\:inline-grid { display: inline-grid; }
-.sm\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.sm\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.sm\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.sm\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.sm\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.sm\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.sm\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.sm\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.sm\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.sm\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.sm\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.sm\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.sm\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.sm\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.sm\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.sm\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.sm\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.sm-grid { display: grid; }
+.sm-inline-grid { display: inline-grid; }
+.sm-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.sm-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.sm-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.sm-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.sm-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.sm-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.sm-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.sm-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.sm-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.sm-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.sm-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.sm-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.sm-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.sm-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.sm-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.sm-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.sm-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.sm-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 48rem) {
-.md\:grid { display: grid; }
-.md\:inline-grid { display: inline-grid; }
-.md\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.md\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.md\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.md\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.md\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.md\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.md\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.md\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.md\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.md\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.md\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.md\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.md\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.md\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.md\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.md-grid { display: grid; }
+.md-inline-grid { display: inline-grid; }
+.md-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.md-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.md-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.md-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.md-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.md-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.md-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.md-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.md-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.md-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.md-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.md-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.md-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.md-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.md-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.md-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.md-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.md-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 62rem) {
-.lg\:grid { display: grid; }
-.lg\:inline-grid { display: inline-grid; }
-.lg\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.lg\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.lg\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.lg\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.lg\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.lg\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.lg\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.lg\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.lg\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.lg\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.lg\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.lg\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.lg\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.lg\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.lg\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.lg\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.lg-grid { display: grid; }
+.lg-inline-grid { display: inline-grid; }
+.lg-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.lg-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.lg-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.lg-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.lg-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.lg-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.lg-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.lg-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.lg-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.lg-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.lg-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.lg-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.lg-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.lg-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.lg-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.lg-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.lg-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.lg-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }
 @media (width >= 80rem) {
-.xl\:grid { display: grid; }
-.xl\:inline-grid { display: inline-grid; }
-.xl\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-.xl\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.xl\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.xl\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
-.xl\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-.xl\:grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-.xl\:grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
-.xl\:grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-.xl\:grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
-.xl\:grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
-.xl\:grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
-.xl\:grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
-.xl\:grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
-.xl\:grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
-.xl\:grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
-.xl\:grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
-.xl\:grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
-.xl\:grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
+.xl-grid { display: grid; }
+.xl-inline-grid { display: inline-grid; }
+.xl-grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
+.xl-grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.xl-grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.xl-grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.xl-grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+.xl-grid-cols-6 { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.xl-grid-cols-7 { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.xl-grid-cols-8 { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+.xl-grid-cols-9 { grid-template-columns: repeat(9, minmax(0, 1fr)); }
+.xl-grid-cols-10 { grid-template-columns: repeat(10, minmax(0, 1fr)); }
+.xl-grid-cols-11 { grid-template-columns: repeat(11, minmax(0, 1fr)); }
+.xl-grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.xl-grid-rows-1 { grid-template-rows: repeat(1, minmax(0, 1fr)); }
+.xl-grid-rows-2 { grid-template-rows: repeat(2, minmax(0, 1fr)); }
+.xl-grid-rows-3 { grid-template-rows: repeat(3, minmax(0, 1fr)); }
+.xl-grid-rows-4 { grid-template-rows: repeat(4, minmax(0, 1fr)); }
+.xl-grid-rows-5 { grid-template-rows: repeat(5, minmax(0, 1fr)); }
+.xl-grid-rows-6 { grid-template-rows: repeat(6, minmax(0, 1fr)); }
 }

--- a/plugins/acss-utilities/assets/utilities/spacing.css
+++ b/plugins/acss-utilities/assets/utilities/spacing.css
@@ -211,850 +211,850 @@
 .gap-32 { gap: 8rem; }
 
 @media (width >= 30rem) {
-.sm\:m-0 { margin: 0; }
-.sm\:m-1 { margin: 0.25rem; }
-.sm\:m-2 { margin: 0.5rem; }
-.sm\:m-3 { margin: 0.75rem; }
-.sm\:m-4 { margin: 1rem; }
-.sm\:m-5 { margin: 1.25rem; }
-.sm\:m-6 { margin: 1.5rem; }
-.sm\:m-8 { margin: 2rem; }
-.sm\:m-10 { margin: 2.5rem; }
-.sm\:m-12 { margin: 3rem; }
-.sm\:m-16 { margin: 4rem; }
-.sm\:m-20 { margin: 5rem; }
-.sm\:m-24 { margin: 6rem; }
-.sm\:m-32 { margin: 8rem; }
-.sm\:mt-0 { margin-top: 0; }
-.sm\:mt-1 { margin-top: 0.25rem; }
-.sm\:mt-2 { margin-top: 0.5rem; }
-.sm\:mt-3 { margin-top: 0.75rem; }
-.sm\:mt-4 { margin-top: 1rem; }
-.sm\:mt-5 { margin-top: 1.25rem; }
-.sm\:mt-6 { margin-top: 1.5rem; }
-.sm\:mt-8 { margin-top: 2rem; }
-.sm\:mt-10 { margin-top: 2.5rem; }
-.sm\:mt-12 { margin-top: 3rem; }
-.sm\:mt-16 { margin-top: 4rem; }
-.sm\:mt-20 { margin-top: 5rem; }
-.sm\:mt-24 { margin-top: 6rem; }
-.sm\:mt-32 { margin-top: 8rem; }
-.sm\:mb-0 { margin-bottom: 0; }
-.sm\:mb-1 { margin-bottom: 0.25rem; }
-.sm\:mb-2 { margin-bottom: 0.5rem; }
-.sm\:mb-3 { margin-bottom: 0.75rem; }
-.sm\:mb-4 { margin-bottom: 1rem; }
-.sm\:mb-5 { margin-bottom: 1.25rem; }
-.sm\:mb-6 { margin-bottom: 1.5rem; }
-.sm\:mb-8 { margin-bottom: 2rem; }
-.sm\:mb-10 { margin-bottom: 2.5rem; }
-.sm\:mb-12 { margin-bottom: 3rem; }
-.sm\:mb-16 { margin-bottom: 4rem; }
-.sm\:mb-20 { margin-bottom: 5rem; }
-.sm\:mb-24 { margin-bottom: 6rem; }
-.sm\:mb-32 { margin-bottom: 8rem; }
-.sm\:ml-0 { margin-left: 0; }
-.sm\:ml-1 { margin-left: 0.25rem; }
-.sm\:ml-2 { margin-left: 0.5rem; }
-.sm\:ml-3 { margin-left: 0.75rem; }
-.sm\:ml-4 { margin-left: 1rem; }
-.sm\:ml-5 { margin-left: 1.25rem; }
-.sm\:ml-6 { margin-left: 1.5rem; }
-.sm\:ml-8 { margin-left: 2rem; }
-.sm\:ml-10 { margin-left: 2.5rem; }
-.sm\:ml-12 { margin-left: 3rem; }
-.sm\:ml-16 { margin-left: 4rem; }
-.sm\:ml-20 { margin-left: 5rem; }
-.sm\:ml-24 { margin-left: 6rem; }
-.sm\:ml-32 { margin-left: 8rem; }
-.sm\:mr-0 { margin-right: 0; }
-.sm\:mr-1 { margin-right: 0.25rem; }
-.sm\:mr-2 { margin-right: 0.5rem; }
-.sm\:mr-3 { margin-right: 0.75rem; }
-.sm\:mr-4 { margin-right: 1rem; }
-.sm\:mr-5 { margin-right: 1.25rem; }
-.sm\:mr-6 { margin-right: 1.5rem; }
-.sm\:mr-8 { margin-right: 2rem; }
-.sm\:mr-10 { margin-right: 2.5rem; }
-.sm\:mr-12 { margin-right: 3rem; }
-.sm\:mr-16 { margin-right: 4rem; }
-.sm\:mr-20 { margin-right: 5rem; }
-.sm\:mr-24 { margin-right: 6rem; }
-.sm\:mr-32 { margin-right: 8rem; }
-.sm\:mx-0 { margin-left: 0; margin-right: 0; }
-.sm\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.sm\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.sm\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.sm\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.sm\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.sm\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.sm\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.sm\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.sm\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.sm\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.sm\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.sm\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.sm\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.sm\:my-0 { margin-top: 0; margin-bottom: 0; }
-.sm\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.sm\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.sm\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.sm\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.sm\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.sm\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.sm\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.sm\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.sm\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.sm\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.sm\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.sm\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.sm\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.sm\:p-0 { padding: 0; }
-.sm\:p-1 { padding: 0.25rem; }
-.sm\:p-2 { padding: 0.5rem; }
-.sm\:p-3 { padding: 0.75rem; }
-.sm\:p-4 { padding: 1rem; }
-.sm\:p-5 { padding: 1.25rem; }
-.sm\:p-6 { padding: 1.5rem; }
-.sm\:p-8 { padding: 2rem; }
-.sm\:p-10 { padding: 2.5rem; }
-.sm\:p-12 { padding: 3rem; }
-.sm\:p-16 { padding: 4rem; }
-.sm\:p-20 { padding: 5rem; }
-.sm\:p-24 { padding: 6rem; }
-.sm\:p-32 { padding: 8rem; }
-.sm\:pt-0 { padding-top: 0; }
-.sm\:pt-1 { padding-top: 0.25rem; }
-.sm\:pt-2 { padding-top: 0.5rem; }
-.sm\:pt-3 { padding-top: 0.75rem; }
-.sm\:pt-4 { padding-top: 1rem; }
-.sm\:pt-5 { padding-top: 1.25rem; }
-.sm\:pt-6 { padding-top: 1.5rem; }
-.sm\:pt-8 { padding-top: 2rem; }
-.sm\:pt-10 { padding-top: 2.5rem; }
-.sm\:pt-12 { padding-top: 3rem; }
-.sm\:pt-16 { padding-top: 4rem; }
-.sm\:pt-20 { padding-top: 5rem; }
-.sm\:pt-24 { padding-top: 6rem; }
-.sm\:pt-32 { padding-top: 8rem; }
-.sm\:pb-0 { padding-bottom: 0; }
-.sm\:pb-1 { padding-bottom: 0.25rem; }
-.sm\:pb-2 { padding-bottom: 0.5rem; }
-.sm\:pb-3 { padding-bottom: 0.75rem; }
-.sm\:pb-4 { padding-bottom: 1rem; }
-.sm\:pb-5 { padding-bottom: 1.25rem; }
-.sm\:pb-6 { padding-bottom: 1.5rem; }
-.sm\:pb-8 { padding-bottom: 2rem; }
-.sm\:pb-10 { padding-bottom: 2.5rem; }
-.sm\:pb-12 { padding-bottom: 3rem; }
-.sm\:pb-16 { padding-bottom: 4rem; }
-.sm\:pb-20 { padding-bottom: 5rem; }
-.sm\:pb-24 { padding-bottom: 6rem; }
-.sm\:pb-32 { padding-bottom: 8rem; }
-.sm\:pl-0 { padding-left: 0; }
-.sm\:pl-1 { padding-left: 0.25rem; }
-.sm\:pl-2 { padding-left: 0.5rem; }
-.sm\:pl-3 { padding-left: 0.75rem; }
-.sm\:pl-4 { padding-left: 1rem; }
-.sm\:pl-5 { padding-left: 1.25rem; }
-.sm\:pl-6 { padding-left: 1.5rem; }
-.sm\:pl-8 { padding-left: 2rem; }
-.sm\:pl-10 { padding-left: 2.5rem; }
-.sm\:pl-12 { padding-left: 3rem; }
-.sm\:pl-16 { padding-left: 4rem; }
-.sm\:pl-20 { padding-left: 5rem; }
-.sm\:pl-24 { padding-left: 6rem; }
-.sm\:pl-32 { padding-left: 8rem; }
-.sm\:pr-0 { padding-right: 0; }
-.sm\:pr-1 { padding-right: 0.25rem; }
-.sm\:pr-2 { padding-right: 0.5rem; }
-.sm\:pr-3 { padding-right: 0.75rem; }
-.sm\:pr-4 { padding-right: 1rem; }
-.sm\:pr-5 { padding-right: 1.25rem; }
-.sm\:pr-6 { padding-right: 1.5rem; }
-.sm\:pr-8 { padding-right: 2rem; }
-.sm\:pr-10 { padding-right: 2.5rem; }
-.sm\:pr-12 { padding-right: 3rem; }
-.sm\:pr-16 { padding-right: 4rem; }
-.sm\:pr-20 { padding-right: 5rem; }
-.sm\:pr-24 { padding-right: 6rem; }
-.sm\:pr-32 { padding-right: 8rem; }
-.sm\:px-0 { padding-left: 0; padding-right: 0; }
-.sm\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.sm\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.sm\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.sm\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.sm\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.sm\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.sm\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.sm\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.sm\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.sm\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.sm\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.sm\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.sm\:py-0 { padding-top: 0; padding-bottom: 0; }
-.sm\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.sm\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.sm\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.sm\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.sm\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.sm\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.sm\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.sm\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.sm\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.sm\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.sm\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.sm\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.sm\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.sm\:gap-0 { gap: 0; }
-.sm\:gap-1 { gap: 0.25rem; }
-.sm\:gap-2 { gap: 0.5rem; }
-.sm\:gap-3 { gap: 0.75rem; }
-.sm\:gap-4 { gap: 1rem; }
-.sm\:gap-5 { gap: 1.25rem; }
-.sm\:gap-6 { gap: 1.5rem; }
-.sm\:gap-8 { gap: 2rem; }
-.sm\:gap-10 { gap: 2.5rem; }
-.sm\:gap-12 { gap: 3rem; }
-.sm\:gap-16 { gap: 4rem; }
-.sm\:gap-20 { gap: 5rem; }
-.sm\:gap-24 { gap: 6rem; }
-.sm\:gap-32 { gap: 8rem; }
+.sm-m-0 { margin: 0; }
+.sm-m-1 { margin: 0.25rem; }
+.sm-m-2 { margin: 0.5rem; }
+.sm-m-3 { margin: 0.75rem; }
+.sm-m-4 { margin: 1rem; }
+.sm-m-5 { margin: 1.25rem; }
+.sm-m-6 { margin: 1.5rem; }
+.sm-m-8 { margin: 2rem; }
+.sm-m-10 { margin: 2.5rem; }
+.sm-m-12 { margin: 3rem; }
+.sm-m-16 { margin: 4rem; }
+.sm-m-20 { margin: 5rem; }
+.sm-m-24 { margin: 6rem; }
+.sm-m-32 { margin: 8rem; }
+.sm-mt-0 { margin-top: 0; }
+.sm-mt-1 { margin-top: 0.25rem; }
+.sm-mt-2 { margin-top: 0.5rem; }
+.sm-mt-3 { margin-top: 0.75rem; }
+.sm-mt-4 { margin-top: 1rem; }
+.sm-mt-5 { margin-top: 1.25rem; }
+.sm-mt-6 { margin-top: 1.5rem; }
+.sm-mt-8 { margin-top: 2rem; }
+.sm-mt-10 { margin-top: 2.5rem; }
+.sm-mt-12 { margin-top: 3rem; }
+.sm-mt-16 { margin-top: 4rem; }
+.sm-mt-20 { margin-top: 5rem; }
+.sm-mt-24 { margin-top: 6rem; }
+.sm-mt-32 { margin-top: 8rem; }
+.sm-mb-0 { margin-bottom: 0; }
+.sm-mb-1 { margin-bottom: 0.25rem; }
+.sm-mb-2 { margin-bottom: 0.5rem; }
+.sm-mb-3 { margin-bottom: 0.75rem; }
+.sm-mb-4 { margin-bottom: 1rem; }
+.sm-mb-5 { margin-bottom: 1.25rem; }
+.sm-mb-6 { margin-bottom: 1.5rem; }
+.sm-mb-8 { margin-bottom: 2rem; }
+.sm-mb-10 { margin-bottom: 2.5rem; }
+.sm-mb-12 { margin-bottom: 3rem; }
+.sm-mb-16 { margin-bottom: 4rem; }
+.sm-mb-20 { margin-bottom: 5rem; }
+.sm-mb-24 { margin-bottom: 6rem; }
+.sm-mb-32 { margin-bottom: 8rem; }
+.sm-ml-0 { margin-left: 0; }
+.sm-ml-1 { margin-left: 0.25rem; }
+.sm-ml-2 { margin-left: 0.5rem; }
+.sm-ml-3 { margin-left: 0.75rem; }
+.sm-ml-4 { margin-left: 1rem; }
+.sm-ml-5 { margin-left: 1.25rem; }
+.sm-ml-6 { margin-left: 1.5rem; }
+.sm-ml-8 { margin-left: 2rem; }
+.sm-ml-10 { margin-left: 2.5rem; }
+.sm-ml-12 { margin-left: 3rem; }
+.sm-ml-16 { margin-left: 4rem; }
+.sm-ml-20 { margin-left: 5rem; }
+.sm-ml-24 { margin-left: 6rem; }
+.sm-ml-32 { margin-left: 8rem; }
+.sm-mr-0 { margin-right: 0; }
+.sm-mr-1 { margin-right: 0.25rem; }
+.sm-mr-2 { margin-right: 0.5rem; }
+.sm-mr-3 { margin-right: 0.75rem; }
+.sm-mr-4 { margin-right: 1rem; }
+.sm-mr-5 { margin-right: 1.25rem; }
+.sm-mr-6 { margin-right: 1.5rem; }
+.sm-mr-8 { margin-right: 2rem; }
+.sm-mr-10 { margin-right: 2.5rem; }
+.sm-mr-12 { margin-right: 3rem; }
+.sm-mr-16 { margin-right: 4rem; }
+.sm-mr-20 { margin-right: 5rem; }
+.sm-mr-24 { margin-right: 6rem; }
+.sm-mr-32 { margin-right: 8rem; }
+.sm-mx-0 { margin-left: 0; margin-right: 0; }
+.sm-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.sm-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.sm-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.sm-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.sm-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.sm-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.sm-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.sm-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.sm-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.sm-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.sm-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.sm-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.sm-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.sm-my-0 { margin-top: 0; margin-bottom: 0; }
+.sm-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.sm-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.sm-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.sm-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.sm-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.sm-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.sm-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.sm-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.sm-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.sm-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.sm-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.sm-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.sm-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.sm-p-0 { padding: 0; }
+.sm-p-1 { padding: 0.25rem; }
+.sm-p-2 { padding: 0.5rem; }
+.sm-p-3 { padding: 0.75rem; }
+.sm-p-4 { padding: 1rem; }
+.sm-p-5 { padding: 1.25rem; }
+.sm-p-6 { padding: 1.5rem; }
+.sm-p-8 { padding: 2rem; }
+.sm-p-10 { padding: 2.5rem; }
+.sm-p-12 { padding: 3rem; }
+.sm-p-16 { padding: 4rem; }
+.sm-p-20 { padding: 5rem; }
+.sm-p-24 { padding: 6rem; }
+.sm-p-32 { padding: 8rem; }
+.sm-pt-0 { padding-top: 0; }
+.sm-pt-1 { padding-top: 0.25rem; }
+.sm-pt-2 { padding-top: 0.5rem; }
+.sm-pt-3 { padding-top: 0.75rem; }
+.sm-pt-4 { padding-top: 1rem; }
+.sm-pt-5 { padding-top: 1.25rem; }
+.sm-pt-6 { padding-top: 1.5rem; }
+.sm-pt-8 { padding-top: 2rem; }
+.sm-pt-10 { padding-top: 2.5rem; }
+.sm-pt-12 { padding-top: 3rem; }
+.sm-pt-16 { padding-top: 4rem; }
+.sm-pt-20 { padding-top: 5rem; }
+.sm-pt-24 { padding-top: 6rem; }
+.sm-pt-32 { padding-top: 8rem; }
+.sm-pb-0 { padding-bottom: 0; }
+.sm-pb-1 { padding-bottom: 0.25rem; }
+.sm-pb-2 { padding-bottom: 0.5rem; }
+.sm-pb-3 { padding-bottom: 0.75rem; }
+.sm-pb-4 { padding-bottom: 1rem; }
+.sm-pb-5 { padding-bottom: 1.25rem; }
+.sm-pb-6 { padding-bottom: 1.5rem; }
+.sm-pb-8 { padding-bottom: 2rem; }
+.sm-pb-10 { padding-bottom: 2.5rem; }
+.sm-pb-12 { padding-bottom: 3rem; }
+.sm-pb-16 { padding-bottom: 4rem; }
+.sm-pb-20 { padding-bottom: 5rem; }
+.sm-pb-24 { padding-bottom: 6rem; }
+.sm-pb-32 { padding-bottom: 8rem; }
+.sm-pl-0 { padding-left: 0; }
+.sm-pl-1 { padding-left: 0.25rem; }
+.sm-pl-2 { padding-left: 0.5rem; }
+.sm-pl-3 { padding-left: 0.75rem; }
+.sm-pl-4 { padding-left: 1rem; }
+.sm-pl-5 { padding-left: 1.25rem; }
+.sm-pl-6 { padding-left: 1.5rem; }
+.sm-pl-8 { padding-left: 2rem; }
+.sm-pl-10 { padding-left: 2.5rem; }
+.sm-pl-12 { padding-left: 3rem; }
+.sm-pl-16 { padding-left: 4rem; }
+.sm-pl-20 { padding-left: 5rem; }
+.sm-pl-24 { padding-left: 6rem; }
+.sm-pl-32 { padding-left: 8rem; }
+.sm-pr-0 { padding-right: 0; }
+.sm-pr-1 { padding-right: 0.25rem; }
+.sm-pr-2 { padding-right: 0.5rem; }
+.sm-pr-3 { padding-right: 0.75rem; }
+.sm-pr-4 { padding-right: 1rem; }
+.sm-pr-5 { padding-right: 1.25rem; }
+.sm-pr-6 { padding-right: 1.5rem; }
+.sm-pr-8 { padding-right: 2rem; }
+.sm-pr-10 { padding-right: 2.5rem; }
+.sm-pr-12 { padding-right: 3rem; }
+.sm-pr-16 { padding-right: 4rem; }
+.sm-pr-20 { padding-right: 5rem; }
+.sm-pr-24 { padding-right: 6rem; }
+.sm-pr-32 { padding-right: 8rem; }
+.sm-px-0 { padding-left: 0; padding-right: 0; }
+.sm-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.sm-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.sm-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.sm-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.sm-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.sm-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.sm-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.sm-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.sm-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.sm-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.sm-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.sm-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.sm-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.sm-py-0 { padding-top: 0; padding-bottom: 0; }
+.sm-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.sm-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.sm-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.sm-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.sm-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.sm-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.sm-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.sm-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.sm-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.sm-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.sm-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.sm-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.sm-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.sm-gap-0 { gap: 0; }
+.sm-gap-1 { gap: 0.25rem; }
+.sm-gap-2 { gap: 0.5rem; }
+.sm-gap-3 { gap: 0.75rem; }
+.sm-gap-4 { gap: 1rem; }
+.sm-gap-5 { gap: 1.25rem; }
+.sm-gap-6 { gap: 1.5rem; }
+.sm-gap-8 { gap: 2rem; }
+.sm-gap-10 { gap: 2.5rem; }
+.sm-gap-12 { gap: 3rem; }
+.sm-gap-16 { gap: 4rem; }
+.sm-gap-20 { gap: 5rem; }
+.sm-gap-24 { gap: 6rem; }
+.sm-gap-32 { gap: 8rem; }
 }
 @media (width >= 48rem) {
-.md\:m-0 { margin: 0; }
-.md\:m-1 { margin: 0.25rem; }
-.md\:m-2 { margin: 0.5rem; }
-.md\:m-3 { margin: 0.75rem; }
-.md\:m-4 { margin: 1rem; }
-.md\:m-5 { margin: 1.25rem; }
-.md\:m-6 { margin: 1.5rem; }
-.md\:m-8 { margin: 2rem; }
-.md\:m-10 { margin: 2.5rem; }
-.md\:m-12 { margin: 3rem; }
-.md\:m-16 { margin: 4rem; }
-.md\:m-20 { margin: 5rem; }
-.md\:m-24 { margin: 6rem; }
-.md\:m-32 { margin: 8rem; }
-.md\:mt-0 { margin-top: 0; }
-.md\:mt-1 { margin-top: 0.25rem; }
-.md\:mt-2 { margin-top: 0.5rem; }
-.md\:mt-3 { margin-top: 0.75rem; }
-.md\:mt-4 { margin-top: 1rem; }
-.md\:mt-5 { margin-top: 1.25rem; }
-.md\:mt-6 { margin-top: 1.5rem; }
-.md\:mt-8 { margin-top: 2rem; }
-.md\:mt-10 { margin-top: 2.5rem; }
-.md\:mt-12 { margin-top: 3rem; }
-.md\:mt-16 { margin-top: 4rem; }
-.md\:mt-20 { margin-top: 5rem; }
-.md\:mt-24 { margin-top: 6rem; }
-.md\:mt-32 { margin-top: 8rem; }
-.md\:mb-0 { margin-bottom: 0; }
-.md\:mb-1 { margin-bottom: 0.25rem; }
-.md\:mb-2 { margin-bottom: 0.5rem; }
-.md\:mb-3 { margin-bottom: 0.75rem; }
-.md\:mb-4 { margin-bottom: 1rem; }
-.md\:mb-5 { margin-bottom: 1.25rem; }
-.md\:mb-6 { margin-bottom: 1.5rem; }
-.md\:mb-8 { margin-bottom: 2rem; }
-.md\:mb-10 { margin-bottom: 2.5rem; }
-.md\:mb-12 { margin-bottom: 3rem; }
-.md\:mb-16 { margin-bottom: 4rem; }
-.md\:mb-20 { margin-bottom: 5rem; }
-.md\:mb-24 { margin-bottom: 6rem; }
-.md\:mb-32 { margin-bottom: 8rem; }
-.md\:ml-0 { margin-left: 0; }
-.md\:ml-1 { margin-left: 0.25rem; }
-.md\:ml-2 { margin-left: 0.5rem; }
-.md\:ml-3 { margin-left: 0.75rem; }
-.md\:ml-4 { margin-left: 1rem; }
-.md\:ml-5 { margin-left: 1.25rem; }
-.md\:ml-6 { margin-left: 1.5rem; }
-.md\:ml-8 { margin-left: 2rem; }
-.md\:ml-10 { margin-left: 2.5rem; }
-.md\:ml-12 { margin-left: 3rem; }
-.md\:ml-16 { margin-left: 4rem; }
-.md\:ml-20 { margin-left: 5rem; }
-.md\:ml-24 { margin-left: 6rem; }
-.md\:ml-32 { margin-left: 8rem; }
-.md\:mr-0 { margin-right: 0; }
-.md\:mr-1 { margin-right: 0.25rem; }
-.md\:mr-2 { margin-right: 0.5rem; }
-.md\:mr-3 { margin-right: 0.75rem; }
-.md\:mr-4 { margin-right: 1rem; }
-.md\:mr-5 { margin-right: 1.25rem; }
-.md\:mr-6 { margin-right: 1.5rem; }
-.md\:mr-8 { margin-right: 2rem; }
-.md\:mr-10 { margin-right: 2.5rem; }
-.md\:mr-12 { margin-right: 3rem; }
-.md\:mr-16 { margin-right: 4rem; }
-.md\:mr-20 { margin-right: 5rem; }
-.md\:mr-24 { margin-right: 6rem; }
-.md\:mr-32 { margin-right: 8rem; }
-.md\:mx-0 { margin-left: 0; margin-right: 0; }
-.md\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.md\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.md\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.md\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.md\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.md\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.md\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.md\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.md\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.md\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.md\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.md\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.md\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.md\:my-0 { margin-top: 0; margin-bottom: 0; }
-.md\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.md\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.md\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.md\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.md\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.md\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.md\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.md\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.md\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.md\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.md\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.md\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.md\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.md\:p-0 { padding: 0; }
-.md\:p-1 { padding: 0.25rem; }
-.md\:p-2 { padding: 0.5rem; }
-.md\:p-3 { padding: 0.75rem; }
-.md\:p-4 { padding: 1rem; }
-.md\:p-5 { padding: 1.25rem; }
-.md\:p-6 { padding: 1.5rem; }
-.md\:p-8 { padding: 2rem; }
-.md\:p-10 { padding: 2.5rem; }
-.md\:p-12 { padding: 3rem; }
-.md\:p-16 { padding: 4rem; }
-.md\:p-20 { padding: 5rem; }
-.md\:p-24 { padding: 6rem; }
-.md\:p-32 { padding: 8rem; }
-.md\:pt-0 { padding-top: 0; }
-.md\:pt-1 { padding-top: 0.25rem; }
-.md\:pt-2 { padding-top: 0.5rem; }
-.md\:pt-3 { padding-top: 0.75rem; }
-.md\:pt-4 { padding-top: 1rem; }
-.md\:pt-5 { padding-top: 1.25rem; }
-.md\:pt-6 { padding-top: 1.5rem; }
-.md\:pt-8 { padding-top: 2rem; }
-.md\:pt-10 { padding-top: 2.5rem; }
-.md\:pt-12 { padding-top: 3rem; }
-.md\:pt-16 { padding-top: 4rem; }
-.md\:pt-20 { padding-top: 5rem; }
-.md\:pt-24 { padding-top: 6rem; }
-.md\:pt-32 { padding-top: 8rem; }
-.md\:pb-0 { padding-bottom: 0; }
-.md\:pb-1 { padding-bottom: 0.25rem; }
-.md\:pb-2 { padding-bottom: 0.5rem; }
-.md\:pb-3 { padding-bottom: 0.75rem; }
-.md\:pb-4 { padding-bottom: 1rem; }
-.md\:pb-5 { padding-bottom: 1.25rem; }
-.md\:pb-6 { padding-bottom: 1.5rem; }
-.md\:pb-8 { padding-bottom: 2rem; }
-.md\:pb-10 { padding-bottom: 2.5rem; }
-.md\:pb-12 { padding-bottom: 3rem; }
-.md\:pb-16 { padding-bottom: 4rem; }
-.md\:pb-20 { padding-bottom: 5rem; }
-.md\:pb-24 { padding-bottom: 6rem; }
-.md\:pb-32 { padding-bottom: 8rem; }
-.md\:pl-0 { padding-left: 0; }
-.md\:pl-1 { padding-left: 0.25rem; }
-.md\:pl-2 { padding-left: 0.5rem; }
-.md\:pl-3 { padding-left: 0.75rem; }
-.md\:pl-4 { padding-left: 1rem; }
-.md\:pl-5 { padding-left: 1.25rem; }
-.md\:pl-6 { padding-left: 1.5rem; }
-.md\:pl-8 { padding-left: 2rem; }
-.md\:pl-10 { padding-left: 2.5rem; }
-.md\:pl-12 { padding-left: 3rem; }
-.md\:pl-16 { padding-left: 4rem; }
-.md\:pl-20 { padding-left: 5rem; }
-.md\:pl-24 { padding-left: 6rem; }
-.md\:pl-32 { padding-left: 8rem; }
-.md\:pr-0 { padding-right: 0; }
-.md\:pr-1 { padding-right: 0.25rem; }
-.md\:pr-2 { padding-right: 0.5rem; }
-.md\:pr-3 { padding-right: 0.75rem; }
-.md\:pr-4 { padding-right: 1rem; }
-.md\:pr-5 { padding-right: 1.25rem; }
-.md\:pr-6 { padding-right: 1.5rem; }
-.md\:pr-8 { padding-right: 2rem; }
-.md\:pr-10 { padding-right: 2.5rem; }
-.md\:pr-12 { padding-right: 3rem; }
-.md\:pr-16 { padding-right: 4rem; }
-.md\:pr-20 { padding-right: 5rem; }
-.md\:pr-24 { padding-right: 6rem; }
-.md\:pr-32 { padding-right: 8rem; }
-.md\:px-0 { padding-left: 0; padding-right: 0; }
-.md\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.md\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.md\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.md\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.md\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.md\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.md\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.md\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.md\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.md\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.md\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.md\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.md\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.md\:py-0 { padding-top: 0; padding-bottom: 0; }
-.md\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.md\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.md\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.md\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.md\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.md\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.md\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.md\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.md\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.md\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.md\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.md\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.md\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.md\:gap-0 { gap: 0; }
-.md\:gap-1 { gap: 0.25rem; }
-.md\:gap-2 { gap: 0.5rem; }
-.md\:gap-3 { gap: 0.75rem; }
-.md\:gap-4 { gap: 1rem; }
-.md\:gap-5 { gap: 1.25rem; }
-.md\:gap-6 { gap: 1.5rem; }
-.md\:gap-8 { gap: 2rem; }
-.md\:gap-10 { gap: 2.5rem; }
-.md\:gap-12 { gap: 3rem; }
-.md\:gap-16 { gap: 4rem; }
-.md\:gap-20 { gap: 5rem; }
-.md\:gap-24 { gap: 6rem; }
-.md\:gap-32 { gap: 8rem; }
+.md-m-0 { margin: 0; }
+.md-m-1 { margin: 0.25rem; }
+.md-m-2 { margin: 0.5rem; }
+.md-m-3 { margin: 0.75rem; }
+.md-m-4 { margin: 1rem; }
+.md-m-5 { margin: 1.25rem; }
+.md-m-6 { margin: 1.5rem; }
+.md-m-8 { margin: 2rem; }
+.md-m-10 { margin: 2.5rem; }
+.md-m-12 { margin: 3rem; }
+.md-m-16 { margin: 4rem; }
+.md-m-20 { margin: 5rem; }
+.md-m-24 { margin: 6rem; }
+.md-m-32 { margin: 8rem; }
+.md-mt-0 { margin-top: 0; }
+.md-mt-1 { margin-top: 0.25rem; }
+.md-mt-2 { margin-top: 0.5rem; }
+.md-mt-3 { margin-top: 0.75rem; }
+.md-mt-4 { margin-top: 1rem; }
+.md-mt-5 { margin-top: 1.25rem; }
+.md-mt-6 { margin-top: 1.5rem; }
+.md-mt-8 { margin-top: 2rem; }
+.md-mt-10 { margin-top: 2.5rem; }
+.md-mt-12 { margin-top: 3rem; }
+.md-mt-16 { margin-top: 4rem; }
+.md-mt-20 { margin-top: 5rem; }
+.md-mt-24 { margin-top: 6rem; }
+.md-mt-32 { margin-top: 8rem; }
+.md-mb-0 { margin-bottom: 0; }
+.md-mb-1 { margin-bottom: 0.25rem; }
+.md-mb-2 { margin-bottom: 0.5rem; }
+.md-mb-3 { margin-bottom: 0.75rem; }
+.md-mb-4 { margin-bottom: 1rem; }
+.md-mb-5 { margin-bottom: 1.25rem; }
+.md-mb-6 { margin-bottom: 1.5rem; }
+.md-mb-8 { margin-bottom: 2rem; }
+.md-mb-10 { margin-bottom: 2.5rem; }
+.md-mb-12 { margin-bottom: 3rem; }
+.md-mb-16 { margin-bottom: 4rem; }
+.md-mb-20 { margin-bottom: 5rem; }
+.md-mb-24 { margin-bottom: 6rem; }
+.md-mb-32 { margin-bottom: 8rem; }
+.md-ml-0 { margin-left: 0; }
+.md-ml-1 { margin-left: 0.25rem; }
+.md-ml-2 { margin-left: 0.5rem; }
+.md-ml-3 { margin-left: 0.75rem; }
+.md-ml-4 { margin-left: 1rem; }
+.md-ml-5 { margin-left: 1.25rem; }
+.md-ml-6 { margin-left: 1.5rem; }
+.md-ml-8 { margin-left: 2rem; }
+.md-ml-10 { margin-left: 2.5rem; }
+.md-ml-12 { margin-left: 3rem; }
+.md-ml-16 { margin-left: 4rem; }
+.md-ml-20 { margin-left: 5rem; }
+.md-ml-24 { margin-left: 6rem; }
+.md-ml-32 { margin-left: 8rem; }
+.md-mr-0 { margin-right: 0; }
+.md-mr-1 { margin-right: 0.25rem; }
+.md-mr-2 { margin-right: 0.5rem; }
+.md-mr-3 { margin-right: 0.75rem; }
+.md-mr-4 { margin-right: 1rem; }
+.md-mr-5 { margin-right: 1.25rem; }
+.md-mr-6 { margin-right: 1.5rem; }
+.md-mr-8 { margin-right: 2rem; }
+.md-mr-10 { margin-right: 2.5rem; }
+.md-mr-12 { margin-right: 3rem; }
+.md-mr-16 { margin-right: 4rem; }
+.md-mr-20 { margin-right: 5rem; }
+.md-mr-24 { margin-right: 6rem; }
+.md-mr-32 { margin-right: 8rem; }
+.md-mx-0 { margin-left: 0; margin-right: 0; }
+.md-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.md-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.md-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.md-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.md-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.md-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.md-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.md-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.md-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.md-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.md-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.md-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.md-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.md-my-0 { margin-top: 0; margin-bottom: 0; }
+.md-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.md-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.md-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.md-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.md-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.md-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.md-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.md-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.md-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.md-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.md-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.md-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.md-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.md-p-0 { padding: 0; }
+.md-p-1 { padding: 0.25rem; }
+.md-p-2 { padding: 0.5rem; }
+.md-p-3 { padding: 0.75rem; }
+.md-p-4 { padding: 1rem; }
+.md-p-5 { padding: 1.25rem; }
+.md-p-6 { padding: 1.5rem; }
+.md-p-8 { padding: 2rem; }
+.md-p-10 { padding: 2.5rem; }
+.md-p-12 { padding: 3rem; }
+.md-p-16 { padding: 4rem; }
+.md-p-20 { padding: 5rem; }
+.md-p-24 { padding: 6rem; }
+.md-p-32 { padding: 8rem; }
+.md-pt-0 { padding-top: 0; }
+.md-pt-1 { padding-top: 0.25rem; }
+.md-pt-2 { padding-top: 0.5rem; }
+.md-pt-3 { padding-top: 0.75rem; }
+.md-pt-4 { padding-top: 1rem; }
+.md-pt-5 { padding-top: 1.25rem; }
+.md-pt-6 { padding-top: 1.5rem; }
+.md-pt-8 { padding-top: 2rem; }
+.md-pt-10 { padding-top: 2.5rem; }
+.md-pt-12 { padding-top: 3rem; }
+.md-pt-16 { padding-top: 4rem; }
+.md-pt-20 { padding-top: 5rem; }
+.md-pt-24 { padding-top: 6rem; }
+.md-pt-32 { padding-top: 8rem; }
+.md-pb-0 { padding-bottom: 0; }
+.md-pb-1 { padding-bottom: 0.25rem; }
+.md-pb-2 { padding-bottom: 0.5rem; }
+.md-pb-3 { padding-bottom: 0.75rem; }
+.md-pb-4 { padding-bottom: 1rem; }
+.md-pb-5 { padding-bottom: 1.25rem; }
+.md-pb-6 { padding-bottom: 1.5rem; }
+.md-pb-8 { padding-bottom: 2rem; }
+.md-pb-10 { padding-bottom: 2.5rem; }
+.md-pb-12 { padding-bottom: 3rem; }
+.md-pb-16 { padding-bottom: 4rem; }
+.md-pb-20 { padding-bottom: 5rem; }
+.md-pb-24 { padding-bottom: 6rem; }
+.md-pb-32 { padding-bottom: 8rem; }
+.md-pl-0 { padding-left: 0; }
+.md-pl-1 { padding-left: 0.25rem; }
+.md-pl-2 { padding-left: 0.5rem; }
+.md-pl-3 { padding-left: 0.75rem; }
+.md-pl-4 { padding-left: 1rem; }
+.md-pl-5 { padding-left: 1.25rem; }
+.md-pl-6 { padding-left: 1.5rem; }
+.md-pl-8 { padding-left: 2rem; }
+.md-pl-10 { padding-left: 2.5rem; }
+.md-pl-12 { padding-left: 3rem; }
+.md-pl-16 { padding-left: 4rem; }
+.md-pl-20 { padding-left: 5rem; }
+.md-pl-24 { padding-left: 6rem; }
+.md-pl-32 { padding-left: 8rem; }
+.md-pr-0 { padding-right: 0; }
+.md-pr-1 { padding-right: 0.25rem; }
+.md-pr-2 { padding-right: 0.5rem; }
+.md-pr-3 { padding-right: 0.75rem; }
+.md-pr-4 { padding-right: 1rem; }
+.md-pr-5 { padding-right: 1.25rem; }
+.md-pr-6 { padding-right: 1.5rem; }
+.md-pr-8 { padding-right: 2rem; }
+.md-pr-10 { padding-right: 2.5rem; }
+.md-pr-12 { padding-right: 3rem; }
+.md-pr-16 { padding-right: 4rem; }
+.md-pr-20 { padding-right: 5rem; }
+.md-pr-24 { padding-right: 6rem; }
+.md-pr-32 { padding-right: 8rem; }
+.md-px-0 { padding-left: 0; padding-right: 0; }
+.md-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.md-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.md-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.md-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.md-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.md-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.md-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.md-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.md-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.md-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.md-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.md-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.md-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.md-py-0 { padding-top: 0; padding-bottom: 0; }
+.md-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.md-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.md-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.md-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.md-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.md-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.md-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.md-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.md-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.md-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.md-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.md-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.md-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.md-gap-0 { gap: 0; }
+.md-gap-1 { gap: 0.25rem; }
+.md-gap-2 { gap: 0.5rem; }
+.md-gap-3 { gap: 0.75rem; }
+.md-gap-4 { gap: 1rem; }
+.md-gap-5 { gap: 1.25rem; }
+.md-gap-6 { gap: 1.5rem; }
+.md-gap-8 { gap: 2rem; }
+.md-gap-10 { gap: 2.5rem; }
+.md-gap-12 { gap: 3rem; }
+.md-gap-16 { gap: 4rem; }
+.md-gap-20 { gap: 5rem; }
+.md-gap-24 { gap: 6rem; }
+.md-gap-32 { gap: 8rem; }
 }
 @media (width >= 62rem) {
-.lg\:m-0 { margin: 0; }
-.lg\:m-1 { margin: 0.25rem; }
-.lg\:m-2 { margin: 0.5rem; }
-.lg\:m-3 { margin: 0.75rem; }
-.lg\:m-4 { margin: 1rem; }
-.lg\:m-5 { margin: 1.25rem; }
-.lg\:m-6 { margin: 1.5rem; }
-.lg\:m-8 { margin: 2rem; }
-.lg\:m-10 { margin: 2.5rem; }
-.lg\:m-12 { margin: 3rem; }
-.lg\:m-16 { margin: 4rem; }
-.lg\:m-20 { margin: 5rem; }
-.lg\:m-24 { margin: 6rem; }
-.lg\:m-32 { margin: 8rem; }
-.lg\:mt-0 { margin-top: 0; }
-.lg\:mt-1 { margin-top: 0.25rem; }
-.lg\:mt-2 { margin-top: 0.5rem; }
-.lg\:mt-3 { margin-top: 0.75rem; }
-.lg\:mt-4 { margin-top: 1rem; }
-.lg\:mt-5 { margin-top: 1.25rem; }
-.lg\:mt-6 { margin-top: 1.5rem; }
-.lg\:mt-8 { margin-top: 2rem; }
-.lg\:mt-10 { margin-top: 2.5rem; }
-.lg\:mt-12 { margin-top: 3rem; }
-.lg\:mt-16 { margin-top: 4rem; }
-.lg\:mt-20 { margin-top: 5rem; }
-.lg\:mt-24 { margin-top: 6rem; }
-.lg\:mt-32 { margin-top: 8rem; }
-.lg\:mb-0 { margin-bottom: 0; }
-.lg\:mb-1 { margin-bottom: 0.25rem; }
-.lg\:mb-2 { margin-bottom: 0.5rem; }
-.lg\:mb-3 { margin-bottom: 0.75rem; }
-.lg\:mb-4 { margin-bottom: 1rem; }
-.lg\:mb-5 { margin-bottom: 1.25rem; }
-.lg\:mb-6 { margin-bottom: 1.5rem; }
-.lg\:mb-8 { margin-bottom: 2rem; }
-.lg\:mb-10 { margin-bottom: 2.5rem; }
-.lg\:mb-12 { margin-bottom: 3rem; }
-.lg\:mb-16 { margin-bottom: 4rem; }
-.lg\:mb-20 { margin-bottom: 5rem; }
-.lg\:mb-24 { margin-bottom: 6rem; }
-.lg\:mb-32 { margin-bottom: 8rem; }
-.lg\:ml-0 { margin-left: 0; }
-.lg\:ml-1 { margin-left: 0.25rem; }
-.lg\:ml-2 { margin-left: 0.5rem; }
-.lg\:ml-3 { margin-left: 0.75rem; }
-.lg\:ml-4 { margin-left: 1rem; }
-.lg\:ml-5 { margin-left: 1.25rem; }
-.lg\:ml-6 { margin-left: 1.5rem; }
-.lg\:ml-8 { margin-left: 2rem; }
-.lg\:ml-10 { margin-left: 2.5rem; }
-.lg\:ml-12 { margin-left: 3rem; }
-.lg\:ml-16 { margin-left: 4rem; }
-.lg\:ml-20 { margin-left: 5rem; }
-.lg\:ml-24 { margin-left: 6rem; }
-.lg\:ml-32 { margin-left: 8rem; }
-.lg\:mr-0 { margin-right: 0; }
-.lg\:mr-1 { margin-right: 0.25rem; }
-.lg\:mr-2 { margin-right: 0.5rem; }
-.lg\:mr-3 { margin-right: 0.75rem; }
-.lg\:mr-4 { margin-right: 1rem; }
-.lg\:mr-5 { margin-right: 1.25rem; }
-.lg\:mr-6 { margin-right: 1.5rem; }
-.lg\:mr-8 { margin-right: 2rem; }
-.lg\:mr-10 { margin-right: 2.5rem; }
-.lg\:mr-12 { margin-right: 3rem; }
-.lg\:mr-16 { margin-right: 4rem; }
-.lg\:mr-20 { margin-right: 5rem; }
-.lg\:mr-24 { margin-right: 6rem; }
-.lg\:mr-32 { margin-right: 8rem; }
-.lg\:mx-0 { margin-left: 0; margin-right: 0; }
-.lg\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.lg\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.lg\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.lg\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.lg\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.lg\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.lg\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.lg\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.lg\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.lg\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.lg\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.lg\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.lg\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.lg\:my-0 { margin-top: 0; margin-bottom: 0; }
-.lg\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.lg\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.lg\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.lg\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.lg\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.lg\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.lg\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.lg\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.lg\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.lg\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.lg\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.lg\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.lg\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.lg\:p-0 { padding: 0; }
-.lg\:p-1 { padding: 0.25rem; }
-.lg\:p-2 { padding: 0.5rem; }
-.lg\:p-3 { padding: 0.75rem; }
-.lg\:p-4 { padding: 1rem; }
-.lg\:p-5 { padding: 1.25rem; }
-.lg\:p-6 { padding: 1.5rem; }
-.lg\:p-8 { padding: 2rem; }
-.lg\:p-10 { padding: 2.5rem; }
-.lg\:p-12 { padding: 3rem; }
-.lg\:p-16 { padding: 4rem; }
-.lg\:p-20 { padding: 5rem; }
-.lg\:p-24 { padding: 6rem; }
-.lg\:p-32 { padding: 8rem; }
-.lg\:pt-0 { padding-top: 0; }
-.lg\:pt-1 { padding-top: 0.25rem; }
-.lg\:pt-2 { padding-top: 0.5rem; }
-.lg\:pt-3 { padding-top: 0.75rem; }
-.lg\:pt-4 { padding-top: 1rem; }
-.lg\:pt-5 { padding-top: 1.25rem; }
-.lg\:pt-6 { padding-top: 1.5rem; }
-.lg\:pt-8 { padding-top: 2rem; }
-.lg\:pt-10 { padding-top: 2.5rem; }
-.lg\:pt-12 { padding-top: 3rem; }
-.lg\:pt-16 { padding-top: 4rem; }
-.lg\:pt-20 { padding-top: 5rem; }
-.lg\:pt-24 { padding-top: 6rem; }
-.lg\:pt-32 { padding-top: 8rem; }
-.lg\:pb-0 { padding-bottom: 0; }
-.lg\:pb-1 { padding-bottom: 0.25rem; }
-.lg\:pb-2 { padding-bottom: 0.5rem; }
-.lg\:pb-3 { padding-bottom: 0.75rem; }
-.lg\:pb-4 { padding-bottom: 1rem; }
-.lg\:pb-5 { padding-bottom: 1.25rem; }
-.lg\:pb-6 { padding-bottom: 1.5rem; }
-.lg\:pb-8 { padding-bottom: 2rem; }
-.lg\:pb-10 { padding-bottom: 2.5rem; }
-.lg\:pb-12 { padding-bottom: 3rem; }
-.lg\:pb-16 { padding-bottom: 4rem; }
-.lg\:pb-20 { padding-bottom: 5rem; }
-.lg\:pb-24 { padding-bottom: 6rem; }
-.lg\:pb-32 { padding-bottom: 8rem; }
-.lg\:pl-0 { padding-left: 0; }
-.lg\:pl-1 { padding-left: 0.25rem; }
-.lg\:pl-2 { padding-left: 0.5rem; }
-.lg\:pl-3 { padding-left: 0.75rem; }
-.lg\:pl-4 { padding-left: 1rem; }
-.lg\:pl-5 { padding-left: 1.25rem; }
-.lg\:pl-6 { padding-left: 1.5rem; }
-.lg\:pl-8 { padding-left: 2rem; }
-.lg\:pl-10 { padding-left: 2.5rem; }
-.lg\:pl-12 { padding-left: 3rem; }
-.lg\:pl-16 { padding-left: 4rem; }
-.lg\:pl-20 { padding-left: 5rem; }
-.lg\:pl-24 { padding-left: 6rem; }
-.lg\:pl-32 { padding-left: 8rem; }
-.lg\:pr-0 { padding-right: 0; }
-.lg\:pr-1 { padding-right: 0.25rem; }
-.lg\:pr-2 { padding-right: 0.5rem; }
-.lg\:pr-3 { padding-right: 0.75rem; }
-.lg\:pr-4 { padding-right: 1rem; }
-.lg\:pr-5 { padding-right: 1.25rem; }
-.lg\:pr-6 { padding-right: 1.5rem; }
-.lg\:pr-8 { padding-right: 2rem; }
-.lg\:pr-10 { padding-right: 2.5rem; }
-.lg\:pr-12 { padding-right: 3rem; }
-.lg\:pr-16 { padding-right: 4rem; }
-.lg\:pr-20 { padding-right: 5rem; }
-.lg\:pr-24 { padding-right: 6rem; }
-.lg\:pr-32 { padding-right: 8rem; }
-.lg\:px-0 { padding-left: 0; padding-right: 0; }
-.lg\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.lg\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.lg\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.lg\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.lg\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.lg\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.lg\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.lg\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.lg\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.lg\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.lg\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.lg\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.lg\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.lg\:py-0 { padding-top: 0; padding-bottom: 0; }
-.lg\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.lg\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.lg\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.lg\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.lg\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.lg\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.lg\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.lg\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.lg\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.lg\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.lg\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.lg\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.lg\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.lg\:gap-0 { gap: 0; }
-.lg\:gap-1 { gap: 0.25rem; }
-.lg\:gap-2 { gap: 0.5rem; }
-.lg\:gap-3 { gap: 0.75rem; }
-.lg\:gap-4 { gap: 1rem; }
-.lg\:gap-5 { gap: 1.25rem; }
-.lg\:gap-6 { gap: 1.5rem; }
-.lg\:gap-8 { gap: 2rem; }
-.lg\:gap-10 { gap: 2.5rem; }
-.lg\:gap-12 { gap: 3rem; }
-.lg\:gap-16 { gap: 4rem; }
-.lg\:gap-20 { gap: 5rem; }
-.lg\:gap-24 { gap: 6rem; }
-.lg\:gap-32 { gap: 8rem; }
+.lg-m-0 { margin: 0; }
+.lg-m-1 { margin: 0.25rem; }
+.lg-m-2 { margin: 0.5rem; }
+.lg-m-3 { margin: 0.75rem; }
+.lg-m-4 { margin: 1rem; }
+.lg-m-5 { margin: 1.25rem; }
+.lg-m-6 { margin: 1.5rem; }
+.lg-m-8 { margin: 2rem; }
+.lg-m-10 { margin: 2.5rem; }
+.lg-m-12 { margin: 3rem; }
+.lg-m-16 { margin: 4rem; }
+.lg-m-20 { margin: 5rem; }
+.lg-m-24 { margin: 6rem; }
+.lg-m-32 { margin: 8rem; }
+.lg-mt-0 { margin-top: 0; }
+.lg-mt-1 { margin-top: 0.25rem; }
+.lg-mt-2 { margin-top: 0.5rem; }
+.lg-mt-3 { margin-top: 0.75rem; }
+.lg-mt-4 { margin-top: 1rem; }
+.lg-mt-5 { margin-top: 1.25rem; }
+.lg-mt-6 { margin-top: 1.5rem; }
+.lg-mt-8 { margin-top: 2rem; }
+.lg-mt-10 { margin-top: 2.5rem; }
+.lg-mt-12 { margin-top: 3rem; }
+.lg-mt-16 { margin-top: 4rem; }
+.lg-mt-20 { margin-top: 5rem; }
+.lg-mt-24 { margin-top: 6rem; }
+.lg-mt-32 { margin-top: 8rem; }
+.lg-mb-0 { margin-bottom: 0; }
+.lg-mb-1 { margin-bottom: 0.25rem; }
+.lg-mb-2 { margin-bottom: 0.5rem; }
+.lg-mb-3 { margin-bottom: 0.75rem; }
+.lg-mb-4 { margin-bottom: 1rem; }
+.lg-mb-5 { margin-bottom: 1.25rem; }
+.lg-mb-6 { margin-bottom: 1.5rem; }
+.lg-mb-8 { margin-bottom: 2rem; }
+.lg-mb-10 { margin-bottom: 2.5rem; }
+.lg-mb-12 { margin-bottom: 3rem; }
+.lg-mb-16 { margin-bottom: 4rem; }
+.lg-mb-20 { margin-bottom: 5rem; }
+.lg-mb-24 { margin-bottom: 6rem; }
+.lg-mb-32 { margin-bottom: 8rem; }
+.lg-ml-0 { margin-left: 0; }
+.lg-ml-1 { margin-left: 0.25rem; }
+.lg-ml-2 { margin-left: 0.5rem; }
+.lg-ml-3 { margin-left: 0.75rem; }
+.lg-ml-4 { margin-left: 1rem; }
+.lg-ml-5 { margin-left: 1.25rem; }
+.lg-ml-6 { margin-left: 1.5rem; }
+.lg-ml-8 { margin-left: 2rem; }
+.lg-ml-10 { margin-left: 2.5rem; }
+.lg-ml-12 { margin-left: 3rem; }
+.lg-ml-16 { margin-left: 4rem; }
+.lg-ml-20 { margin-left: 5rem; }
+.lg-ml-24 { margin-left: 6rem; }
+.lg-ml-32 { margin-left: 8rem; }
+.lg-mr-0 { margin-right: 0; }
+.lg-mr-1 { margin-right: 0.25rem; }
+.lg-mr-2 { margin-right: 0.5rem; }
+.lg-mr-3 { margin-right: 0.75rem; }
+.lg-mr-4 { margin-right: 1rem; }
+.lg-mr-5 { margin-right: 1.25rem; }
+.lg-mr-6 { margin-right: 1.5rem; }
+.lg-mr-8 { margin-right: 2rem; }
+.lg-mr-10 { margin-right: 2.5rem; }
+.lg-mr-12 { margin-right: 3rem; }
+.lg-mr-16 { margin-right: 4rem; }
+.lg-mr-20 { margin-right: 5rem; }
+.lg-mr-24 { margin-right: 6rem; }
+.lg-mr-32 { margin-right: 8rem; }
+.lg-mx-0 { margin-left: 0; margin-right: 0; }
+.lg-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.lg-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.lg-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.lg-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.lg-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.lg-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.lg-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.lg-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.lg-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.lg-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.lg-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.lg-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.lg-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.lg-my-0 { margin-top: 0; margin-bottom: 0; }
+.lg-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.lg-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.lg-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.lg-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.lg-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.lg-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.lg-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.lg-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.lg-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.lg-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.lg-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.lg-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.lg-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.lg-p-0 { padding: 0; }
+.lg-p-1 { padding: 0.25rem; }
+.lg-p-2 { padding: 0.5rem; }
+.lg-p-3 { padding: 0.75rem; }
+.lg-p-4 { padding: 1rem; }
+.lg-p-5 { padding: 1.25rem; }
+.lg-p-6 { padding: 1.5rem; }
+.lg-p-8 { padding: 2rem; }
+.lg-p-10 { padding: 2.5rem; }
+.lg-p-12 { padding: 3rem; }
+.lg-p-16 { padding: 4rem; }
+.lg-p-20 { padding: 5rem; }
+.lg-p-24 { padding: 6rem; }
+.lg-p-32 { padding: 8rem; }
+.lg-pt-0 { padding-top: 0; }
+.lg-pt-1 { padding-top: 0.25rem; }
+.lg-pt-2 { padding-top: 0.5rem; }
+.lg-pt-3 { padding-top: 0.75rem; }
+.lg-pt-4 { padding-top: 1rem; }
+.lg-pt-5 { padding-top: 1.25rem; }
+.lg-pt-6 { padding-top: 1.5rem; }
+.lg-pt-8 { padding-top: 2rem; }
+.lg-pt-10 { padding-top: 2.5rem; }
+.lg-pt-12 { padding-top: 3rem; }
+.lg-pt-16 { padding-top: 4rem; }
+.lg-pt-20 { padding-top: 5rem; }
+.lg-pt-24 { padding-top: 6rem; }
+.lg-pt-32 { padding-top: 8rem; }
+.lg-pb-0 { padding-bottom: 0; }
+.lg-pb-1 { padding-bottom: 0.25rem; }
+.lg-pb-2 { padding-bottom: 0.5rem; }
+.lg-pb-3 { padding-bottom: 0.75rem; }
+.lg-pb-4 { padding-bottom: 1rem; }
+.lg-pb-5 { padding-bottom: 1.25rem; }
+.lg-pb-6 { padding-bottom: 1.5rem; }
+.lg-pb-8 { padding-bottom: 2rem; }
+.lg-pb-10 { padding-bottom: 2.5rem; }
+.lg-pb-12 { padding-bottom: 3rem; }
+.lg-pb-16 { padding-bottom: 4rem; }
+.lg-pb-20 { padding-bottom: 5rem; }
+.lg-pb-24 { padding-bottom: 6rem; }
+.lg-pb-32 { padding-bottom: 8rem; }
+.lg-pl-0 { padding-left: 0; }
+.lg-pl-1 { padding-left: 0.25rem; }
+.lg-pl-2 { padding-left: 0.5rem; }
+.lg-pl-3 { padding-left: 0.75rem; }
+.lg-pl-4 { padding-left: 1rem; }
+.lg-pl-5 { padding-left: 1.25rem; }
+.lg-pl-6 { padding-left: 1.5rem; }
+.lg-pl-8 { padding-left: 2rem; }
+.lg-pl-10 { padding-left: 2.5rem; }
+.lg-pl-12 { padding-left: 3rem; }
+.lg-pl-16 { padding-left: 4rem; }
+.lg-pl-20 { padding-left: 5rem; }
+.lg-pl-24 { padding-left: 6rem; }
+.lg-pl-32 { padding-left: 8rem; }
+.lg-pr-0 { padding-right: 0; }
+.lg-pr-1 { padding-right: 0.25rem; }
+.lg-pr-2 { padding-right: 0.5rem; }
+.lg-pr-3 { padding-right: 0.75rem; }
+.lg-pr-4 { padding-right: 1rem; }
+.lg-pr-5 { padding-right: 1.25rem; }
+.lg-pr-6 { padding-right: 1.5rem; }
+.lg-pr-8 { padding-right: 2rem; }
+.lg-pr-10 { padding-right: 2.5rem; }
+.lg-pr-12 { padding-right: 3rem; }
+.lg-pr-16 { padding-right: 4rem; }
+.lg-pr-20 { padding-right: 5rem; }
+.lg-pr-24 { padding-right: 6rem; }
+.lg-pr-32 { padding-right: 8rem; }
+.lg-px-0 { padding-left: 0; padding-right: 0; }
+.lg-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.lg-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.lg-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.lg-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.lg-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.lg-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.lg-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.lg-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.lg-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.lg-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.lg-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.lg-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.lg-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.lg-py-0 { padding-top: 0; padding-bottom: 0; }
+.lg-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.lg-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.lg-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.lg-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.lg-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.lg-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.lg-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.lg-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.lg-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.lg-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.lg-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.lg-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.lg-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.lg-gap-0 { gap: 0; }
+.lg-gap-1 { gap: 0.25rem; }
+.lg-gap-2 { gap: 0.5rem; }
+.lg-gap-3 { gap: 0.75rem; }
+.lg-gap-4 { gap: 1rem; }
+.lg-gap-5 { gap: 1.25rem; }
+.lg-gap-6 { gap: 1.5rem; }
+.lg-gap-8 { gap: 2rem; }
+.lg-gap-10 { gap: 2.5rem; }
+.lg-gap-12 { gap: 3rem; }
+.lg-gap-16 { gap: 4rem; }
+.lg-gap-20 { gap: 5rem; }
+.lg-gap-24 { gap: 6rem; }
+.lg-gap-32 { gap: 8rem; }
 }
 @media (width >= 80rem) {
-.xl\:m-0 { margin: 0; }
-.xl\:m-1 { margin: 0.25rem; }
-.xl\:m-2 { margin: 0.5rem; }
-.xl\:m-3 { margin: 0.75rem; }
-.xl\:m-4 { margin: 1rem; }
-.xl\:m-5 { margin: 1.25rem; }
-.xl\:m-6 { margin: 1.5rem; }
-.xl\:m-8 { margin: 2rem; }
-.xl\:m-10 { margin: 2.5rem; }
-.xl\:m-12 { margin: 3rem; }
-.xl\:m-16 { margin: 4rem; }
-.xl\:m-20 { margin: 5rem; }
-.xl\:m-24 { margin: 6rem; }
-.xl\:m-32 { margin: 8rem; }
-.xl\:mt-0 { margin-top: 0; }
-.xl\:mt-1 { margin-top: 0.25rem; }
-.xl\:mt-2 { margin-top: 0.5rem; }
-.xl\:mt-3 { margin-top: 0.75rem; }
-.xl\:mt-4 { margin-top: 1rem; }
-.xl\:mt-5 { margin-top: 1.25rem; }
-.xl\:mt-6 { margin-top: 1.5rem; }
-.xl\:mt-8 { margin-top: 2rem; }
-.xl\:mt-10 { margin-top: 2.5rem; }
-.xl\:mt-12 { margin-top: 3rem; }
-.xl\:mt-16 { margin-top: 4rem; }
-.xl\:mt-20 { margin-top: 5rem; }
-.xl\:mt-24 { margin-top: 6rem; }
-.xl\:mt-32 { margin-top: 8rem; }
-.xl\:mb-0 { margin-bottom: 0; }
-.xl\:mb-1 { margin-bottom: 0.25rem; }
-.xl\:mb-2 { margin-bottom: 0.5rem; }
-.xl\:mb-3 { margin-bottom: 0.75rem; }
-.xl\:mb-4 { margin-bottom: 1rem; }
-.xl\:mb-5 { margin-bottom: 1.25rem; }
-.xl\:mb-6 { margin-bottom: 1.5rem; }
-.xl\:mb-8 { margin-bottom: 2rem; }
-.xl\:mb-10 { margin-bottom: 2.5rem; }
-.xl\:mb-12 { margin-bottom: 3rem; }
-.xl\:mb-16 { margin-bottom: 4rem; }
-.xl\:mb-20 { margin-bottom: 5rem; }
-.xl\:mb-24 { margin-bottom: 6rem; }
-.xl\:mb-32 { margin-bottom: 8rem; }
-.xl\:ml-0 { margin-left: 0; }
-.xl\:ml-1 { margin-left: 0.25rem; }
-.xl\:ml-2 { margin-left: 0.5rem; }
-.xl\:ml-3 { margin-left: 0.75rem; }
-.xl\:ml-4 { margin-left: 1rem; }
-.xl\:ml-5 { margin-left: 1.25rem; }
-.xl\:ml-6 { margin-left: 1.5rem; }
-.xl\:ml-8 { margin-left: 2rem; }
-.xl\:ml-10 { margin-left: 2.5rem; }
-.xl\:ml-12 { margin-left: 3rem; }
-.xl\:ml-16 { margin-left: 4rem; }
-.xl\:ml-20 { margin-left: 5rem; }
-.xl\:ml-24 { margin-left: 6rem; }
-.xl\:ml-32 { margin-left: 8rem; }
-.xl\:mr-0 { margin-right: 0; }
-.xl\:mr-1 { margin-right: 0.25rem; }
-.xl\:mr-2 { margin-right: 0.5rem; }
-.xl\:mr-3 { margin-right: 0.75rem; }
-.xl\:mr-4 { margin-right: 1rem; }
-.xl\:mr-5 { margin-right: 1.25rem; }
-.xl\:mr-6 { margin-right: 1.5rem; }
-.xl\:mr-8 { margin-right: 2rem; }
-.xl\:mr-10 { margin-right: 2.5rem; }
-.xl\:mr-12 { margin-right: 3rem; }
-.xl\:mr-16 { margin-right: 4rem; }
-.xl\:mr-20 { margin-right: 5rem; }
-.xl\:mr-24 { margin-right: 6rem; }
-.xl\:mr-32 { margin-right: 8rem; }
-.xl\:mx-0 { margin-left: 0; margin-right: 0; }
-.xl\:mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
-.xl\:mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
-.xl\:mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
-.xl\:mx-4 { margin-left: 1rem; margin-right: 1rem; }
-.xl\:mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
-.xl\:mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
-.xl\:mx-8 { margin-left: 2rem; margin-right: 2rem; }
-.xl\:mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
-.xl\:mx-12 { margin-left: 3rem; margin-right: 3rem; }
-.xl\:mx-16 { margin-left: 4rem; margin-right: 4rem; }
-.xl\:mx-20 { margin-left: 5rem; margin-right: 5rem; }
-.xl\:mx-24 { margin-left: 6rem; margin-right: 6rem; }
-.xl\:mx-32 { margin-left: 8rem; margin-right: 8rem; }
-.xl\:my-0 { margin-top: 0; margin-bottom: 0; }
-.xl\:my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.xl\:my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
-.xl\:my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
-.xl\:my-4 { margin-top: 1rem; margin-bottom: 1rem; }
-.xl\:my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
-.xl\:my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
-.xl\:my-8 { margin-top: 2rem; margin-bottom: 2rem; }
-.xl\:my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-.xl\:my-12 { margin-top: 3rem; margin-bottom: 3rem; }
-.xl\:my-16 { margin-top: 4rem; margin-bottom: 4rem; }
-.xl\:my-20 { margin-top: 5rem; margin-bottom: 5rem; }
-.xl\:my-24 { margin-top: 6rem; margin-bottom: 6rem; }
-.xl\:my-32 { margin-top: 8rem; margin-bottom: 8rem; }
-.xl\:p-0 { padding: 0; }
-.xl\:p-1 { padding: 0.25rem; }
-.xl\:p-2 { padding: 0.5rem; }
-.xl\:p-3 { padding: 0.75rem; }
-.xl\:p-4 { padding: 1rem; }
-.xl\:p-5 { padding: 1.25rem; }
-.xl\:p-6 { padding: 1.5rem; }
-.xl\:p-8 { padding: 2rem; }
-.xl\:p-10 { padding: 2.5rem; }
-.xl\:p-12 { padding: 3rem; }
-.xl\:p-16 { padding: 4rem; }
-.xl\:p-20 { padding: 5rem; }
-.xl\:p-24 { padding: 6rem; }
-.xl\:p-32 { padding: 8rem; }
-.xl\:pt-0 { padding-top: 0; }
-.xl\:pt-1 { padding-top: 0.25rem; }
-.xl\:pt-2 { padding-top: 0.5rem; }
-.xl\:pt-3 { padding-top: 0.75rem; }
-.xl\:pt-4 { padding-top: 1rem; }
-.xl\:pt-5 { padding-top: 1.25rem; }
-.xl\:pt-6 { padding-top: 1.5rem; }
-.xl\:pt-8 { padding-top: 2rem; }
-.xl\:pt-10 { padding-top: 2.5rem; }
-.xl\:pt-12 { padding-top: 3rem; }
-.xl\:pt-16 { padding-top: 4rem; }
-.xl\:pt-20 { padding-top: 5rem; }
-.xl\:pt-24 { padding-top: 6rem; }
-.xl\:pt-32 { padding-top: 8rem; }
-.xl\:pb-0 { padding-bottom: 0; }
-.xl\:pb-1 { padding-bottom: 0.25rem; }
-.xl\:pb-2 { padding-bottom: 0.5rem; }
-.xl\:pb-3 { padding-bottom: 0.75rem; }
-.xl\:pb-4 { padding-bottom: 1rem; }
-.xl\:pb-5 { padding-bottom: 1.25rem; }
-.xl\:pb-6 { padding-bottom: 1.5rem; }
-.xl\:pb-8 { padding-bottom: 2rem; }
-.xl\:pb-10 { padding-bottom: 2.5rem; }
-.xl\:pb-12 { padding-bottom: 3rem; }
-.xl\:pb-16 { padding-bottom: 4rem; }
-.xl\:pb-20 { padding-bottom: 5rem; }
-.xl\:pb-24 { padding-bottom: 6rem; }
-.xl\:pb-32 { padding-bottom: 8rem; }
-.xl\:pl-0 { padding-left: 0; }
-.xl\:pl-1 { padding-left: 0.25rem; }
-.xl\:pl-2 { padding-left: 0.5rem; }
-.xl\:pl-3 { padding-left: 0.75rem; }
-.xl\:pl-4 { padding-left: 1rem; }
-.xl\:pl-5 { padding-left: 1.25rem; }
-.xl\:pl-6 { padding-left: 1.5rem; }
-.xl\:pl-8 { padding-left: 2rem; }
-.xl\:pl-10 { padding-left: 2.5rem; }
-.xl\:pl-12 { padding-left: 3rem; }
-.xl\:pl-16 { padding-left: 4rem; }
-.xl\:pl-20 { padding-left: 5rem; }
-.xl\:pl-24 { padding-left: 6rem; }
-.xl\:pl-32 { padding-left: 8rem; }
-.xl\:pr-0 { padding-right: 0; }
-.xl\:pr-1 { padding-right: 0.25rem; }
-.xl\:pr-2 { padding-right: 0.5rem; }
-.xl\:pr-3 { padding-right: 0.75rem; }
-.xl\:pr-4 { padding-right: 1rem; }
-.xl\:pr-5 { padding-right: 1.25rem; }
-.xl\:pr-6 { padding-right: 1.5rem; }
-.xl\:pr-8 { padding-right: 2rem; }
-.xl\:pr-10 { padding-right: 2.5rem; }
-.xl\:pr-12 { padding-right: 3rem; }
-.xl\:pr-16 { padding-right: 4rem; }
-.xl\:pr-20 { padding-right: 5rem; }
-.xl\:pr-24 { padding-right: 6rem; }
-.xl\:pr-32 { padding-right: 8rem; }
-.xl\:px-0 { padding-left: 0; padding-right: 0; }
-.xl\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-.xl\:px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-.xl\:px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-.xl\:px-4 { padding-left: 1rem; padding-right: 1rem; }
-.xl\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
-.xl\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
-.xl\:px-8 { padding-left: 2rem; padding-right: 2rem; }
-.xl\:px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
-.xl\:px-12 { padding-left: 3rem; padding-right: 3rem; }
-.xl\:px-16 { padding-left: 4rem; padding-right: 4rem; }
-.xl\:px-20 { padding-left: 5rem; padding-right: 5rem; }
-.xl\:px-24 { padding-left: 6rem; padding-right: 6rem; }
-.xl\:px-32 { padding-left: 8rem; padding-right: 8rem; }
-.xl\:py-0 { padding-top: 0; padding-bottom: 0; }
-.xl\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.xl\:py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-.xl\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
-.xl\:py-4 { padding-top: 1rem; padding-bottom: 1rem; }
-.xl\:py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
-.xl\:py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
-.xl\:py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-.xl\:py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-.xl\:py-12 { padding-top: 3rem; padding-bottom: 3rem; }
-.xl\:py-16 { padding-top: 4rem; padding-bottom: 4rem; }
-.xl\:py-20 { padding-top: 5rem; padding-bottom: 5rem; }
-.xl\:py-24 { padding-top: 6rem; padding-bottom: 6rem; }
-.xl\:py-32 { padding-top: 8rem; padding-bottom: 8rem; }
-.xl\:gap-0 { gap: 0; }
-.xl\:gap-1 { gap: 0.25rem; }
-.xl\:gap-2 { gap: 0.5rem; }
-.xl\:gap-3 { gap: 0.75rem; }
-.xl\:gap-4 { gap: 1rem; }
-.xl\:gap-5 { gap: 1.25rem; }
-.xl\:gap-6 { gap: 1.5rem; }
-.xl\:gap-8 { gap: 2rem; }
-.xl\:gap-10 { gap: 2.5rem; }
-.xl\:gap-12 { gap: 3rem; }
-.xl\:gap-16 { gap: 4rem; }
-.xl\:gap-20 { gap: 5rem; }
-.xl\:gap-24 { gap: 6rem; }
-.xl\:gap-32 { gap: 8rem; }
+.xl-m-0 { margin: 0; }
+.xl-m-1 { margin: 0.25rem; }
+.xl-m-2 { margin: 0.5rem; }
+.xl-m-3 { margin: 0.75rem; }
+.xl-m-4 { margin: 1rem; }
+.xl-m-5 { margin: 1.25rem; }
+.xl-m-6 { margin: 1.5rem; }
+.xl-m-8 { margin: 2rem; }
+.xl-m-10 { margin: 2.5rem; }
+.xl-m-12 { margin: 3rem; }
+.xl-m-16 { margin: 4rem; }
+.xl-m-20 { margin: 5rem; }
+.xl-m-24 { margin: 6rem; }
+.xl-m-32 { margin: 8rem; }
+.xl-mt-0 { margin-top: 0; }
+.xl-mt-1 { margin-top: 0.25rem; }
+.xl-mt-2 { margin-top: 0.5rem; }
+.xl-mt-3 { margin-top: 0.75rem; }
+.xl-mt-4 { margin-top: 1rem; }
+.xl-mt-5 { margin-top: 1.25rem; }
+.xl-mt-6 { margin-top: 1.5rem; }
+.xl-mt-8 { margin-top: 2rem; }
+.xl-mt-10 { margin-top: 2.5rem; }
+.xl-mt-12 { margin-top: 3rem; }
+.xl-mt-16 { margin-top: 4rem; }
+.xl-mt-20 { margin-top: 5rem; }
+.xl-mt-24 { margin-top: 6rem; }
+.xl-mt-32 { margin-top: 8rem; }
+.xl-mb-0 { margin-bottom: 0; }
+.xl-mb-1 { margin-bottom: 0.25rem; }
+.xl-mb-2 { margin-bottom: 0.5rem; }
+.xl-mb-3 { margin-bottom: 0.75rem; }
+.xl-mb-4 { margin-bottom: 1rem; }
+.xl-mb-5 { margin-bottom: 1.25rem; }
+.xl-mb-6 { margin-bottom: 1.5rem; }
+.xl-mb-8 { margin-bottom: 2rem; }
+.xl-mb-10 { margin-bottom: 2.5rem; }
+.xl-mb-12 { margin-bottom: 3rem; }
+.xl-mb-16 { margin-bottom: 4rem; }
+.xl-mb-20 { margin-bottom: 5rem; }
+.xl-mb-24 { margin-bottom: 6rem; }
+.xl-mb-32 { margin-bottom: 8rem; }
+.xl-ml-0 { margin-left: 0; }
+.xl-ml-1 { margin-left: 0.25rem; }
+.xl-ml-2 { margin-left: 0.5rem; }
+.xl-ml-3 { margin-left: 0.75rem; }
+.xl-ml-4 { margin-left: 1rem; }
+.xl-ml-5 { margin-left: 1.25rem; }
+.xl-ml-6 { margin-left: 1.5rem; }
+.xl-ml-8 { margin-left: 2rem; }
+.xl-ml-10 { margin-left: 2.5rem; }
+.xl-ml-12 { margin-left: 3rem; }
+.xl-ml-16 { margin-left: 4rem; }
+.xl-ml-20 { margin-left: 5rem; }
+.xl-ml-24 { margin-left: 6rem; }
+.xl-ml-32 { margin-left: 8rem; }
+.xl-mr-0 { margin-right: 0; }
+.xl-mr-1 { margin-right: 0.25rem; }
+.xl-mr-2 { margin-right: 0.5rem; }
+.xl-mr-3 { margin-right: 0.75rem; }
+.xl-mr-4 { margin-right: 1rem; }
+.xl-mr-5 { margin-right: 1.25rem; }
+.xl-mr-6 { margin-right: 1.5rem; }
+.xl-mr-8 { margin-right: 2rem; }
+.xl-mr-10 { margin-right: 2.5rem; }
+.xl-mr-12 { margin-right: 3rem; }
+.xl-mr-16 { margin-right: 4rem; }
+.xl-mr-20 { margin-right: 5rem; }
+.xl-mr-24 { margin-right: 6rem; }
+.xl-mr-32 { margin-right: 8rem; }
+.xl-mx-0 { margin-left: 0; margin-right: 0; }
+.xl-mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+.xl-mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+.xl-mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+.xl-mx-4 { margin-left: 1rem; margin-right: 1rem; }
+.xl-mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+.xl-mx-6 { margin-left: 1.5rem; margin-right: 1.5rem; }
+.xl-mx-8 { margin-left: 2rem; margin-right: 2rem; }
+.xl-mx-10 { margin-left: 2.5rem; margin-right: 2.5rem; }
+.xl-mx-12 { margin-left: 3rem; margin-right: 3rem; }
+.xl-mx-16 { margin-left: 4rem; margin-right: 4rem; }
+.xl-mx-20 { margin-left: 5rem; margin-right: 5rem; }
+.xl-mx-24 { margin-left: 6rem; margin-right: 6rem; }
+.xl-mx-32 { margin-left: 8rem; margin-right: 8rem; }
+.xl-my-0 { margin-top: 0; margin-bottom: 0; }
+.xl-my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.xl-my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+.xl-my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+.xl-my-4 { margin-top: 1rem; margin-bottom: 1rem; }
+.xl-my-5 { margin-top: 1.25rem; margin-bottom: 1.25rem; }
+.xl-my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+.xl-my-8 { margin-top: 2rem; margin-bottom: 2rem; }
+.xl-my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
+.xl-my-12 { margin-top: 3rem; margin-bottom: 3rem; }
+.xl-my-16 { margin-top: 4rem; margin-bottom: 4rem; }
+.xl-my-20 { margin-top: 5rem; margin-bottom: 5rem; }
+.xl-my-24 { margin-top: 6rem; margin-bottom: 6rem; }
+.xl-my-32 { margin-top: 8rem; margin-bottom: 8rem; }
+.xl-p-0 { padding: 0; }
+.xl-p-1 { padding: 0.25rem; }
+.xl-p-2 { padding: 0.5rem; }
+.xl-p-3 { padding: 0.75rem; }
+.xl-p-4 { padding: 1rem; }
+.xl-p-5 { padding: 1.25rem; }
+.xl-p-6 { padding: 1.5rem; }
+.xl-p-8 { padding: 2rem; }
+.xl-p-10 { padding: 2.5rem; }
+.xl-p-12 { padding: 3rem; }
+.xl-p-16 { padding: 4rem; }
+.xl-p-20 { padding: 5rem; }
+.xl-p-24 { padding: 6rem; }
+.xl-p-32 { padding: 8rem; }
+.xl-pt-0 { padding-top: 0; }
+.xl-pt-1 { padding-top: 0.25rem; }
+.xl-pt-2 { padding-top: 0.5rem; }
+.xl-pt-3 { padding-top: 0.75rem; }
+.xl-pt-4 { padding-top: 1rem; }
+.xl-pt-5 { padding-top: 1.25rem; }
+.xl-pt-6 { padding-top: 1.5rem; }
+.xl-pt-8 { padding-top: 2rem; }
+.xl-pt-10 { padding-top: 2.5rem; }
+.xl-pt-12 { padding-top: 3rem; }
+.xl-pt-16 { padding-top: 4rem; }
+.xl-pt-20 { padding-top: 5rem; }
+.xl-pt-24 { padding-top: 6rem; }
+.xl-pt-32 { padding-top: 8rem; }
+.xl-pb-0 { padding-bottom: 0; }
+.xl-pb-1 { padding-bottom: 0.25rem; }
+.xl-pb-2 { padding-bottom: 0.5rem; }
+.xl-pb-3 { padding-bottom: 0.75rem; }
+.xl-pb-4 { padding-bottom: 1rem; }
+.xl-pb-5 { padding-bottom: 1.25rem; }
+.xl-pb-6 { padding-bottom: 1.5rem; }
+.xl-pb-8 { padding-bottom: 2rem; }
+.xl-pb-10 { padding-bottom: 2.5rem; }
+.xl-pb-12 { padding-bottom: 3rem; }
+.xl-pb-16 { padding-bottom: 4rem; }
+.xl-pb-20 { padding-bottom: 5rem; }
+.xl-pb-24 { padding-bottom: 6rem; }
+.xl-pb-32 { padding-bottom: 8rem; }
+.xl-pl-0 { padding-left: 0; }
+.xl-pl-1 { padding-left: 0.25rem; }
+.xl-pl-2 { padding-left: 0.5rem; }
+.xl-pl-3 { padding-left: 0.75rem; }
+.xl-pl-4 { padding-left: 1rem; }
+.xl-pl-5 { padding-left: 1.25rem; }
+.xl-pl-6 { padding-left: 1.5rem; }
+.xl-pl-8 { padding-left: 2rem; }
+.xl-pl-10 { padding-left: 2.5rem; }
+.xl-pl-12 { padding-left: 3rem; }
+.xl-pl-16 { padding-left: 4rem; }
+.xl-pl-20 { padding-left: 5rem; }
+.xl-pl-24 { padding-left: 6rem; }
+.xl-pl-32 { padding-left: 8rem; }
+.xl-pr-0 { padding-right: 0; }
+.xl-pr-1 { padding-right: 0.25rem; }
+.xl-pr-2 { padding-right: 0.5rem; }
+.xl-pr-3 { padding-right: 0.75rem; }
+.xl-pr-4 { padding-right: 1rem; }
+.xl-pr-5 { padding-right: 1.25rem; }
+.xl-pr-6 { padding-right: 1.5rem; }
+.xl-pr-8 { padding-right: 2rem; }
+.xl-pr-10 { padding-right: 2.5rem; }
+.xl-pr-12 { padding-right: 3rem; }
+.xl-pr-16 { padding-right: 4rem; }
+.xl-pr-20 { padding-right: 5rem; }
+.xl-pr-24 { padding-right: 6rem; }
+.xl-pr-32 { padding-right: 8rem; }
+.xl-px-0 { padding-left: 0; padding-right: 0; }
+.xl-px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+.xl-px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+.xl-px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+.xl-px-4 { padding-left: 1rem; padding-right: 1rem; }
+.xl-px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+.xl-px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.xl-px-8 { padding-left: 2rem; padding-right: 2rem; }
+.xl-px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+.xl-px-12 { padding-left: 3rem; padding-right: 3rem; }
+.xl-px-16 { padding-left: 4rem; padding-right: 4rem; }
+.xl-px-20 { padding-left: 5rem; padding-right: 5rem; }
+.xl-px-24 { padding-left: 6rem; padding-right: 6rem; }
+.xl-px-32 { padding-left: 8rem; padding-right: 8rem; }
+.xl-py-0 { padding-top: 0; padding-bottom: 0; }
+.xl-py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.xl-py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+.xl-py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.xl-py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.xl-py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+.xl-py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+.xl-py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.xl-py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+.xl-py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.xl-py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.xl-py-20 { padding-top: 5rem; padding-bottom: 5rem; }
+.xl-py-24 { padding-top: 6rem; padding-bottom: 6rem; }
+.xl-py-32 { padding-top: 8rem; padding-bottom: 8rem; }
+.xl-gap-0 { gap: 0; }
+.xl-gap-1 { gap: 0.25rem; }
+.xl-gap-2 { gap: 0.5rem; }
+.xl-gap-3 { gap: 0.75rem; }
+.xl-gap-4 { gap: 1rem; }
+.xl-gap-5 { gap: 1.25rem; }
+.xl-gap-6 { gap: 1.5rem; }
+.xl-gap-8 { gap: 2rem; }
+.xl-gap-10 { gap: 2.5rem; }
+.xl-gap-12 { gap: 3rem; }
+.xl-gap-16 { gap: 4rem; }
+.xl-gap-20 { gap: 5rem; }
+.xl-gap-24 { gap: 6rem; }
+.xl-gap-32 { gap: 8rem; }
 }

--- a/plugins/acss-utilities/docs/concepts.md
+++ b/plugins/acss-utilities/docs/concepts.md
@@ -43,23 +43,23 @@ Five prefixes ship by default: `sm`, `md`, `lg`, `xl`, `print`. The breakpoint w
 | `md` | 48rem | `@media (width >= 48rem)` |
 | `lg` | 62rem | `@media (width >= 62rem)` |
 | `xl` | 80rem | `@media (width >= 80rem)` |
-| `print` | — | `@media print { .print\:hide { … } }` (only `hide` is emitted) |
+| `print` | — | `@media print { .print-hide { … } }` (only `hide` is emitted) |
 
-In the stylesheet the colon is escaped as `\:`. In your JSX/HTML it is **not** escaped:
+Responsive class names use a plain hyphen prefix — no escaping in the stylesheet or in JSX:
 
 ```tsx
-<div className="hide md:show lg:hide">…</div>
+<div className="hide md-show lg-hide">…</div>
 ```
 
-If you write `.sm:hide` in CSS without the backslash, the selector is invalid and the rule never matches. See [`references/breakpoints.md`](../skills/utilities/references/breakpoints.md).
+See [`references/breakpoints.md`](../skills/utilities/references/breakpoints.md) for the full breakpoint table and class-naming rules.
 
-Not every family is responsive. Color, type, radius, shadow, position, and z-index emit only base classes. Spacing, display, flex, and grid emit the full `sm/md/lg/xl` set. The `families.<name>.responsive` flag in the tokens file controls this.
+Not every family is responsive. Color, type, radius, shadow, position, and z-index emit only base classes. Spacing, display, flex, and grid emit the full `sm-/md-/lg-/xl-` set. The `families.<name>.responsive` flag in the tokens file controls this.
 
 ## `!important` is reserved for display and visibility
 
 Utility classes generally compose with component styles. They do **not** stamp `!important` on every property, because the user should be able to override `.bg-primary` with a more specific component rule.
 
-The exceptions are `display`, `visibility`, and the `print:hide` / `sm:hide` family — these need to win over any positioning or layout rule that the component author may have set. So:
+The exceptions are `display`, `visibility`, and the `print-hide` / `sm-hide` family — these need to win over any positioning or layout rule that the component author may have set. So:
 
 ```css
 .hide { display: none !important; }

--- a/plugins/acss-utilities/docs/troubleshooting.md
+++ b/plugins/acss-utilities/docs/troubleshooting.md
@@ -20,18 +20,21 @@ pip3 install --user tinycss2
 
 ---
 
-## `.sm:hide` is not firing
+## `.sm-hide` is not firing
 
-**Symptom:** A class like `.md:show` or `.lg:hide` does not match any element.
+**Symptom:** A class like `.md-show` or `.lg-hide` does not match any element.
 
-**Cause:** The CSS file uses an escaped colon (`.md\:show`); the JSX/HTML uses an **unescaped** colon (`md:show`). If you write `.md:show` in your stylesheet, the parser treats `:show` as a pseudo-class and the rule never matches.
+**Cause (migrating from 0.1.x):** You may still be using the old colon-based class names in JSX (`md:show`) while the new bundle ships only `.md-show`. The colon form is no longer valid.
 
-**Fix:**
+**Fix:** Run the migration script to update all JSX/CSS references:
 
-- **In stylesheets** (the bundled `utilities.css` and any custom rules): always write `\:` — `.md\:show { … }`.
-- **In JSX / HTML / template literals**: never escape — `<div className="md:show">…`.
+```bash
+python3 plugins/acss-utilities/scripts/migrate_classnames.py src/ --write
+```
 
-The bundled `utilities.css` already gets this right; the issue only comes up when you author additional utilities by hand.
+Or do a manual search-and-replace: `sm:` → `sm-`, `md:` → `md-`, `lg:` → `lg-`, `xl:` → `xl-`, `print:` → `print-` in all JSX `className` strings.
+
+**Cause (hand-authored CSS):** If you write `.md-show` in a custom stylesheet at the top level (outside any `@media` block), the validator will reject it with "collides with breakpoint prefix". Move it inside `@media (width >= 48rem)` or rename it to avoid the `md-` prefix.
 
 ---
 

--- a/plugins/acss-utilities/docs/tutorial.md
+++ b/plugins/acss-utilities/docs/tutorial.md
@@ -77,21 +77,19 @@ Every class in the bundle is documented in [`references/utility-catalogue.md`](.
 
 ## Step 4 — Hide a class on small screens
 
-Responsive prefixes use `sm:`, `md:`, `lg:`, `xl:`. In your JSX, the colon is **not** escaped:
+Responsive prefixes use `sm-`, `md-`, `lg-`, `xl-`. Use them the same way in JSX and in the stylesheet — no escaping required:
 
 ```tsx
-<aside className="hide md:show">…</aside>
+<aside className="hide md-show">…</aside>
 ```
 
 This element is hidden by default and revealed at `≥ 48rem` (the `md` breakpoint). The CSS rule it matches looks like:
 
 ```css
 @media (width >= 48rem) {
-  .md\:show { display: revert !important; }
+  .md-show { display: revert !important; }
 }
 ```
-
-Note the `\:` in the CSS file — that's the escaped form. JSX/HTML always uses the unescaped `md:show`.
 
 See [`references/breakpoints.md`](../skills/utilities/references/breakpoints.md) for the full breakpoint table.
 

--- a/plugins/acss-utilities/scripts/generate_utilities.py
+++ b/plugins/acss-utilities/scripts/generate_utilities.py
@@ -18,9 +18,9 @@ Stdlib only.
 
 Class conventions match fpkit/acss upstream:
   - kebab-case selectors, no prefix (`.bg-primary`, `.mt-4`)
-  - responsive variants via escaped colon (`.sm\\:hide`) at breakpoints
+  - responsive variants via hyphen prefix (`.sm-hide`) at breakpoints
     sm/md/lg/xl from tokens.breakpoints
-  - print:hide for the print media query
+  - print-hide for the print media query
   - !important on display/visibility utilities only (composes elsewhere)
 """
 from __future__ import annotations
@@ -71,11 +71,11 @@ def _section(title: str, body: str) -> str:
 
 
 def _wrap_responsive(body: str, family: str, tokens: dict, emit_base: Callable[[str], str]) -> str:
-    """Append @media blocks with `.bp\\:<class>` variants for each breakpoint."""
+    """Append @media blocks with `.bp-<class>` variants for each breakpoint."""
     parts = [body]
     for bp in _bp_keys(tokens):
         width = tokens["breakpoints"][bp]
-        prefixed = emit_base(bp + r"\:")
+        prefixed = emit_base(bp + "-")
         parts.append(f"@media (width >= {width}) {{\n{prefixed}}}")
     return "\n".join(parts)
 
@@ -181,8 +181,8 @@ def emit_display(tokens: dict) -> str:
 
     if tokens["families"]["display"].get("responsive"):
         for bp, width in tokens["breakpoints"].items():
-            body += f"@media (width >= {width}) {{\n{block(bp + chr(92) + ':')}}}\n"
-    body += "@media print { .print\\:hide { display: none !important; } }\n"
+            body += f"@media (width >= {width}) {{\n{block(bp + '-')}}}\n"
+    body += "@media print { .print-hide { display: none !important; } }\n"
     return _section("display utilities", body)
 
 

--- a/plugins/acss-utilities/scripts/migrate_classnames.py
+++ b/plugins/acss-utilities/scripts/migrate_classnames.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Migrate acss-utilities class names from 0.1.x colon form to 0.2.0 hyphen form.
+
+Rewrites `sm:hide` → `sm-hide`, `md:p-6` → `md-p-6`, etc. in source files.
+By default performs a dry run and prints a unified diff per modified file.
+Use --write to apply changes in place.
+
+Contract: generator/validator (data on stdout, errors on stderr, exit 0/1/2).
+Stdlib only.
+
+Usage:
+    migrate_classnames.py <path> [<path>...]
+                          [--write]
+                          [--include=<glob>,<glob>,...]
+                          [--exclude=<glob>,<glob>,...]
+                          [--prefixes=sm,md,lg,xl,print]
+
+Exit codes:
+    0 — no changes needed (or all applied with --write)
+    1 — dry-run: changes pending (use --write to apply)
+    2 — usage / IO error
+
+Match strategy (conservative):
+    The substitution `(sm|md|lg|xl|print):` → `<prefix>-` is applied only
+    inside string-literal contexts per file type:
+      - JSX/TSX, TS/JS: inside `className="..."`, `className='...'`,
+        `className={\`...\`}`, and clsx/classnames call arguments.
+      - HTML/Svelte/Vue/Astro: inside `class="..."` and `className="..."` attributes.
+      - CSS/SCSS: inside `@apply <classes>;` directives and literal `.<prefix>\\:<name>`
+        selectors (old escaped-colon form in hand-authored CSS).
+
+    Known limitations (documented, not silently skipped):
+      - Combo prefixes like `lg:hover:bg-primary` (not used by this plugin's grammar)
+        will have the leading `lg:` rewritten to `lg-` — incorrect in that system.
+      - Vue `:class="[...]"` array bindings, Svelte `class:` directives, and Astro
+        expressions are not rewritten in v0.2.0 — use --write with review.
+      - Comments inside any format are skipped.
+
+    Idempotency: running the script twice on the same tree produces zero diffs
+    on the second run.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import fnmatch
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_PREFIXES = ("sm", "md", "lg", "xl", "print")
+
+# Extensions handled per family.
+JSX_EXTS = {".jsx", ".tsx"}
+JS_EXTS = {".js", ".ts", ".mjs", ".cjs"}
+HTML_EXTS = {".html", ".svelte", ".vue", ".astro"}
+CSS_EXTS = {".css", ".scss"}
+
+ALL_HANDLED = JSX_EXTS | JS_EXTS | HTML_EXTS | CSS_EXTS
+
+# Default glob patterns to exclude (version-control dirs, build artefacts).
+DEFAULT_EXCLUDES = {
+    ".git", "node_modules", "dist", "build", ".next", ".nuxt", "__pycache__",
+}
+
+
+# ---------------------------------------------------------------------------
+# Core rewriter
+# ---------------------------------------------------------------------------
+
+def _build_prefix_re(prefixes: Tuple[str, ...]) -> re.Pattern[str]:
+    """Match `<prefix>:<letter>` — the `:` is the substitution target."""
+    alt = "|".join(re.escape(p) for p in sorted(prefixes, key=len, reverse=True))
+    return re.compile(r"(?<![A-Za-z0-9_-])(" + alt + r"):([a-z])")
+
+
+def _replace(m: re.Match, _prefixes: Tuple[str, ...]) -> str:
+    return m.group(1) + "-" + m.group(2)
+
+
+def _rewrite_string_value(text: str, prefix_re: re.Pattern) -> str:
+    """Replace all `<prefix>:` → `<prefix>-` inside `text`."""
+    return prefix_re.sub(lambda m: _replace(m, ()), text)
+
+
+# --- JSX / TS / JS ---------------------------------------------------------
+
+# className="..." or className='...' (static strings)
+_JSX_CLASSNAME_DQ = re.compile(r'(className\s*=\s*")([^"]*?)(")')
+_JSX_CLASSNAME_SQ = re.compile(r"(className\s*=\s*')([^']*?)(')")
+# className={`...`} template literal
+_JSX_CLASSNAME_TMPL = re.compile(r"(className\s*=\s*\{`)(.*?)(`\})", re.DOTALL)
+# clsx/classnames/cx("...", '...') — captures first arg string only; handles
+# typical patterns like clsx("hide sm:show", condition && "md:flex")
+_CLSX_STR_DQ = re.compile(r'(clsx|classnames|cx)\s*\(([^)]*)\)', re.DOTALL)
+
+
+def _rewrite_jsx(src: str, prefix_re: re.Pattern) -> str:
+    def rw_attr(m: re.Match) -> str:
+        return m.group(1) + _rewrite_string_value(m.group(2), prefix_re) + m.group(3)
+
+    out = _JSX_CLASSNAME_DQ.sub(rw_attr, src)
+    out = _JSX_CLASSNAME_SQ.sub(rw_attr, out)
+    out = _JSX_CLASSNAME_TMPL.sub(rw_attr, out)
+
+    # clsx/cx calls: rewrite string literals inside the call parens.
+    def rw_clsx(m: re.Match) -> str:
+        fn = m.group(1)
+        args = m.group(2)
+        # Replace inside double-quoted strings within the args.
+        args = re.sub(r'"([^"]*)"', lambda a: '"' + _rewrite_string_value(a.group(1), prefix_re) + '"', args)
+        args = re.sub(r"'([^']*)'", lambda a: "'" + _rewrite_string_value(a.group(1), prefix_re) + "'", args)
+        return fn + "(" + args + ")"
+
+    out = _CLSX_STR_DQ.sub(rw_clsx, out)
+    return out
+
+
+# --- HTML / Svelte / Vue / Astro --------------------------------------------
+
+# class="..." or className="..." attribute values only.
+_HTML_CLASS_DQ = re.compile(r'((?:class|className)\s*=\s*")([^"]*?)(")')
+_HTML_CLASS_SQ = re.compile(r"((?:class|className)\s*=\s*')([^']*?)(')")
+
+
+def _rewrite_html(src: str, prefix_re: re.Pattern) -> str:
+    def rw(m: re.Match) -> str:
+        return m.group(1) + _rewrite_string_value(m.group(2), prefix_re) + m.group(3)
+
+    out = _HTML_CLASS_DQ.sub(rw, src)
+    out = _HTML_CLASS_SQ.sub(rw, out)
+    return out
+
+
+# --- CSS / SCSS -------------------------------------------------------------
+
+# @apply <classes>;  — rewrite only the class list.
+_APPLY_RE = re.compile(r"(@apply\s+)(.*?)(;)", re.DOTALL)
+# Old escaped-colon selector: `.sm\:hide` in hand-authored CSS.
+_CSS_ESCAPED_COLON = re.compile(r"\.((?:sm|md|lg|xl|print))\\:([a-z][a-z0-9-]*)")
+
+
+def _rewrite_css(src: str, prefix_re: re.Pattern) -> str:
+    def rw_apply(m: re.Match) -> str:
+        return m.group(1) + _rewrite_string_value(m.group(2), prefix_re) + m.group(3)
+
+    out = _APPLY_RE.sub(rw_apply, src)
+    # Rewrite old escaped-colon selectors to hyphen form.
+    out = _CSS_ESCAPED_COLON.sub(lambda m: "." + m.group(1) + "-" + m.group(2), out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# File-level dispatch
+# ---------------------------------------------------------------------------
+
+def rewrite_file(path: Path, prefixes: Tuple[str, ...]) -> Optional[str]:
+    """Return rewritten content if any changes are needed, else None."""
+    ext = path.suffix.lower()
+    if ext not in ALL_HANDLED:
+        return None
+
+    src = path.read_text(encoding="utf-8", errors="replace")
+    prefix_re = _build_prefix_re(prefixes)
+
+    if ext in JSX_EXTS | JS_EXTS:
+        out = _rewrite_jsx(src, prefix_re)
+    elif ext in HTML_EXTS:
+        out = _rewrite_html(src, prefix_re)
+    elif ext in CSS_EXTS:
+        out = _rewrite_css(src, prefix_re)
+    else:
+        return None
+
+    return out if out != src else None
+
+
+# ---------------------------------------------------------------------------
+# File collection
+# ---------------------------------------------------------------------------
+
+def _matches_any(name: str, patterns: List[str]) -> bool:
+    return any(fnmatch.fnmatch(name, p) for p in patterns)
+
+
+def collect_paths(
+    roots: List[Path],
+    include: List[str],
+    exclude: List[str],
+) -> List[Path]:
+    found: List[Path] = []
+    for root in roots:
+        if root.is_file():
+            if root.suffix.lower() in ALL_HANDLED:
+                found.append(root)
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            # Skip excluded directories (check any component of the relative path).
+            rel = p.relative_to(root)
+            parts = rel.parts
+            if any(_matches_any(part, list(DEFAULT_EXCLUDES) + exclude) for part in parts):
+                continue
+            if p.suffix.lower() not in ALL_HANDLED:
+                continue
+            if include and not _matches_any(p.name, include):
+                continue
+            found.append(p)
+    return sorted(set(found))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("paths", nargs="+", help="Files or directories to process")
+    parser.add_argument("--write", action="store_true", help="Apply changes in place (default: dry-run diff)")
+    parser.add_argument("--include", default="", help="Comma-separated glob patterns to include (e.g. '*.tsx,*.ts')")
+    parser.add_argument("--exclude", default="", help="Comma-separated glob patterns to exclude")
+    parser.add_argument("--prefixes", default=",".join(DEFAULT_PREFIXES),
+                        help="Breakpoint prefixes to rewrite (default: sm,md,lg,xl,print)")
+    args = parser.parse_args()
+
+    include = [p.strip() for p in args.include.split(",") if p.strip()]
+    exclude = [p.strip() for p in args.exclude.split(",") if p.strip()]
+    prefixes = tuple(p.strip() for p in args.prefixes.split(",") if p.strip())
+
+    roots: List[Path] = []
+    for raw in args.paths:
+        p = Path(raw)
+        if not p.exists():
+            print(f"error: path not found: {p}", file=sys.stderr)
+            return 2
+        roots.append(p)
+
+    files = collect_paths(roots, include, exclude)
+    if not files:
+        print("No handled files found.", file=sys.stderr)
+        return 0
+
+    changes_pending = False
+
+    for path in files:
+        try:
+            new_content = rewrite_file(path, prefixes)
+        except OSError as e:
+            print(f"error reading {path}: {e}", file=sys.stderr)
+            return 2
+
+        if new_content is None:
+            continue
+
+        changes_pending = True
+
+        if args.write:
+            try:
+                path.write_text(new_content, encoding="utf-8")
+                print(f"updated: {path}")
+            except OSError as e:
+                print(f"error writing {path}: {e}", file=sys.stderr)
+                return 2
+        else:
+            # Print unified diff.
+            old_lines = path.read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+            new_lines = new_content.splitlines(keepends=True)
+            diff = difflib.unified_diff(
+                old_lines, new_lines,
+                fromfile=f"a/{path}",
+                tofile=f"b/{path}",
+            )
+            sys.stdout.writelines(diff)
+
+    if changes_pending and not args.write:
+        print("\n# Dry run complete — rerun with --write to apply changes.", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/clsx-helper.after.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/clsx-helper.after.tsx
@@ -1,0 +1,4 @@
+// clsx helper fixture
+import clsx from "clsx";
+const cls = clsx("hide sm-show", isMobile && "md-flex", "lg-p-4");
+const cls2 = cx('print-hide', active && 'xl-bg-primary');

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/clsx-helper.before.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/clsx-helper.before.tsx
@@ -1,0 +1,4 @@
+// clsx helper fixture
+import clsx from "clsx";
+const cls = clsx("hide sm:show", isMobile && "md:flex", "lg:p-4");
+const cls2 = cx('print:hide', active && 'xl:bg-primary');

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/css-selector.after.css
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/css-selector.after.css
@@ -1,0 +1,8 @@
+/* CSS escaped-colon selector fixture */
+@media (width >= 30rem) {
+  .sm-hide { display: none !important; }
+  .sm-show { display: revert !important; }
+}
+@media (width >= 48rem) {
+  .md-flex-row { flex-direction: row; }
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/css-selector.before.css
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/css-selector.before.css
@@ -1,0 +1,8 @@
+/* CSS escaped-colon selector fixture */
+@media (width >= 30rem) {
+  .sm\:hide { display: none !important; }
+  .sm\:show { display: revert !important; }
+}
+@media (width >= 48rem) {
+  .md\:flex-row { flex-direction: row; }
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/html-class.after.html
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/html-class.after.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="hide sm-show md-flex-row">
+    <nav className="bg-primary lg-p-6 xl-grid-cols-3">nav</nav>
+  </div>
+</body>
+</html>

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/html-class.before.html
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/html-class.before.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="hide sm:show md:flex-row">
+    <nav className="bg-primary lg:p-6 xl:grid-cols-3">nav</nav>
+  </div>
+</body>
+</html>

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/jsx-classname.after.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/jsx-classname.after.tsx
@@ -1,0 +1,8 @@
+// JSX className fixture
+export function Card() {
+  return (
+    <div className="hide sm-show md-flex-row lg-p-8 xl-grid-cols-2">
+      <aside className="bg-primary print-hide">Content</aside>
+    </div>
+  );
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/jsx-classname.before.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/jsx-classname.before.tsx
@@ -1,0 +1,8 @@
+// JSX className fixture
+export function Card() {
+  return (
+    <div className="hide sm:show md:flex-row lg:p-8 xl:grid-cols-2">
+      <aside className="bg-primary print:hide">Content</aside>
+    </div>
+  );
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/negative-url.after.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/negative-url.after.tsx
@@ -1,0 +1,5 @@
+// Negative case: URL containing sm:foo must NOT be rewritten
+const url = "https://example.com/sm:foo?bar=md:baz";
+const link = <a href="https://cdn.example.com/sm:icon.svg">Link</a>;
+// Only className values should be touched
+const cls = <div className="sm-hide">x</div>;

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/negative-url.before.tsx
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/negative-url.before.tsx
@@ -1,0 +1,5 @@
+// Negative case: URL containing sm:foo must NOT be rewritten
+const url = "https://example.com/sm:foo?bar=md:baz";
+const link = <a href="https://cdn.example.com/sm:icon.svg">Link</a>;
+// Only className values should be touched
+const cls = <div className="sm:hide">x</div>;

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/scss-apply.after.scss
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/scss-apply.after.scss
@@ -1,0 +1,7 @@
+/* SCSS @apply fixture */
+.card {
+  @apply hide sm-show md-flex-row;
+}
+.btn {
+  @apply bg-primary lg-p-6 xl-text-lg;
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/scss-apply.before.scss
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/scss-apply.before.scss
@@ -1,0 +1,7 @@
+/* SCSS @apply fixture */
+.card {
+  @apply hide sm:show md:flex-row;
+}
+.btn {
+  @apply bg-primary lg:p-6 xl:text-lg;
+}

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/ts-template-literal.after.ts
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/ts-template-literal.after.ts
@@ -1,0 +1,7 @@
+// TypeScript: rewrite inside className= and clsx() only
+// (bare string assignments are NOT rewritten — see script docstring)
+import clsx from "clsx";
+
+const isMobile = true;
+const classes = clsx("hide sm-show", isMobile ? "md-flex-row" : "lg-flex-col");
+const btn = classnames("bg-primary xl-p-6", active && "sm-font-bold");

--- a/plugins/acss-utilities/scripts/tests/migrate_fixtures/ts-template-literal.before.ts
+++ b/plugins/acss-utilities/scripts/tests/migrate_fixtures/ts-template-literal.before.ts
@@ -1,0 +1,7 @@
+// TypeScript: rewrite inside className= and clsx() only
+// (bare string assignments are NOT rewritten — see script docstring)
+import clsx from "clsx";
+
+const isMobile = true;
+const classes = clsx("hide sm:show", isMobile ? "md:flex-row" : "lg:flex-col");
+const btn = classnames("bg-primary xl:p-6", active && "sm:font-bold");

--- a/plugins/acss-utilities/scripts/validate_utilities.py
+++ b/plugins/acss-utilities/scripts/validate_utilities.py
@@ -6,7 +6,7 @@ Two modes (auto-detected by filename):
 
   Mode A — utility CSS files (`utilities.css` or `utilities/<family>.css`)
     - Selectors must be `.kebab-case`, with optional escaped breakpoint
-      prefix (e.g. `.sm\\:hide`) and optional pseudo-class (e.g. `:focus`).
+      prefix (e.g. `.sm-hide`) and optional pseudo-class (e.g. `:focus`).
     - Every `var(--x)` must include a fallback (`var(--x, …)`).
     - No duplicate selectors at the same nesting level.
     - Every responsive variant present at one breakpoint must be present
@@ -55,12 +55,13 @@ except ImportError:
 # from the same source.
 DEFAULT_PREFIXES = ("sm", "md", "lg", "xl", "print")
 
-# A utility selector: `.<prefix>\:<name>` or `.<name>`, with optional
-# pseudo-class (e.g. `:focus`, `:focus-within`).
+# A utility selector: `.<body>` or `.<bp>-<name>`, with optional pseudo-class
+# (e.g. `:focus`, `:focus-within`). Stage A: canonical form only. Stage B
+# prefix detection is done in validate_utility_file by checking whether body
+# starts with a known breakpoint prefix followed by `-`.
 SELECTOR_RE = re.compile(
     r"^\."
-    r"(?:(?P<prefix>[a-z][a-z0-9-]*)\\:)?"        # optional escaped prefix
-    r"(?P<name>[a-z][a-z0-9-]*)"
+    r"(?P<body>[a-z][a-z0-9-]*)"
     r"(?P<pseudo>(?::[a-z-]+)*)$"
 )
 
@@ -79,19 +80,19 @@ def _selectors_from_prelude(prelude) -> List[str]:
     return [s.strip() for s in text.split(",") if s.strip()]
 
 
-def _validate_selector(sel: str, prefixes: Tuple[str, ...]) -> List[str]:
-    failures: List[str] = []
+def _validate_selector(sel: str, prefixes: Tuple[str, ...] = DEFAULT_PREFIXES) -> List[str]:
+    """Stage A: canonical form check. Also rejects bare prefix names as bodies.
+
+    A selector like `.sm:hide` looks like the old colon syntax (body=`sm`,
+    pseudo=`:hide`) and must be rejected — breakpoint prefix strings are
+    reserved and cannot appear as standalone class names.
+    """
     m = SELECTOR_RE.match(sel)
     if not m:
-        failures.append(f"selector not in canonical form: {sel}")
-        return failures
-    prefix = m.group("prefix")
-    if prefix and prefix not in prefixes:
-        failures.append(
-            f"selector {sel}: unknown breakpoint prefix '{prefix}' "
-            f"(allowed: {', '.join(prefixes)})"
-        )
-    return failures
+        return [f"selector not in canonical form: {sel}"]
+    if m.group("body") in prefixes:
+        return [f"selector not in canonical form: {sel}"]
+    return []
 
 
 def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
@@ -109,24 +110,43 @@ def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
     per_bp_classes: Dict[str, Set[str]] = defaultdict(set)
 
     def visit_qualified(rule, current_ctx: str):
-        body = tinycss2.serialize(rule.content) if rule.content else ""
-        for m in VAR_NO_FALLBACK_RE.finditer(body):
-            failures.append(f"{path.name}: var() without fallback: {m.group(0)}")
+        rule_body = tinycss2.serialize(rule.content) if rule.content else ""
+        for var_m in VAR_NO_FALLBACK_RE.finditer(rule_body):
+            failures.append(f"{path.name}: var() without fallback: {var_m.group(0)}")
         for sel in _selectors_from_prelude(rule.prelude):
             failures.extend(_validate_selector(sel, prefixes))
             seen_selectors[(current_ctx, sel)] += 1
-            sm = SELECTOR_RE.match(sel)
-            if not sm:
+            m = SELECTOR_RE.match(sel)
+            if not m:
                 continue
-            prefix = sm.group("prefix") or ""
-            name = sm.group("name")
-            # Pseudo-classes don't participate in parity checks.
-            if sm.group("pseudo"):
+            sel_body = m.group("body")
+            # Pseudo-classes don't participate in parity/collision checks.
+            if m.group("pseudo"):
                 continue
-            if not prefix:
-                base_classes.add(name)
+            # Stage B: detect if this selector uses a known breakpoint prefix.
+            detected_prefix = ""
+            detected_name = sel_body
+            for bp in prefixes:
+                if sel_body.startswith(bp + "-"):
+                    detected_prefix = bp
+                    detected_name = sel_body[len(bp) + 1:]
+                    break
+            if not detected_prefix:
+                base_classes.add(sel_body)
             else:
-                per_bp_classes[prefix].add(name)
+                # Collision guard: prefixed selectors must be inside the right @media.
+                in_width = "width >=" in current_ctx
+                in_print = "print" in current_ctx and "width" not in current_ctx
+                if detected_prefix == "print":
+                    if not in_print:
+                        failures.append(
+                            f"{path.name}: base class '.{sel_body}' collides with breakpoint prefix — rename"
+                        )
+                elif not in_width:
+                    failures.append(
+                        f"{path.name}: base class '.{sel_body}' collides with breakpoint prefix — rename"
+                    )
+                per_bp_classes[detected_prefix].add(detected_name)
 
     for rule in rules:
         if rule.type == "error":
@@ -148,9 +168,19 @@ def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
             ctx_label = ctx or "top-level"
             failures.append(f"{path.name}: duplicate selector {sel} in {ctx_label} ({count}×)")
 
-    # Responsive parity: every base class that appears prefixed at one bp
-    # should appear at every other declared bp (`print` is exempt — fpkit
-    # only ships `.print\:hide`).
+    # Check 1: base-class-existence — every responsive variant must have a
+    # corresponding base class in the same file. Without this, a generator
+    # bug could emit `.sm-bogus` at all breakpoints with no `.bogus` base.
+    for bp, names in per_bp_classes.items():
+        for name in names:
+            if name not in base_classes:
+                failures.append(
+                    f"{path.name}: responsive variant '.{bp}-{name}' has no base class '.{name}'"
+                )
+
+    # Check 3: responsive parity — every base class that appears prefixed at
+    # one bp should appear at every other declared bp (`print` is exempt —
+    # fpkit only ships `.print-hide`).
     declared_bps = sorted(b for b in per_bp_classes if b != "print")
     if declared_bps:
         for bp in declared_bps:
@@ -162,7 +192,7 @@ def validate_utility_file(path: Path, prefixes: Tuple[str, ...]) -> List[str]:
                 missing = [other for other in declared_bps if cls not in per_bp_classes[other]]
                 if missing:
                     failures.append(
-                        f"{path.name}: responsive parity gap — '.{bp}\\:{cls}' "
+                        f"{path.name}: responsive parity gap — '.{bp}-{cls}' "
                         f"is declared but missing at: {', '.join(missing)}"
                     )
 

--- a/plugins/acss-utilities/skills/utilities/SKILL.md
+++ b/plugins/acss-utilities/skills/utilities/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: utilities
-description: Generate, list, tune, and bridge Tailwind-style atomic CSS utility classes for fpkit/acss projects. Mirrors fpkit upstream conventions (kebab-case, no prefix, responsive `sm:`/`md:`/`lg:`/`xl:` variants). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH role names to fpkit-style names in both light and dark modes. Use when the developer wants to add utility classes to their project, list which utilities are available, adjust the spacing baseline or breakpoints, or regenerate the bridge after a theme change.
+description: Generate, list, tune, and bridge Tailwind-style atomic CSS utility classes for fpkit/acss projects. Uses kebab-case class names with hyphen-prefixed responsive variants (`sm-hide`, `md-p-6`, `lg-flex-row`). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH role names to fpkit-style names in both light and dark modes. Use when the developer wants to add utility classes to their project, list which utilities are available, adjust the spacing baseline or breakpoints, or regenerate the bridge after a theme change.
 allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # utilities

--- a/plugins/acss-utilities/skills/utilities/references/breakpoints.md
+++ b/plugins/acss-utilities/skills/utilities/references/breakpoints.md
@@ -11,16 +11,16 @@ Responsive variants are generated for every family with `families.<f>.responsive
 | `lg` | `62rem` | 992 px | `_display.scss` (fpkit) |
 | `xl` | `80rem` | 1280 px | `_display.scss` (fpkit) |
 
-The `print` prefix is special — it maps to `@media print` rather than a viewport width. fpkit only ships `.print:hide` upstream; this plugin matches that scope and does not add other `print:` variants.
+The `print` prefix is special — it maps to `@media print` rather than a viewport width. fpkit only ships `.print:hide` upstream; this plugin emits `.print-hide` using the same hyphen-prefix convention and does not add other `print-` variants.
 
 ## Media-query syntax
 
-The generator emits modern range syntax matching fpkit:
+The generator emits modern range syntax. Responsive variants use a plain hyphen prefix — no CSS-escaping needed:
 
 ```css
 @media (width >= 30rem) {
-  .sm\:hide { display: none !important; }
-  .sm\:show { display: revert !important; }
+  .sm-hide { display: none !important; }
+  .sm-show { display: revert !important; }
   /* … every base class with `responsive: true` */
 }
 ```
@@ -29,14 +29,14 @@ Not the legacy `@media (min-width: 30rem)` form. Browser support: Chrome 104+, F
 
 ## JSX usage
 
-In CSS the colon is escaped (`\:`) because `:` is a pseudo-class delimiter; in JSX `className` strings, write the colon literally:
+Responsive class names are plain kebab-case — no escaping in CSS or JSX:
 
 ```tsx
-<div className="hide sm:show">
+<div className="hide sm-show">
   Mobile-only header
 </div>
 
-<button className="bg-primary p-4 md:p-6 lg:p-8">
+<button className="bg-primary p-4 md-p-6 lg-p-8">
   Padded button
 </button>
 ```
@@ -46,15 +46,17 @@ In CSS the colon is escaped (`\:`) because `:` is a pseudo-class delimiter; in J
 `/utility-tune "add an xs breakpoint at 20rem"` will:
 
 1. Edit `breakpoints.xs` in `utilities.tokens.json`.
-2. Regenerate the bundle — every family with `responsive: true` will get `.xs:` variants.
+2. Regenerate the bundle — every family with `responsive: true` will get `.xs-` variants.
 3. Run `validate_utilities.py` with `--prefixes=sm,md,lg,xl,xs,print` so the new prefix is accepted.
 
-Breakpoint **removal** is also supported but bundle size will drop and any project consuming `.<removed>:` classes will fall through to the base. Always communicate the removal to consumers.
+Breakpoint **removal** is also supported but bundle size will drop and any project consuming `.<removed>-` classes will fall through to the base. Always communicate the removal to consumers.
 
 ## Responsive-parity check
 
-The validator enforces that every responsive class declared at one breakpoint is declared at every other declared breakpoint. So if your tokens.json enables `responsive: true` for `flex`, every `.flex-*` class must appear at `sm:`, `md:`, `lg:`, *and* `xl:` — partial declarations fail the contract.
+The validator enforces that every responsive class declared at one breakpoint is declared at every other declared breakpoint. So if your tokens.json enables `responsive: true` for `flex`, every `.flex-*` class must appear at `sm-`, `md-`, `lg-`, *and* `xl-` — partial declarations fail the contract.
 
-This guard prevents the silent pattern where a developer writes `.md:flex-row` in source, but the bundle only emits `.sm:flex-row` (so the class disappears at md+ and the row falls back to whatever the base value is). Generators that loop over breakpoints are the safe path; hand-authored CSS within a per-family partial must mirror across all breakpoints declared in the file.
+The validator also requires that every responsive variant has a matching base class in the same file. So `.sm-bogus` at all four breakpoints with no base `.bogus` fails with a base-class-existence error.
+
+This guard prevents the silent pattern where a developer writes `.md-flex-row` in source, but the bundle only emits `.sm-flex-row` (so the class disappears at md+ and the row falls back to whatever the base value is). Generators that loop over breakpoints are the safe path; hand-authored CSS within a per-family partial must mirror across all breakpoints declared in the file.
 
 `print` is exempt from the parity check (it's a single-purpose prefix, not part of the responsive family).

--- a/plugins/acss-utilities/skills/utilities/references/naming-convention.md
+++ b/plugins/acss-utilities/skills/utilities/references/naming-convention.md
@@ -1,18 +1,28 @@
 # Naming convention
 
-Class names mirror **fpkit/acss upstream** (`@fpkit/acss@6.5.0`) verbatim where present, and follow the same kebab-case pattern for families this plugin extends beyond upstream. See [ATTRIBUTION.md](../../../ATTRIBUTION.md) for the upstream/extended split.
+Class names use kebab-case throughout. Responsive variants use a plain hyphen separator — no CSS-escape boilerplate in source or JSX. Token values, breakpoint widths, and media-query syntax still mirror fpkit upstream; class-name form is a deliberate divergence. See [ATTRIBUTION.md](../../../ATTRIBUTION.md) for the upstream/extended split.
 
 ## Selector form
 
 ```text
-.<prefix>\:<name><pseudo?>
+.<name><pseudo?>              (base)
+.<prefix>-<name><pseudo?>     (responsive variant)
 ```
 
-- **`<prefix>`** — *optional*. One of `sm`, `md`, `lg`, `xl`, `print`. The `:` separator is escaped to `\:` in CSS but written as `:` in JSX (`<div className="sm:hide">…`).
+- **`<prefix>`** — *optional*. One of `sm`, `md`, `lg`, `xl`, `print`. Followed by a literal hyphen. Examples: `sm-hide`, `md-p-6`, `xl-flex-row`.
 - **`<name>`** — kebab-case; lowercase letters, digits, and hyphens. Starts with a letter. Examples: `bg-primary`, `mt-4`, `flex-col-reverse`, `grid-cols-12`.
 - **`<pseudo>`** — *optional*. Any standard CSS pseudo-class (`:focus`, `:focus-within`, `:hover`). Used by `sr-only-focusable`.
 
-The validator (`scripts/validate_utilities.py`) enforces this form. PascalCase, snake_case, and unrecognized prefixes (`xxl:`, `desktop:`) all fail.
+The validator (`scripts/validate_utilities.py`) enforces this form. PascalCase, snake_case, and old colon-separator syntax (`sm:hide`, `md\:p-6`) all fail.
+
+### Prefix-allowlist rule
+
+The strings `sm`, `md`, `lg`, `xl`, and `print` are **reserved** as prefix namespaces. The validator enforces two structural properties:
+
+1. **Context constraint** — any selector whose body starts with `<prefix>-` is only valid inside the matching `@media` block (`@media (width >= …)` for viewport prefixes; `@media print` for `print-`). A selector like `.sm-foo` at the top level fails with "collides with breakpoint prefix — rename".
+2. **Base-class-existence** — for every responsive variant `.sm-foo`, a base class `.foo` must exist in the same file. This prevents generator bugs from silently emitting variants with no base to fall back to.
+
+**Worked example:** adding a top-level `.sm-card` class (perhaps to mean "small card") is invalid — rename it to `.card-sm` or `.card-compact` to avoid the namespace collision.
 
 ## Family-name conventions
 
@@ -22,7 +32,7 @@ The validator (`scripts/validate_utilities.py`) enforces this form. PascalCase, 
 | `color-text` | `text-` | `color` (when value is a role) |
 | `color-border` | `border-` | `border-color` |
 | `spacing` | `m-/mt-/mb-/ml-/mr-/mx-/my-/p-/pt-/pb-/pl-/pr-/px-/py-/gap-` | `margin*`, `padding*`, `gap` |
-| `display` | `hide`, `show`, `invisible`, `sr-only`, `sr-only-focusable`, `print:hide` | `display`, `visibility` |
+| `display` | `hide`, `show`, `invisible`, `sr-only`, `sr-only-focusable`, `print-hide` | `display`, `visibility` |
 | `flex` | `flex`, `flex-*`, `justify-*`, `items-*` | `display`, `flex-*`, `justify-content`, `align-items` |
 | `grid` | `grid`, `grid-cols-*`, `grid-rows-*`, `inline-grid` | `display`, `grid-template-*` |
 | `type` | `text-{xs,sm,…}`, `font-*`, `leading-*`, `text-{left,center,right,justify}` | `font-size`, `font-weight`, `line-height`, `text-align` |
@@ -44,7 +54,7 @@ This collision is intentional — fpkit and Tailwind both ship it. The names don
 
 Only **display / visibility** utilities use `!important`:
 
-- `.hide`, `.show`, `.invisible`, all `.<bp>:hide` variants, `.print:hide`
+- `.hide`, `.show`, `.invisible`, all `.<bp>-hide` variants, `.print-hide`
 
 Rationale: utilities that change layout intent (showing or hiding a block) must defeat any component-level `display:` rules. Color / spacing / typography utilities are **composable** and should not use `!important` — they layer on top of component CSS through the cascade.
 

--- a/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
+++ b/plugins/acss-utilities/skills/utilities/references/utility-catalogue.md
@@ -10,7 +10,7 @@ Every family the plugin emits in v1, every class within it, and the CSS custom p
 | `color-text` | no | 11 | `--color-*`, `--color-text-*` |
 | `color-border` | no | 11 | `--color-*` |
 | `spacing` | yes (sm/md/lg/xl) | 210 base + 210 × 4 bps = 1050 | none — literal rem values |
-| `display` | yes (sm/md/lg/xl/print) | 3 responsive base (`hide`/`show`/`invisible`) + 3 × 4 bps + `print:hide` + sr-only ×2 = 18 | none |
+| `display` | yes (sm/md/lg/xl/print) | 3 responsive base (`hide`/`show`/`invisible`) + 3 × 4 bps + `print-hide` + sr-only ×2 = 18 | none |
 | `flex` | yes (sm/md/lg/xl) | 21 base × 5 = 105 | none |
 | `grid` | yes (sm/md/lg/xl) | 20 base × 5 = 100 | none |
 | `type` | no | 19 | none — literal values from `tokens.type` |
@@ -69,7 +69,7 @@ Generated from `tokens.spacing.{baseline, scale, properties}`. Each (property, s
 - **Properties**: `m`, `mt`, `mb`, `ml`, `mr`, `mx`, `my`, `p`, `pt`, `pb`, `pl`, `pr`, `px`, `py`, `gap`
 - **Scale**: `[0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32]`
 - **Baseline**: `0.25rem` (so `.m-4 = 1rem`, `.p-8 = 2rem`)
-- **Responsive**: yes — every class has `.sm:`, `.md:`, `.lg:`, `.xl:` variants
+- **Responsive**: yes — every class has `.sm-`, `.md-`, `.lg-`, `.xl-` variants
 
 Examples:
 
@@ -80,7 +80,7 @@ Examples:
 | `.mt-2` | `margin-top: 0.5rem` |
 | `.px-6` | `padding-left: 1.5rem; padding-right: 1.5rem` |
 | `.gap-3` | `gap: 0.75rem` |
-| `.sm:p-4` | wrapped in `@media (width >= 30rem)` |
+| `.sm-p-4` | wrapped in `@media (width >= 30rem)` |
 
 ## display
 
@@ -93,8 +93,8 @@ Layout / visibility primitives.
 | `.invisible` | `visibility: hidden !important` | preserves layout |
 | `.sr-only` | absolute clip rect | screen-reader-only utility |
 | `.sr-only-focusable` | absolute clip rect, becomes static on focus | skip-link pattern |
-| `.print:hide` | `display: none !important` inside `@media print` | print-specific |
-| `.sm:hide` etc. | `display: none !important` inside `@media (width >= …)` | responsive |
+| `.print-hide` | `display: none !important` inside `@media print` | print-specific |
+| `.sm-hide` etc. | `display: none !important` inside `@media (width >= …)` | responsive |
 
 `.sr-only` and `.sr-only-focusable` are not responsive — they're accessibility primitives that should always be active regardless of viewport.
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,6 +20,7 @@
 #      bundle-size budget).
 #   9. acss-utilities idempotency: regenerate from utilities.tokens.json
 #      and diff against the committed bundle + per-family partials.
+#  10. migrate_classnames.py fixture round-trip + idempotency.
 #
 # Why syntax-only TSX validation: the reference docs split TSX across
 # multiple Key Pattern sections containing illustrative JSX or
@@ -205,6 +206,53 @@ if [ -f "$UTIL_DIR/utilities.tokens.json" ]; then
   green "acss-utilities idempotency OK"
 else
   yellow "no plugins/acss-utilities/assets/utilities.tokens.json — skipping idempotency check"
+fi
+
+# Step 10
+section "10. migrate_classnames.py fixture round-trip + idempotency"
+MIGRATE_SCRIPT="$REPO_ROOT/plugins/acss-utilities/scripts/migrate_classnames.py"
+FIXTURES_DIR="$REPO_ROOT/plugins/acss-utilities/scripts/tests/migrate_fixtures"
+if [ -f "$MIGRATE_SCRIPT" ] && [ -d "$FIXTURES_DIR" ]; then
+  MIGRATE_LOG="$TMP_ROOT/migrate-classnames.log"
+  MIGRATE_FAIL=0
+  MIGRATE_TMP="$TMP_ROOT/migrate-fixtures"
+  mkdir -p "$MIGRATE_TMP"
+  for before in "$FIXTURES_DIR"/*.before.*; do
+    [ -f "$before" ] || continue
+    bname="$(basename "$before")"
+    ext="${bname##*.}"
+    stem="${bname%.before.*}"
+    after="$FIXTURES_DIR/${stem}.after.${ext}"
+    [ -f "$after" ] || continue
+    tmp_copy="$MIGRATE_TMP/${bname}"
+    cp "$before" "$tmp_copy"
+    # Run once (write mode)
+    python3 "$MIGRATE_SCRIPT" "$tmp_copy" --write >/dev/null 2>&1
+    # Compare to .after fixture
+    if ! diff -q "$tmp_copy" "$after" >/dev/null 2>&1; then
+      echo "FAIL (round-trip): $stem" >> "$MIGRATE_LOG"
+      diff "$after" "$tmp_copy" >> "$MIGRATE_LOG" 2>&1 || true
+      MIGRATE_FAIL=1
+      continue
+    fi
+    # Run again (idempotency)
+    cp "$tmp_copy" "${tmp_copy}.orig"
+    python3 "$MIGRATE_SCRIPT" "$tmp_copy" --write >/dev/null 2>&1
+    if ! diff -q "${tmp_copy}.orig" "$tmp_copy" >/dev/null 2>&1; then
+      echo "FAIL (idempotency): $stem" >> "$MIGRATE_LOG"
+      MIGRATE_FAIL=1
+    fi
+    rm -f "${tmp_copy}.orig"
+  done
+  if [ "$MIGRATE_FAIL" -eq 0 ]; then
+    green "migrate_classnames fixture tests OK"
+  else
+    red "migrate_classnames fixture tests FAILED:"
+    cat "$MIGRATE_LOG"
+    exit 1
+  fi
+else
+  yellow "migrate_classnames.py or fixtures not found — skipping"
 fi
 
 section "ALL STEPS GREEN"


### PR DESCRIPTION
## Summary

- **Breaking:** responsive variant class names now use a plain hyphen separator (`.sm-hide`, `.md-p-6`, `.print-hide`) instead of the escaped-colon form (`.sm\:hide`). No CSS escaping needed in stylesheets or JSX `className` strings.
- **Validator redesigned:** new Stage B prefix detection, base-class-existence check, collision guard (prefix selectors only valid inside matching `@media`), reserved bare prefix names to catch old colon syntax.
- **New `scripts/migrate_classnames.py`:** dry-run/write codemod covering JSX/TSX, TS/JS (clsx/classnames), HTML (`class=`/`className=`), CSS/SCSS (`@apply` + escaped selectors). 7 fixture pairs, integrated into `tests/run.sh` Step 10.
- All CSS partials regenerated; `tests/run.sh` 10/10 green.
- Version bumped to `0.2.0`; docs, CHANGELOG, ATTRIBUTION, and marketplace description updated.

## Migration

Search-and-replace in JSX `className` strings and CSS `@apply` directives: `sm:` → `sm-`, `md:` → `md-`, `lg:` → `lg-`, `xl:` → `xl-`, `print:` → `print-`. Automated path: `python3 plugins/acss-utilities/scripts/migrate_classnames.py src/ --write`.

## Test plan

- [x] `tests/run.sh` all 10 steps green
- [x] Validator rejects old bundle (exit 1 with canonical-form errors)
- [x] Validator passes new bundle (exit 0)
- [x] Three negative validator tests: raw colon selector, variant-with-no-base, top-level prefix collision
- [x] Generator idempotency verified
- [x] Migration script: 7 fixture round-trips + idempotency pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)