### PR TITLE
docs(acss-kit): add browser-preview recipe for generated components

### DIFF
--- a/docs/plans/precious-cooking-bunny.md
+++ b/docs/plans/precious-cooking-bunny.md
@@ -1,0 +1,98 @@
+# Document the browser-preview workflow for kit-add components
+
+## Context
+
+We just used a 3-step workflow to render the `kit-add`-generated `Button` component in Chrome for visual verification:
+
+1. Compile the generated SCSS → CSS
+2. Write a standalone HTML preview file (compiled CSS inlined, demo markup using the `data-*` variant attributes) into `tests/sandbox/`
+3. Serve `tests/sandbox/` over `python3 -m http.server` and open the preview URL (manually or via the `claude-in-chrome` MCP)
+
+This is the only way to *visually* smoke-test a generated component today. `tests/setup.sh` deliberately omits a dev server (see `tests/README.md` line 131 — "previewing rendered components in a real browser was explicitly removed because the goal is to test the skill output, not to render a React app"), so contributors with no playbook for visual checks tend to either skip the visual verification entirely or reach for a heavier Vite/Storybook setup.
+
+The intended outcome of this plan: capture the workflow as a task-oriented recipe so any contributor can reproduce it in under a minute, **without** contradicting the existing "no dev server in the sandbox" stance — the recipe is framed as a static-HTML preview (compiled CSS + plain markup), not a React dev server.
+
+## Approach
+
+Add **one new recipe** to `plugins/acss-kit/docs/recipes.md` and **one cross-reference line** in `tests/README.md`.
+
+### File 1 — `plugins/acss-kit/docs/recipes.md` (add new section)
+
+Append a `## Preview a generated component in a browser` section after the existing recipes. The section follows the file's existing shape (intro paragraph → Prerequisites → numbered steps → expected outcome). Concretely:
+
+- **Intro** — one paragraph: this is an opt-in, static-HTML smoke check that exercises the *compiled CSS and `data-*` selectors*; it does not boot React. Use it to eyeball variant coverage after generating a new component, not to test event handlers.
+- **Prerequisites:**
+  - `tests/sandbox/` exists (run `tests/setup.sh` if not — link to `tests/README.md#demo-fixture`)
+  - The target component has been generated via `/kit-add <name>` into the sandbox
+  - Python 3 on `PATH` (no extra deps — uses `python3 -m http.server`)
+- **Steps (numbered):**
+  1. From `tests/sandbox/`, compile the SCSS:
+     ```sh
+     npx sass --no-source-map src/components/fpkit/<name>/<name>.scss > /tmp/<name>.css
+     ```
+     (The recipe does not need to dump CSS to a separate file — but stating the option lets contributors inspect the compiled output if `<name>-preview.html` shows nothing.)
+  2. Write `tests/sandbox/<name>-preview.html` from the template below. Inline the compiled CSS in a `<style>` block; render one row per variant using the `data-color`, `data-style`, `data-btn`, and `aria-disabled` attributes the component would emit.
+  3. Start a local HTTP server from `tests/sandbox/`:
+     ```sh
+     python3 -m http.server 7743 &
+     ```
+     (Background it so the same shell can stop it later with `kill %1` or by capturing the PID.)
+  4. Open `http://localhost:7743/<name>-preview.html` — manually, or in a Claude Code session via the `claude-in-chrome` MCP (`navigate` + `computer screenshot`).
+  5. Stop the server when done: `kill %1` (or the saved PID).
+- **HTML template** — a fenced `html` block based on the `button-preview.html` we just wrote. Keep it generic by naming the variant rows after the `data-*` axes (`Default / Colors / Style variants / Sizes / Disabled`) and noting that components without a given axis simply omit that row.
+- **Honest-scope note** — one sentence at the end: this preview only covers what CSS can render. Behavior (focus management, `useDisabledState` short-circuiting, keyboard activation) is verified by `tests/e2e.sh`'s axe-core run, not here.
+- **Gitignore note** — one sentence: `*-preview.html` files are scratch artifacts; either delete them or add a `tests/sandbox/*-preview.html` entry to the gitignore (mention but don't prescribe).
+
+### File 2 — `tests/README.md` (one-line cross-reference)
+
+Inside the existing `## Demo fixture: tests/setup.sh` section (around the "Running the recipe" subsection at ~line 156), add a single bullet:
+
+> **Optional:** to visually verify a generated component's CSS variants in a browser, see [Preview a generated component in a browser](../plugins/acss-kit/docs/recipes.md#preview-a-generated-component-in-a-browser). This is a static-HTML preview, not a revival of the removed dev server.
+
+The framing ("static-HTML preview, not a revival of the removed dev server") preserves the existing stance on line 131 while pointing readers at the escape hatch.
+
+## Files to modify
+
+- `plugins/acss-kit/docs/recipes.md` — add new `## Preview a generated component in a browser` section (≈ 60 lines including the HTML template fence)
+- `tests/README.md` — add one cross-reference bullet inside `## Demo fixture: tests/setup.sh`
+
+## Files NOT to modify
+
+- `plugins/acss-kit/docs/visual-guide.md` line 128's screenshot TODO — out of scope for this plan; can be addressed separately
+- `plugins/acss-kit/docs/README.md` — the recipes file is already linked from the index, so no link update needed
+- `tests/setup.sh` — explicitly do not bake the preview HTML or HTTP server into the bootstrap; this stays opt-in
+- `tests/sandbox/.gitignore` (or root `.gitignore`) — mention the gitignore option in the recipe but don't prescribe a code change as part of this plan; the sandbox is itself gitignored under `.claude/worktrees/`, so committed `*-preview.html` would only matter if a contributor runs `tests/setup.sh` outside a worktree
+
+## Existing patterns reused
+
+- **Recipe shape** — the file's existing recipes (`First run`, `Generate a single leaf component`, `Generate a component with dependencies`) all use the same intro + Prerequisites + numbered steps shape. Mirror it exactly.
+- **Cross-reference style** — `tests/README.md` already cross-links between sections (e.g. `Quick local test: --plugin-dir` → `Demo fixture: tests/setup.sh`). The new bullet matches that style.
+- **HTML preview template** — the `button-preview.html` we just generated at `tests/sandbox/button-preview.html` (in the worktree) is the canonical template. Generalize the `<h2>` row labels to match each component's variant axes.
+
+## Verification
+
+End-to-end test of the plan after implementation:
+
+1. From `/Users/shawnsandy/devbox/acss-plugins/.claude/worktrees/test-plugin/`, render the new recipes section and confirm the markdown is well-formed:
+   ```sh
+   grep -n "Preview a generated component in a browser" plugins/acss-kit/docs/recipes.md
+   grep -n "Preview a generated component in a browser" tests/README.md
+   ```
+2. Walk through the recipe verbatim with a *different* component (not `button` — try `badge` or `card`) to confirm the steps generalize:
+   - `bash tests/setup.sh --reset` to wipe and rebuild the sandbox
+   - `/kit-add badge` (in a Claude session inside `tests/sandbox/`)
+   - Follow steps 1–5 of the new recipe, swapping `<name>` for `badge`
+   - Confirm the preview renders and the `data-*` rows show variant changes
+3. Run the existing test suite to confirm the doc-only changes do not break the structural validation:
+   ```sh
+   bash tests/run.sh
+   ```
+   Expected: all 9 steps green (no doc-aware checks exist, but this confirms no accidental file moves).
+4. Confirm the hyperlinks resolve when rendered on GitHub:
+   - `tests/README.md` → `plugins/acss-kit/docs/recipes.md#preview-a-generated-component-in-a-browser` (relative path, anchor matches the heading slug)
+
+## Out of scope (next steps)
+
+- Promoting `button-preview.html` to a reusable Python or Node script that auto-generates the HTML from a component's reference doc — would let contributors run `python3 scripts/preview.py button` instead of hand-writing the HTML. Worth considering once the recipe sees use.
+- Linking the recipe from `plugins/acss-kit/docs/visual-guide.md` line 128's screenshot TODO. Separate concern (visual-guide is about the broader theme/style story, not per-component previews).
+- Adding a `*-preview.html` entry to `tests/sandbox/.gitignore`. The sandbox lives under `.claude/worktrees/` (already gitignored) for most contributors; only contributors who run `tests/setup.sh` from the repo root would need this.

--- a/plugins/acss-kit/docs/recipes.md
+++ b/plugins/acss-kit/docs/recipes.md
@@ -183,3 +183,107 @@ Output includes the Generation Contract (dependency tree), the props interface, 
 ```
 
 Prints all components organized by category (Simple / Interactive / Layout / Complex) with a one-line description of each.
+
+---
+
+## Preview a generated component in a browser
+
+An opt-in, static-HTML smoke check that exercises the *compiled CSS and `data-*` selectors* of a generated component — no React runtime required. Use it to eyeball variant coverage after generating a new component, not to test event handlers or dynamic behavior.
+
+**Prerequisites:**
+
+- `tests/sandbox/` exists — run `tests/setup.sh` if not ([Demo fixture](../../../tests/README.md#demo-fixture-testssetupsh))
+- The target component has been generated via `/kit-add <name>` into the sandbox
+- Python 3 on `PATH` (no extra deps — uses `python3 -m http.server`)
+
+**Steps:**
+
+1. From `tests/sandbox/`, compile the component's SCSS to a plain CSS string:
+
+   ```sh
+   npx sass --no-source-map src/components/fpkit/<name>/<name>.scss > /tmp/<name>.css
+   ```
+
+   This step is optional but useful if the preview renders nothing — you can inspect the compiled output directly to confirm selectors compiled as expected.
+
+2. Write `tests/sandbox/<name>-preview.html` using the template below. Paste the compiled CSS into the `<style>` block and render one `<div class="row">` per variant axis the component supports (`data-color`, `data-style`, `data-<name>`, `aria-disabled`). Omit any axis the component does not use.
+
+3. Start a local HTTP server from `tests/sandbox/`:
+
+   ```sh
+   python3 -m http.server 7743 &
+   ```
+
+   Background it so the shell stays usable. Stop it later with `kill %1` or by capturing the PID (`python3 -m http.server 7743 & echo $!`).
+
+4. Open the preview — manually in any browser, or in a Claude Code session via the `claude-in-chrome` MCP (`navigate` then `computer screenshot`):
+
+   ```
+   http://localhost:7743/<name>-preview.html
+   ```
+
+5. Stop the server when done:
+
+   ```sh
+   kill %1
+   ```
+
+**HTML template:**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><Name> Preview — acss-kit</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: system-ui, sans-serif;
+      background: #f8f9fa;
+      color: #1a1a1a;
+      padding: 2rem;
+      margin: 0;
+    }
+    h1 { font-size: 1.25rem; margin-bottom: 2rem; color: #444; font-weight: 500; }
+    h2 { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: #888; margin: 2rem 0 0.75rem; }
+    .row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+
+    /* paste compiled <name>.css output here */
+  </style>
+</head>
+<body>
+  <h1><Name> — acss-kit preview</h1>
+
+  <h2>Default</h2>
+  <div class="row">
+    <!-- default (no variant attributes) -->
+  </div>
+
+  <h2>Colors</h2>
+  <div class="row">
+    <!-- data-color="primary", data-color="danger", etc. — omit if component has no color axis -->
+  </div>
+
+  <h2>Style variants</h2>
+  <div class="row">
+    <!-- data-style="outline", data-style="pill", etc. — omit if component has no style axis -->
+  </div>
+
+  <h2>Sizes</h2>
+  <div class="row">
+    <!-- data-<name>="xs", "sm", "lg", "xl" — omit if component has no size axis -->
+  </div>
+
+  <h2>Disabled (aria-disabled — stays focusable)</h2>
+  <div class="row">
+    <!-- aria-disabled="true" on default and one or two key variants -->
+  </div>
+</body>
+</html>
+```
+
+This preview only covers what CSS can render. Behavior (focus management, keyboard activation, React state) is verified by `tests/e2e.sh`'s axe-core run, not here.
+
+`*-preview.html` files are scratch artifacts; either delete them after use or add a `tests/sandbox/*-preview.html` entry to your gitignore (the sandbox itself is gitignored under `.claude/worktrees/`, so committed preview files only matter if you run `tests/setup.sh` outside a worktree).

--- a/tests/README.md
+++ b/tests/README.md
@@ -196,6 +196,8 @@ Create a signup form with email and password.
 
 The `component-form` skill should auto-trigger, vendor any missing form dependencies through `/kit-add`, and write a form under `src/forms/`.
 
+- **Optional:** to visually verify a generated component's CSS variants in a browser, see [Preview a generated component in a browser](../plugins/acss-kit/docs/recipes.md#preview-a-generated-component-in-a-browser). This is a static-HTML preview, not a revival of the removed dev server.
+
 ### Reset
 
 ```sh


### PR DESCRIPTION
## Summary
- Adds a new `## Preview a generated component in a browser` recipe to `plugins/acss-kit/docs/recipes.md` with 5 numbered steps, an HTML template, and honest-scope notes
- Adds a one-line cross-reference bullet in `tests/README.md` (inside `### Smoke flow`) pointing at the new recipe, framed as a static-HTML preview to preserve the existing no-dev-server stance
- Commits the associated plan file (`docs/plans/precious-cooking-bunny.md`)

## Changes
Documents the 3-step static-HTML workflow for visually smoke-testing a `kit-add`-generated component (compile SCSS → write preview HTML → serve via `python3 -m http.server`). The recipe is opt-in and does not touch `tests/setup.sh` or the sandbox bootstrap — it stays a contributor escape hatch for eyeballing CSS variant coverage without a React dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)