### PR TITLE
Add acss-utilities plugin and update documentation

### DIFF
--- a/.agents/skills/verify-plugins/SKILL.md
+++ b/.agents/skills/verify-plugins/SKILL.md
@@ -77,7 +77,14 @@ plugins/acss-kit
   PASS  skills/ contains SKILL.md files
   PASS  commands/ has .md files
 
-Summary: 1 plugin checked, 0 failures total.
+plugins/acss-utilities
+  PASS  Manifest fields (name, version, description)
+  PASS  Marketplace entry has no version key
+  PASS  README.md present
+  PASS  skills/ contains SKILL.md files
+  PASS  commands/ has .md files
+
+Summary: 2 plugins checked, 0 failures total.
 ```
 
 If all pass: "All plugins passed structural checks."

--- a/.claude/skills/verify-plugins/SKILL.md
+++ b/.claude/skills/verify-plugins/SKILL.md
@@ -77,7 +77,14 @@ plugins/acss-kit
   PASS  skills/ contains SKILL.md files
   PASS  commands/ has .md files
 
-Summary: 1 plugin checked, 0 failures total.
+plugins/acss-utilities
+  PASS  Manifest fields (name, version, description)
+  PASS  Marketplace entry has no version key
+  PASS  README.md present
+  PASS  skills/ contains SKILL.md files
+  PASS  commands/ has .md files
+
+Summary: 2 plugins checked, 0 failures total.
 ```
 
 If all pass: "All plugins passed structural checks."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,10 @@ A Claude Code **plugin marketplace** - not a Node.js or Python package. There ar
 
 **Stack:** Claude Code plugin format, Python 3 (scripts), SCSS/CSS custom properties (generated output).
 
-The repo contains one plugin:
+The repo contains two plugins:
 
 - `plugins/acss-kit` - accessible React components and CSS themes for fpkit/acss projects.
+- `plugins/acss-utilities` - Tailwind-style atomic CSS utility classes paired with `acss-kit`'s OKLCH theme tokens via a bridge file.
 
 Maintainer tooling for working on this repo lives at `.claude/` (review agents, authoring/release skills, validation commands, advisory rules, hooks) — see [`.claude/README.md`](./.claude/README.md) for the index.
 
@@ -18,6 +19,7 @@ Install from a Claude Code session:
 ```
 /plugin marketplace add shawn-sandy/agentic-acss-plugins
 /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
+/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins
 ```
 
 ## Plugin structure
@@ -50,9 +52,9 @@ Body delegates to the master SKILL.md, never re-implements logic inline.
 
 ## Version bumps
 
-Plugin versions live in one authoritative place:
+Plugin versions live in one authoritative place per plugin:
 
-- `plugins/acss-kit/.claude-plugin/plugin.json` - Claude Code and `/plugin update` read this
+- `plugins/<plugin>/.claude-plugin/plugin.json` - Claude Code and `/plugin update` read this
 - `.claude-plugin/marketplace.json` - omit a per-plugin `version` field here
 
 Bump only `plugin.json`. Do not add a `version` key to `marketplace.json` entries.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -37,7 +37,7 @@ Use `/plugin list` to confirm the plugins are installed and to see available sla
 npm install -D sass
 ```
 
-## Commands
+## acss-kit Commands
 
 ### `/kit-list [component]`
 
@@ -101,6 +101,26 @@ Create a signup form with email and password.
 
 It vendors required form dependencies through `/kit-add` when needed, then writes a self-contained React form under `src/forms/`.
 
+## acss-utilities Commands
+
+The `acss-utilities` plugin adds a Tailwind-style atomic CSS layer (`.bg-primary`, `.mt-4`, `.sm-hide`) and a token-bridge that aliases `acss-kit`'s OKLCH roles to fpkit-style names. See the [`acss-utilities` README](plugins/acss-utilities/README.md) and [developer guide](plugins/acss-utilities/docs/README.md) for the full reference.
+
+### `/utility-add`
+
+Drops the generated `utilities.css` bundle and `token-bridge.css` into your project.
+
+### `/utility-list`
+
+Lists utility families and their classes.
+
+### `/utility-bridge`
+
+Regenerates `token-bridge.css` against the active `acss-kit` theme, emitting both `:root` and `[data-theme="dark"]` blocks for parity.
+
+### `/utility-tune`
+
+Adjusts `utilities.tokens.json` (spacing baseline, breakpoints, family enables) from a natural-language request, regenerates the bundle, and validates the result.
+
 ## Migration From Prior Plugins
 
 `acss-kit` replaces the previous marketplace entries:
@@ -129,4 +149,6 @@ Existing `.acss-target.json` files remain compatible.
 - [Root README](README.md) for marketplace overview and install notes.
 - [acss-kit README](plugins/acss-kit/README.md) for full plugin behavior.
 - [acss-kit developer docs](plugins/acss-kit/docs/README.md) for contributor workflows.
+- [acss-utilities README](plugins/acss-utilities/README.md) for utility-class behavior.
+- [acss-utilities developer guide](plugins/acss-utilities/docs/README.md) for the command reference, recipes, and architecture notes.
 - [tests README](tests/README.md) for local smoke testing.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -3,7 +3,10 @@
 
 `agentic-acss-plugins` is a Claude Code plugin marketplace for building accessible React components and CSS themes for fpkit/acss projects.
 
-As of `0.3.0`, the marketplace ships one plugin: `acss-kit`.
+The marketplace ships two plugins:
+
+- `acss-kit` — accessible React components and OKLCH CSS themes for fpkit/acss projects.
+- `acss-utilities` — Tailwind-style atomic CSS utility classes paired with `acss-kit`'s theme tokens via a bridge file.
 
 ## Install
 
@@ -12,6 +15,7 @@ Run these commands inside a Claude Code session:
 ```text
 /plugin marketplace add shawn-sandy/agentic-acss-plugins
 /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
+/plugin install acss-utilities@shawn-sandy-agentic-acss-plugins
 ```
 
 For local testing from this repo:
@@ -19,9 +23,10 @@ For local testing from this repo:
 ```text
 /plugin marketplace add /absolute/path/to/agentic-acss-plugins
 /plugin install acss-kit@agentic-acss-plugins
+/plugin install acss-utilities@agentic-acss-plugins
 ```
 
-Use `/plugin list` to confirm the plugin is installed and to see available slash commands.
+Use `/plugin list` to confirm the plugins are installed and to see available slash commands.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Updated documentation and verification examples to reflect the addition of a second plugin (`acss-utilities`) to the marketplace alongside the existing `acss-kit` plugin.

## Key Changes
- **Documentation updates** across multiple files to reflect two plugins instead of one:
  - `GUIDE.md`: Updated introduction and installation instructions to include `acss-utilities`
  - `AGENTS.md`: Updated repo overview and installation examples for both plugins
  - Updated plugin count references from "one plugin" to "two plugins"

- **Verification examples**: Updated skill documentation files (`.agents/skills/verify-plugins/SKILL.md` and `.claude/skills/verify-plugins/SKILL.md`) with example output showing verification of both `acss-kit` and `acss-utilities` plugins (2 plugins checked instead of 1)

- **Installation instructions**: Added `/plugin install acss-utilities@...` commands to both marketplace and local testing setup sections

- **Plugin descriptions**: Added clear description of `acss-utilities` as "Tailwind-style atomic CSS utility classes paired with `acss-kit`'s theme tokens via a bridge file"

- **Minor clarifications**: Updated references from "the plugin" to "the plugins" and "plugin.json" path examples to use `<plugin>` placeholder for clarity

## Notable Details
All changes are documentation-focused with no modifications to actual plugin code or configuration files. The verification examples now accurately reflect a multi-plugin marketplace structure.

https://claude.ai/code/session_017fmGmV5BK1Xq1NFoRf6SSc