### PR TITLE
docs(.claude/skills/test-component): reformat prose and add bash allo…

### DIFF
--- a/.claude/skills/test-component/SKILL.md
+++ b/.claude/skills/test-component/SKILL.md
@@ -1,14 +1,26 @@
 ---
 name: test-component
-description: Render a quick visual preview of an acss-kit component in the default browser. Use when the user says "test component", "test the button", "show me the alert", "preview <component>", or any phrasing that asks to see what a component looks like. Produces a self-contained HTML file with all variants from the component's Usage Examples.
+description:
+  Render a quick visual preview of an acss-kit component in the default browser.
+  Use when the user says "test component", "test the button", "show me the
+  alert", "preview <component>", or any phrasing that asks to see what a
+  component looks like. Produces a self-contained HTML file with all variants
+  from the component's Usage Examples.
 disable-model-invocation: false
+allowed-tools:
+  - bash
 ---
 
 # test-component
 
-Goal: render a one-page visual preview of an `acss-kit` component fast — no dev server, no build step, no React. The component's SCSS works as plain CSS in any modern browser (CSS nesting is native in Chrome 112+, Firefox 117+, Safari 16.4+), so we copy it verbatim into a `<style>` tag and render the variants as static HTML.
+Goal: render a one-page visual preview of an `acss-kit` component fast — no dev
+server, no build step, no React. The component's SCSS works as plain CSS in any
+modern browser (CSS nesting is native in Chrome 112+, Firefox 117+, Safari
+16.4+), so we copy it verbatim into a `<style>` tag and render the variants as
+static HTML.
 
 Usage examples (any of these should trigger):
+
 - "test component button"
 - "test the alert"
 - "show me what the card looks like"
@@ -16,29 +28,46 @@ Usage examples (any of these should trigger):
 
 ## Steps
 
-1. **Resolve the component name.**
-   Lower-case the user's input and strip the words `the`, `a`, `component`. If the result is empty or names a component without a reference doc, list `plugins/acss-kit/skills/components/references/components/*.md` and ask the user to pick.
+1. **Resolve the component name.** Lower-case the user's input and strip the
+   words `the`, `a`, `component`. If the result is empty or names a component
+   without a reference doc, list
+   `plugins/acss-kit/skills/components/references/components/*.md` and ask the
+   user to pick.
 
-2. **Read the reference doc.**
-   Read `plugins/acss-kit/skills/components/references/components/<name>.md` once. You need three sections from it. For each, locate the `##` heading first, then take the first fenced block **within that section's range** (i.e. before the next `##` heading) — never the first fence in the file:
-   - `## CSS Variables` — first ` ```scss ` block in that section. These are `:root` tokens.
-   - `## SCSS Template` — first ` ```scss ` block in that section. The component styles. Use as-is (CSS nesting is native).
-   - `## Usage Examples` — JSX snippets in that section, to convert to plain HTML.
+2. **Read the reference doc.** Read
+   `plugins/acss-kit/skills/components/references/components/<name>.md` once.
+   You need three sections from it. For each, locate the `##` heading first,
+   then take the first fenced block **within that section's range** (i.e. before
+   the next `##` heading) — never the first fence in the file:
+   - `## CSS Variables` — first ` ```scss ` block in that section. These are
+     `:root` tokens.
+   - `## SCSS Template` — first ` ```scss ` block in that section. The component
+     styles. Use as-is (CSS nesting is native).
+   - `## Usage Examples` — JSX snippets in that section, to convert to plain
+     HTML.
 
-3. **Convert Usage Examples JSX to HTML.**
-   The Props Interface in the same doc documents which props map to which `data-*` attributes — read it and follow it. General rules:
-   - **Tag:** derive the HTML element from the TSX Template's `UI as="..."` value, or from the root JSX tag in Usage Examples — never from the SCSS selector. A class like `.btn` doesn't tell you whether the element is `<button>`, `<a>`, or `<input>`.
-   - **Class:** the SCSS Template's root selector gives the className (e.g. `.btn` → `class="btn"`).
-   - Compound components (`Card.Title`, `Table.Row`, etc.): use the nested SCSS selectors for the className, and the matching JSX/TSX for the tag.
-   - `disabled` prop → `aria-disabled="true"` plus `is-disabled` class. Never the native `disabled` attribute.
+3. **Convert Usage Examples JSX to HTML.** The Props Interface in the same doc
+   documents which props map to which `data-*` attributes — read it and follow
+   it. General rules:
+   - **Tag:** derive the HTML element from the TSX Template's `UI as="..."`
+     value, or from the root JSX tag in Usage Examples — never from the SCSS
+     selector. A class like `.btn` doesn't tell you whether the element is
+     `<button>`, `<a>`, or `<input>`.
+   - **Class:** the SCSS Template's root selector gives the className (e.g.
+     `.btn` → `class="btn"`).
+   - Compound components (`Card.Title`, `Table.Row`, etc.): use the nested SCSS
+     selectors for the className, and the matching JSX/TSX for the tag.
+   - `disabled` prop → `aria-disabled="true"` plus `is-disabled` class. Never
+     the native `disabled` attribute.
    - Drop event handlers (`onClick`, etc.) — this is a static preview.
 
-   Lay out one `<section>` per variant family (color, size, style, state) with a small heading. Cover every distinct example from Usage Examples.
+   Lay out one `<section>` per variant family (color, size, style, state) with a
+   small heading. Cover every distinct example from Usage Examples.
 
-4. **Generate the HTML file.**
-   Run `mkdir -p tests/.tmp` and write `tests/.tmp/preview-<name>.html` using this template:
+4. **Generate the HTML file.** Run `mkdir -p tests/.tmp` and write
+   `tests/.tmp/preview-<name>.html` using this template:
 
-   ````html
+   ```html
    <!doctype html>
    <html lang="en">
    <head>
@@ -87,49 +116,86 @@ Usage examples (any of these should trigger):
      <!-- repeat per variant family -->
    </body>
    </html>
-   ````
+   ```
 
    Notes:
-   - Paste the CSS Variables block contents inside `:root { ... }`. Strip any SCSS-only syntax (there shouldn't be any in CSS Variables blocks — they're plain custom-property declarations).
-   - Paste the SCSS Template verbatim into the `<style>` tag. Modern CSS handles `&:hover`, `&[data-attr]`, and nested selectors natively. Do NOT compile.
-   - If the SCSS uses `@use`, `@mixin`, `@include`, `@if`, or `$variables` (rare in this repo — components are kept var()-driven), call that out and skip those lines with an HTML comment explaining what was dropped. The user can decide whether to address it.
+   - Paste the CSS Variables block contents inside `:root { ... }`. Strip any
+     SCSS-only syntax (there shouldn't be any in CSS Variables blocks — they're
+     plain custom-property declarations).
+   - Paste the SCSS Template verbatim into the `<style>` tag. Modern CSS handles
+     `&:hover`, `&[data-attr]`, and nested selectors natively. Do NOT compile.
+   - If the SCSS uses `@use`, `@mixin`, `@include`, `@if`, or `$variables` (rare
+     in this repo — components are kept var()-driven), call that out and skip
+     those lines with an HTML comment explaining what was dropped. The user can
+     decide whether to address it.
 
-5. **Serve it on a lightweight HTTP server, then open it.**
-   Use `python3 -m http.server` on port `8765` — zero install, already a project dependency.
+5. **Serve it on a lightweight HTTP server, then open it.** Use
+   `python3 -m http.server` on port `8765` — zero install, already a project
+   dependency.
 
-   If `curl` is available, probe the port to reuse an already-running server (an optimization, not required):
+   If `curl` is available, probe the port to reuse an already-running server (an
+   optimization, not required):
+
    ```sh
    curl -fsS -o /dev/null http://localhost:8765/ 2>/dev/null
    ```
-   On non-zero exit (or if `curl` is missing — skip the probe), spawn a new server using the Bash tool with `run_in_background: true` so it survives the turn:
+
+   On non-zero exit (or if `curl` is missing — skip the probe), spawn a new
+   server using the Bash tool with `run_in_background: true` so it survives the
+   turn:
+
    ```sh
    python3 -m http.server 8765 --directory tests/.tmp --bind 127.0.0.1
    ```
-   Then `sleep 0.3` to let it bind. If the port is already taken (python errors with `OSError: [Errno 98] Address already in use`, or curl shows content that doesn't list `preview-*.html`), bump to `8766`/`8767` and retry — don't kill the squatter. If `python3` isn't on PATH, skip the server entirely and use the `file://` URL.
+
+   Then `sleep 0.3` to let it bind. If the port is already taken (python errors
+   with `OSError: [Errno 98] Address already in use`, or curl shows content that
+   doesn't list `preview-*.html`), bump to `8766`/`8767` and retry — don't kill
+   the squatter. If `python3` isn't on PATH, skip the server entirely and use
+   the `file://` URL.
 
    Open the URL, swallowing errors for headless environments:
+
    ```sh
    xdg-open  http://localhost:<port>/preview-<name>.html 2>/dev/null \
      || open http://localhost:<port>/preview-<name>.html 2>/dev/null \
      || true
    ```
-   Always print both URLs so the user has a manual fallback, and tell them how to stop the server:
+
+   Always print both URLs so the user has a manual fallback, and tell them how
+   to stop the server:
+
    ```
    Preview: http://localhost:<port>/preview-<name>.html
    Fallback: file:///<abs-path>/tests/.tmp/preview-<name>.html
    Stop server: pkill -f "http.server <port> --directory tests/.tmp"
    ```
 
-6. **Stay in scope.**
-   If the user asks for something a static preview can't show (click handlers, focus trap, real interaction), say so and recommend `tests/e2e.sh` instead. Don't extend this skill into a general test harness.
+6. **Stay in scope.** If the user asks for something a static preview can't show
+   (click handlers, focus trap, real interaction), say so and recommend
+   `tests/e2e.sh` instead. Don't extend this skill into a general test harness.
 
 ## Edge cases
 
-- **Compound components** (`Card`, `Table`, `List`): the SCSS has nested selectors like `.card .card-title`. Replicate the DOM structure with the matching tags/classes.
-- **Components requiring JS** (`Dialog` uses native `<dialog>` with `showModal()`, `Popover` uses `popover` attribute): render the open state directly via the `open` attribute / `popover` attribute so the visual state shows without scripting.
-- **Form controls** (`Input`, `Checkbox`, `Field`): always pair with a `<label>` so the preview shows the accessible-name story.
-- **Icon components**: if the SCSS doesn't define the glyph, render placeholder SVGs (a 16×16 square with the variant name as text) — note this in a comment.
+- **Compound components** (`Card`, `Table`, `List`): the SCSS has nested
+  selectors like `.card .card-title`. Replicate the DOM structure with the
+  matching tags/classes.
+- **Components requiring JS** (`Dialog` uses native `<dialog>` with
+  `showModal()`, `Popover` uses `popover` attribute): render the open state
+  directly via the `open` attribute / `popover` attribute so the visual state
+  shows without scripting.
+- **Form controls** (`Input`, `Checkbox`, `Field`): always pair with a `<label>`
+  so the preview shows the accessible-name story.
+- **Icon components**: if the SCSS doesn't define the glyph, render placeholder
+  SVGs (a 16×16 square with the variant name as text) — note this in a comment.
 
 ## What success looks like
 
-User says "test the button". In under 5 seconds you produce `tests/.tmp/preview-button.html`, start (or reuse) `python3 -m http.server 8765 --directory tests/.tmp` in the background, attempt to open `http://localhost:8765/preview-button.html`, and print both that URL and the `file://` fallback. The page shows: default button, every color variant in a row, every size variant in a row, every style variant (outline/pill/text/icon) in a row, a disabled example, and a block-width example — all styled by the component's actual CSS.
+User says "test the button". In under 5 seconds you produce
+`tests/.tmp/preview-button.html`, start (or reuse)
+`python3 -m http.server 8765 --directory tests/.tmp` in the background, attempt
+to open `http://localhost:8765/preview-button.html`, and print both that URL and
+the `file://` fallback. The page shows: default button, every color variant in a
+row, every size variant in a row, every style variant (outline/pill/text/icon)
+in a row, a disabled example, and a block-width example — all styled by the
+component's actual CSS.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Claude Code plugin marketplace for building accessible React applications with
 
 | Plugin | Purpose |
 |---|---|
-| [`acss-kit`](./plugins/acss-kit) | Generate accessible React components and CSS themes for fpkit/acss projects. Run `/setup` to bootstrap a project (sass check, `ui.tsx` copy, starter theme), then `/kit-add` for components and `/theme-create` (or `/style-tune`) for themes. Three skills: **components** (markdown-as-source TSX/SCSS generation), **styles** (OKLCH theme generation with WCAG 2.2 AA validation), and the **component-form** pilot. |
+| [`acss-kit`](./plugins/acss-kit) | Generate accessible React components and CSS themes for fpkit/acss projects. Run `/setup` to bootstrap a project (sass check, `ui.tsx` copy, starter theme), then `/kit-add` for components and `/theme-create` or `/style-tune` for theme and component-style work. Skills: **setup** (project bootstrap), **components** (markdown-as-source TSX/SCSS generation), **styles** (OKLCH theme generation and component SCSS tuning with WCAG 2.2 AA validation), plus the **style-tune** and **component-form** pilots. |
 | [`acss-utilities`](./plugins/acss-utilities) | Tailwind-style atomic CSS utility classes (`.bg-primary`, `.mt-4`, `.sm-hide`) for fpkit/acss projects. Hyphen-prefix responsive variants — no CSS escaping needed. Pairs with `acss-kit` via a token-bridge so utility colors resolve against the same OKLCH roles. Run `/utility-add` to drop the bundle into your project; `/utility-list`, `/utility-tune`, and `/utility-bridge` round out the workflow. |
 
 The two plugins are decoupled — install one, both, or use `acss-utilities` standalone with a hand-written theme.

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -273,7 +273,7 @@ The required `## Accessibility` section is load-bearing — don't strip a11y pat
 
 Most components live as reference docs. Composable, complex, or high-iteration components can be promoted to their own skill at `skills/component-<name>/SKILL.md` with discovery-friendly trigger phrases in the frontmatter `description`.
 
-As of 0.4.1 the only component promoted to a skill is `Form` (see `skills/component-form/SKILL.md`). It serves as a pilot — adopt the per-component skill pattern for additional components only after observing trigger reliability in real usage.
+Currently, the only component promoted to a skill is `Form` (see `skills/component-form/SKILL.md`). It serves as a pilot — adopt the per-component skill pattern for additional components only after observing trigger reliability in real usage.
 
 ### 4. Log verification status
 


### PR DESCRIPTION
…wed-tool
This pull request updates documentation for the `test-component` skill and improves plugin descriptions for the `acss-kit` plugin. The main focus is on clarifying instructions, improving formatting for readability, and updating feature descriptions to better reflect current capabilities.

**Documentation and Instruction Improvements**

* [`.claude/skills/test-component/SKILL.md`](diffhunk://#diff-520afaeb8a28f2a336b7b8618a6aee8f5e50f9ffed835b2239c3ee0887b78be2L3-R70): Reformatted and reworded the skill instructions for clarity and readability, including breaking up long lines and adding more explicit step-by-step guidance. Also added the `allowed-tools` field specifying `bash` as an allowed tool. [[1]](diffhunk://#diff-520afaeb8a28f2a336b7b8618a6aee8f5e50f9ffed835b2239c3ee0887b78be2L3-R70) [[2]](diffhunk://#diff-520afaeb8a28f2a336b7b8618a6aee8f5e50f9ffed835b2239c3ee0887b78be2L90-R201)

**Plugin Description Updates**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9): Updated the description of the `acss-kit` plugin to clarify the setup, component, and theme/style-tuning workflows, and to reflect the current set of skills and pilots available.
* [`plugins/acss-kit/README.md`](diffhunk://#diff-3380b8fb63969f86f8a62e88c2fa15302ba831375a22a0ad2925171c00e597bcL276-R276): Updated the explanation about per-component skill promotion to reflect that only the `Form` component is currently promoted, removing the version-specific reference.…wed-tool