### PR TITLE
Add test-component skill for quick component preview

### DIFF
--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: test-component
+description: Render a quick visual preview of an acss-kit component in the default browser. Use when the user says "test component", "test the button", "show me the alert", "preview <component>", or any phrasing that asks to see what a component looks like. Produces a self-contained HTML file with all variants from the component's Usage Examples.
+disable-model-invocation: false
+---
+
+# test-component
+
+Goal: render a one-page visual preview of an `acss-kit` component fast — no dev server, no build step, no React. The component's SCSS works as plain CSS in any modern browser (CSS nesting is native in Chrome 112+, Firefox 117+, Safari 16.4+), so we copy it verbatim into a `<style>` tag and render the variants as static HTML.
+
+Usage examples (any of these should trigger):
+- "test component button"
+- "test the alert"
+- "show me what the card looks like"
+- "preview dialog"
+
+## Steps
+
+1. **Resolve the component name.**
+   - Lower-case it. Strip filler words ("the", "a", "component").
+   - Verify `plugins/acss-kit/skills/components/references/components/<name>.md` exists.
+   - If the name is ambiguous or missing, list `plugins/acss-kit/skills/components/references/components/*.md` and ask the user to pick.
+
+2. **Read the reference doc.**
+   Read the whole file. You need three sections:
+   - `## CSS Variables` — first fenced ``` ```scss ``` block. These are `:root` tokens.
+   - `## SCSS Template` — first fenced ``` ```scss ``` block. The component styles. Use as-is (CSS nesting is native).
+   - `## Usage Examples` — JSX snippets you'll convert to plain HTML.
+
+3. **Convert Usage Examples JSX to HTML.**
+   Each component's reference doc tells you how the JSX maps to DOM. The general rule for `acss-kit`:
+   - The React component renders a single semantic element with a class and data attributes.
+   - Look at the SCSS Template's root selector (e.g. `.btn`, `.alert`, `.card`) — that's the className.
+   - Props that map to `data-*` attributes (`color="primary"` → `data-color="primary"`, `size="lg"` → `data-btn="lg"`, `variant="outline"` → `data-style="outline"`) are documented in the Props Interface.
+   - For Button specifically: combine `size` + `block` + raw `data-btn` into a single space-separated `data-btn` token (see Key Pattern: data-btn Merging in `button.md`).
+   - For compound components (Card.Title, Card.Content, Table.Row, etc.) check the SCSS for the nested selectors and use the matching tag/class.
+   - Replace `disabled` prop with `aria-disabled="true"` and add the `is-disabled` class — never use the native `disabled` attribute.
+   - Drop event handlers (`onClick`, etc.) — this is a static preview.
+
+   Aim for one `<section>` per variant family (color, size, style, state) with a small heading. Cover every distinct example that appears in Usage Examples.
+
+4. **Generate the HTML file.**
+   Write to `tests/.tmp/preview-<name>.html` (create `tests/.tmp/` if missing). Template:
+
+   ````html
+   <!doctype html>
+   <html lang="en">
+   <head>
+     <meta charset="utf-8">
+     <title>Preview: <PascalCaseName></title>
+     <style>
+       /* ---- Page chrome (not part of the component) ---- */
+       *, *::before, *::after { box-sizing: border-box; }
+       body {
+         margin: 0;
+         padding: 2rem;
+         font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+         background: #fafafa;
+         color: #1a1a1a;
+         line-height: 1.5;
+       }
+       h1 { margin: 0 0 0.5rem; font-size: 1.5rem; }
+       h2 { margin: 2rem 0 0.75rem; font-size: 1rem; color: #555; font-weight: 600; }
+       .meta { color: #666; font-size: 0.875rem; margin-bottom: 2rem; }
+       .row { display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center; }
+       .swatch { display: inline-block; padding: 1rem; background: #fff; border: 1px solid #e5e5e5; border-radius: 0.5rem; }
+
+       /* ---- Component CSS Variables (verbatim from <name>.md) ---- */
+       :root {
+         /* paste the CSS Variables block here, indented */
+       }
+
+       /* ---- Component SCSS Template (verbatim, used as native CSS) ---- */
+       /* paste the SCSS Template block here */
+     </style>
+   </head>
+   <body>
+     <h1>Preview: <PascalCaseName></h1>
+     <p class="meta">Source: <code>plugins/acss-kit/skills/components/references/components/<name>.md</code></p>
+
+     <h2>Default</h2>
+     <div class="row swatch">
+       <!-- one minimal example -->
+     </div>
+
+     <h2>Variant family 1 (e.g. Color)</h2>
+     <div class="row swatch">
+       <!-- one element per variant -->
+     </div>
+
+     <!-- repeat per variant family -->
+   </body>
+   </html>
+   ````
+
+   Notes:
+   - Paste the CSS Variables block contents inside `:root { ... }`. Strip any SCSS-only syntax (there shouldn't be any in CSS Variables blocks — they're plain custom-property declarations).
+   - Paste the SCSS Template verbatim into the `<style>` tag. Modern CSS handles `&:hover`, `&[data-attr]`, and nested selectors natively. Do NOT compile.
+   - If the SCSS uses `@use`, `@mixin`, `@include`, `@if`, or `$variables` (rare in this repo — components are kept var()-driven), call that out and skip those lines with an HTML comment explaining what was dropped. The user can decide whether to address it.
+
+5. **Open it.**
+   Try in this order, swallowing errors:
+   ```sh
+   xdg-open tests/.tmp/preview-<name>.html 2>/dev/null \
+     || open tests/.tmp/preview-<name>.html 2>/dev/null \
+     || true
+   ```
+   Then **always** print the absolute path and `file://` URL so the user can open it manually if no GUI is available:
+   ```
+   Preview: file:///<abs-path>/tests/.tmp/preview-<name>.html
+   ```
+
+6. **Don't over-engineer.**
+   - No screenshot generation, no Puppeteer, no React, no Vite, no theme assembly. Just the component's own CSS + the example HTML.
+   - Don't write tests, don't validate accessibility, don't run the full `tests/` harness — there's a separate `/review-component` skill for that.
+   - If the user asks for something the static preview can't show (e.g. "test the click handler", "test focus trap"), say so explicitly and recommend `tests/e2e.sh` instead.
+
+## Edge cases
+
+- **Compound components** (`Card`, `Table`, `List`): the SCSS has nested selectors like `.card .card-title`. Replicate the DOM structure with the matching tags/classes.
+- **Components requiring JS** (`Dialog` uses native `<dialog>` with `showModal()`, `Popover` uses `popover` attribute): render the open state directly via the `open` attribute / `popover` attribute so the visual state shows without scripting.
+- **Form controls** (`Input`, `Checkbox`, `Field`): always pair with a `<label>` so the preview shows the accessible-name story.
+- **Icon components**: if the SCSS doesn't define the glyph, render placeholder SVGs (a 16×16 square with the variant name as text) — note this in a comment.
+
+## What success looks like
+
+User says "test the button". You produce `tests/.tmp/preview-button.html` in under 5 seconds, attempt to open it, and print the `file://` path. The file shows: default button, every color variant in a row, every size variant in a row, every style variant (outline/pill/text/icon) in a row, a disabled example, and a block-width example — all styled by the component's actual CSS.

--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -98,20 +98,39 @@ Usage examples (any of these should trigger):
    - Paste the SCSS Template verbatim into the `<style>` tag. Modern CSS handles `&:hover`, `&[data-attr]`, and nested selectors natively. Do NOT compile.
    - If the SCSS uses `@use`, `@mixin`, `@include`, `@if`, or `$variables` (rare in this repo — components are kept var()-driven), call that out and skip those lines with an HTML comment explaining what was dropped. The user can decide whether to address it.
 
-5. **Open it.**
-   Try in this order, swallowing errors:
+5. **Serve it on a lightweight HTTP server, then open it.**
+   Python 3 is already a project dependency, so `python3 -m http.server` gives us a zero-install static server. Default port: `8765`.
+
+   First, check whether a server is already up on that port (re-runs of this skill should reuse it, not spawn duplicates):
    ```sh
-   xdg-open tests/.tmp/preview-<name>.html 2>/dev/null \
-     || open tests/.tmp/preview-<name>.html 2>/dev/null \
+   curl -fsS -o /dev/null http://localhost:8765/ 2>/dev/null
+   ```
+   - Exit 0 → server already running, skip the spawn step.
+   - Non-zero → start the server. Use the **Bash tool with `run_in_background: true`** so it keeps running after this turn:
+     ```sh
+     python3 -m http.server 8765 --directory tests/.tmp --bind 127.0.0.1
+     ```
+     Then poll the port up to ~5 times with a short sleep until `curl` returns 0, so the open step doesn't race the server's startup.
+   - If port `8765` is taken by something that *isn't* our server (curl returns HTML you don't recognize, or the server's directory listing doesn't show `preview-*.html`), bump to `8766`, `8767`, etc. Don't kill whatever's already on `8765`.
+
+   Then open the URL, swallowing errors so headless environments don't fail:
+   ```sh
+   xdg-open  http://localhost:8765/preview-<name>.html 2>/dev/null \
+     || open http://localhost:8765/preview-<name>.html 2>/dev/null \
      || true
    ```
-   Then **always** print the absolute path and `file://` URL so the user can open it manually if no GUI is available:
+   **Always** print both URLs so the user has a manual fallback:
    ```
-   Preview: file:///<abs-path>/tests/.tmp/preview-<name>.html
+   Preview: http://localhost:8765/preview-<name>.html
+   Fallback (no server): file:///<abs-path>/tests/.tmp/preview-<name>.html
    ```
 
+   If `python3` isn't on PATH (extremely unlikely in this repo — every script under `plugins/acss-kit/scripts/` requires it), skip the server step entirely and use only the `file://` URL.
+
+   Mention to the user that the server is running in the background and can be stopped with `pkill -f "http.server 8765"` (or whatever port was used) when they're done.
+
 6. **Don't over-engineer.**
-   - No screenshot generation, no Puppeteer, no React, no Vite, no theme assembly. Just the component's own CSS + the example HTML.
+   - No screenshot generation, no Puppeteer, no React, no Vite, no theme assembly, no `npx serve` / `live-server` / any node-side dep. Stick with `python3 -m http.server` — already on PATH.
    - Don't write tests, don't validate accessibility, don't run the full `tests/` harness — there's a separate `/review-component` skill for that.
    - If the user asks for something the static preview can't show (e.g. "test the click handler", "test focus trap"), say so explicitly and recommend `tests/e2e.sh` instead.
 
@@ -124,4 +143,4 @@ Usage examples (any of these should trigger):
 
 ## What success looks like
 
-User says "test the button". You produce `tests/.tmp/preview-button.html` in under 5 seconds, attempt to open it, and print the `file://` path. The file shows: default button, every color variant in a row, every size variant in a row, every style variant (outline/pill/text/icon) in a row, a disabled example, and a block-width example — all styled by the component's actual CSS.
+User says "test the button". In under 5 seconds you produce `tests/.tmp/preview-button.html`, start (or reuse) `python3 -m http.server 8765 --directory tests/.tmp` in the background, attempt to open `http://localhost:8765/preview-button.html`, and print both that URL and the `file://` fallback. The page shows: default button, every color variant in a row, every size variant in a row, every style variant (outline/pill/text/icon) in a row, a disabled example, and a block-width example — all styled by the component's actual CSS.

--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -20,15 +20,16 @@ Usage examples (any of these should trigger):
    Lower-case the user's input and strip the words `the`, `a`, `component`. If the result is empty or names a component without a reference doc, list `plugins/acss-kit/skills/components/references/components/*.md` and ask the user to pick.
 
 2. **Read the reference doc.**
-   Read `plugins/acss-kit/skills/components/references/components/<name>.md` once. You need three sections from it:
-   - `## CSS Variables` — first fenced ` ```scss ` block. These are `:root` tokens.
-   - `## SCSS Template` — first fenced ` ```scss ` block. The component styles. Use as-is (CSS nesting is native).
-   - `## Usage Examples` — JSX snippets to convert to plain HTML.
+   Read `plugins/acss-kit/skills/components/references/components/<name>.md` once. You need three sections from it. For each, locate the `##` heading first, then take the first fenced block **within that section's range** (i.e. before the next `##` heading) — never the first fence in the file:
+   - `## CSS Variables` — first ` ```scss ` block in that section. These are `:root` tokens.
+   - `## SCSS Template` — first ` ```scss ` block in that section. The component styles. Use as-is (CSS nesting is native).
+   - `## Usage Examples` — JSX snippets in that section, to convert to plain HTML.
 
 3. **Convert Usage Examples JSX to HTML.**
    The Props Interface in the same doc documents which props map to which `data-*` attributes — read it and follow it. General rules:
-   - The component's root tag and class come from the SCSS Template's root selector (e.g. `.btn` → `<button class="btn">`).
-   - Compound components (`Card.Title`, `Table.Row`, etc.): match the nested SCSS selectors with the matching tag/class.
+   - **Tag:** derive the HTML element from the TSX Template's `UI as="..."` value, or from the root JSX tag in Usage Examples — never from the SCSS selector. A class like `.btn` doesn't tell you whether the element is `<button>`, `<a>`, or `<input>`.
+   - **Class:** the SCSS Template's root selector gives the className (e.g. `.btn` → `class="btn"`).
+   - Compound components (`Card.Title`, `Table.Row`, etc.): use the nested SCSS selectors for the className, and the matching JSX/TSX for the tag.
    - `disabled` prop → `aria-disabled="true"` plus `is-disabled` class. Never the native `disabled` attribute.
    - Drop event handlers (`onClick`, etc.) — this is a static preview.
 
@@ -96,15 +97,15 @@ Usage examples (any of these should trigger):
 5. **Serve it on a lightweight HTTP server, then open it.**
    Use `python3 -m http.server` on port `8765` — zero install, already a project dependency.
 
-   Probe the port; if the server is already up from a previous invocation, reuse it:
+   If `curl` is available, probe the port to reuse an already-running server (an optimization, not required):
    ```sh
    curl -fsS -o /dev/null http://localhost:8765/ 2>/dev/null
    ```
-   On non-zero exit, spawn a new server using the Bash tool with `run_in_background: true` so it survives the turn:
+   On non-zero exit (or if `curl` is missing — skip the probe), spawn a new server using the Bash tool with `run_in_background: true` so it survives the turn:
    ```sh
    python3 -m http.server 8765 --directory tests/.tmp --bind 127.0.0.1
    ```
-   Then `sleep 0.3` to let it bind. If port `8765` is held by something other than our server (curl returns content that doesn't list `preview-*.html`), bump to `8766`/`8767` rather than killing the squatter. If `python3` isn't on PATH, skip the server entirely.
+   Then `sleep 0.3` to let it bind. If the port is already taken (python errors with `OSError: [Errno 98] Address already in use`, or curl shows content that doesn't list `preview-*.html`), bump to `8766`/`8767` and retry — don't kill the squatter. If `python3` isn't on PATH, skip the server entirely and use the `file://` URL.
 
    Open the URL, swallowing errors for headless environments:
    ```sh
@@ -116,7 +117,7 @@ Usage examples (any of these should trigger):
    ```
    Preview: http://localhost:<port>/preview-<name>.html
    Fallback: file:///<abs-path>/tests/.tmp/preview-<name>.html
-   Stop server: pkill -f "http.server <port>"
+   Stop server: pkill -f "http.server <port> --directory tests/.tmp"
    ```
 
 6. **Stay in scope.**

--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -17,30 +17,25 @@ Usage examples (any of these should trigger):
 ## Steps
 
 1. **Resolve the component name.**
-   - Lower-case it. Strip filler words ("the", "a", "component").
-   - Verify `plugins/acss-kit/skills/components/references/components/<name>.md` exists.
-   - If the name is ambiguous or missing, list `plugins/acss-kit/skills/components/references/components/*.md` and ask the user to pick.
+   Lower-case the user's input and strip the words `the`, `a`, `component`. If the result is empty or names a component without a reference doc, list `plugins/acss-kit/skills/components/references/components/*.md` and ask the user to pick.
 
 2. **Read the reference doc.**
-   Read the whole file. You need three sections:
-   - `## CSS Variables` — first fenced ``` ```scss ``` block. These are `:root` tokens.
-   - `## SCSS Template` — first fenced ``` ```scss ``` block. The component styles. Use as-is (CSS nesting is native).
-   - `## Usage Examples` — JSX snippets you'll convert to plain HTML.
+   Read `plugins/acss-kit/skills/components/references/components/<name>.md` once. You need three sections from it:
+   - `## CSS Variables` — first fenced ` ```scss ` block. These are `:root` tokens.
+   - `## SCSS Template` — first fenced ` ```scss ` block. The component styles. Use as-is (CSS nesting is native).
+   - `## Usage Examples` — JSX snippets to convert to plain HTML.
 
 3. **Convert Usage Examples JSX to HTML.**
-   Each component's reference doc tells you how the JSX maps to DOM. The general rule for `acss-kit`:
-   - The React component renders a single semantic element with a class and data attributes.
-   - Look at the SCSS Template's root selector (e.g. `.btn`, `.alert`, `.card`) — that's the className.
-   - Props that map to `data-*` attributes (`color="primary"` → `data-color="primary"`, `size="lg"` → `data-btn="lg"`, `variant="outline"` → `data-style="outline"`) are documented in the Props Interface.
-   - For Button specifically: combine `size` + `block` + raw `data-btn` into a single space-separated `data-btn` token (see Key Pattern: data-btn Merging in `button.md`).
-   - For compound components (Card.Title, Card.Content, Table.Row, etc.) check the SCSS for the nested selectors and use the matching tag/class.
-   - Replace `disabled` prop with `aria-disabled="true"` and add the `is-disabled` class — never use the native `disabled` attribute.
+   The Props Interface in the same doc documents which props map to which `data-*` attributes — read it and follow it. General rules:
+   - The component's root tag and class come from the SCSS Template's root selector (e.g. `.btn` → `<button class="btn">`).
+   - Compound components (`Card.Title`, `Table.Row`, etc.): match the nested SCSS selectors with the matching tag/class.
+   - `disabled` prop → `aria-disabled="true"` plus `is-disabled` class. Never the native `disabled` attribute.
    - Drop event handlers (`onClick`, etc.) — this is a static preview.
 
-   Aim for one `<section>` per variant family (color, size, style, state) with a small heading. Cover every distinct example that appears in Usage Examples.
+   Lay out one `<section>` per variant family (color, size, style, state) with a small heading. Cover every distinct example from Usage Examples.
 
 4. **Generate the HTML file.**
-   Write to `tests/.tmp/preview-<name>.html` (create `tests/.tmp/` if missing). Template:
+   Run `mkdir -p tests/.tmp` and write `tests/.tmp/preview-<name>.html` using this template:
 
    ````html
    <!doctype html>
@@ -99,40 +94,33 @@ Usage examples (any of these should trigger):
    - If the SCSS uses `@use`, `@mixin`, `@include`, `@if`, or `$variables` (rare in this repo — components are kept var()-driven), call that out and skip those lines with an HTML comment explaining what was dropped. The user can decide whether to address it.
 
 5. **Serve it on a lightweight HTTP server, then open it.**
-   Python 3 is already a project dependency, so `python3 -m http.server` gives us a zero-install static server. Default port: `8765`.
+   Use `python3 -m http.server` on port `8765` — zero install, already a project dependency.
 
-   First, check whether a server is already up on that port (re-runs of this skill should reuse it, not spawn duplicates):
+   Probe the port; if the server is already up from a previous invocation, reuse it:
    ```sh
    curl -fsS -o /dev/null http://localhost:8765/ 2>/dev/null
    ```
-   - Exit 0 → server already running, skip the spawn step.
-   - Non-zero → start the server. Use the **Bash tool with `run_in_background: true`** so it keeps running after this turn:
-     ```sh
-     python3 -m http.server 8765 --directory tests/.tmp --bind 127.0.0.1
-     ```
-     Then poll the port up to ~5 times with a short sleep until `curl` returns 0, so the open step doesn't race the server's startup.
-   - If port `8765` is taken by something that *isn't* our server (curl returns HTML you don't recognize, or the server's directory listing doesn't show `preview-*.html`), bump to `8766`, `8767`, etc. Don't kill whatever's already on `8765`.
-
-   Then open the URL, swallowing errors so headless environments don't fail:
+   On non-zero exit, spawn a new server using the Bash tool with `run_in_background: true` so it survives the turn:
    ```sh
-   xdg-open  http://localhost:8765/preview-<name>.html 2>/dev/null \
-     || open http://localhost:8765/preview-<name>.html 2>/dev/null \
+   python3 -m http.server 8765 --directory tests/.tmp --bind 127.0.0.1
+   ```
+   Then `sleep 0.3` to let it bind. If port `8765` is held by something other than our server (curl returns content that doesn't list `preview-*.html`), bump to `8766`/`8767` rather than killing the squatter. If `python3` isn't on PATH, skip the server entirely.
+
+   Open the URL, swallowing errors for headless environments:
+   ```sh
+   xdg-open  http://localhost:<port>/preview-<name>.html 2>/dev/null \
+     || open http://localhost:<port>/preview-<name>.html 2>/dev/null \
      || true
    ```
-   **Always** print both URLs so the user has a manual fallback:
+   Always print both URLs so the user has a manual fallback, and tell them how to stop the server:
    ```
-   Preview: http://localhost:8765/preview-<name>.html
-   Fallback (no server): file:///<abs-path>/tests/.tmp/preview-<name>.html
+   Preview: http://localhost:<port>/preview-<name>.html
+   Fallback: file:///<abs-path>/tests/.tmp/preview-<name>.html
+   Stop server: pkill -f "http.server <port>"
    ```
 
-   If `python3` isn't on PATH (extremely unlikely in this repo — every script under `plugins/acss-kit/scripts/` requires it), skip the server step entirely and use only the `file://` URL.
-
-   Mention to the user that the server is running in the background and can be stopped with `pkill -f "http.server 8765"` (or whatever port was used) when they're done.
-
-6. **Don't over-engineer.**
-   - No screenshot generation, no Puppeteer, no React, no Vite, no theme assembly, no `npx serve` / `live-server` / any node-side dep. Stick with `python3 -m http.server` — already on PATH.
-   - Don't write tests, don't validate accessibility, don't run the full `tests/` harness — there's a separate `/review-component` skill for that.
-   - If the user asks for something the static preview can't show (e.g. "test the click handler", "test focus trap"), say so explicitly and recommend `tests/e2e.sh` instead.
+6. **Stay in scope.**
+   If the user asks for something a static preview can't show (click handlers, focus trap, real interaction), say so and recommend `tests/e2e.sh` instead. Don't extend this skill into a general test harness.
 
 ## Edge cases
 


### PR DESCRIPTION
## Summary
Adds a new Claude skill that enables quick visual previews of `acss-kit` components directly in the browser without requiring a dev server or build step.

## Changes
- **New skill: `test-component`** — A comprehensive skill definition that allows users to preview components by saying "test component button", "show me the alert", etc.
  - Resolves component names from user input
  - Reads component reference documentation (CSS Variables, SCSS Template, Usage Examples)
  - Converts JSX usage examples to plain HTML
  - Generates self-contained HTML files with native CSS (no compilation needed)
  - Serves previews via lightweight Python HTTP server on port 8765
  - Handles edge cases: compound components, form controls, components requiring JS, icon placeholders
  - Provides both HTTP and file:// URLs for accessibility

## Implementation Details
- Leverages native CSS nesting support (Chrome 112+, Firefox 117+, Safari 16.4+) to use SCSS templates as-is without compilation
- Converts React props to HTML data attributes and ARIA attributes following the component's Props Interface
- Generates organized preview pages with variant families (color, size, style, state) in separate sections
- Includes port probing logic to reuse existing servers and fallback to higher ports if needed
- Provides clear user guidance on accessing previews and stopping the server
- Scoped to static previews; recommends `tests/e2e.sh` for interactive testing needs

https://claude.ai/code/session_014KFCMJhzMKdFYMkCzsJeiT