### PR TITLE
docs: expand CLAUDE.md with plugin structure and command reference

### DIFF
--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -24,7 +24,7 @@ Current scripts in `plugins/acss-utilities/scripts/`:
 - `detect_utility_target.py` — detects the target React project + drop directory for `utilities.css`. Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and reads the same `.acss-target.json` (with an added `utilitiesDir` field)
 - `generate_utilities.py` — reads `utilities.tokens.json` and emits per-family CSS partials + a concatenated `utilities.css`. Generator/validator contract; either streams the bundle to stdout or writes to a directory via `--out-dir`
 - `validate_utilities.py` — validates utility CSS files: kebab-case selectors, `var()` fallbacks, no duplicate selectors, responsive parity across breakpoints, bundle-size budget, and `token-bridge.css` `:root` ↔ `[data-theme="dark"]` parity. Generator/validator contract (data + reasons array on stdout, exit 0/1/2)
-- `migrate_classnames.py` — rewrites 0.1.x colon-form utility classes (`sm:hide`) to 0.2.0 hyphen form (`sm-hide`) across source files. Default dry-run prints unified diff; `--write` applies in place. Generator/validator contract (exit 0 = no changes, 1 = dry-run pending, 2 = usage/IO)
+- `migrate_classnames.py` — rewrites 0.1.x colon-form utility classes (`sm:hide`) to 0.2.0 hyphen form (`sm-hide`) across source files. Default dry-run prints unified diff; `--write` applies in place. Generator/validator contract: exit 0 = success (no changes needed, or changes applied via `--write`); exit 1 = dry-run with changes pending (`--write` to apply); exit 2 = usage / IO error
 
 ## Detector contract (machine-callable, structured)
 

--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -23,7 +23,7 @@ Current scripts in `plugins/acss-utilities/scripts/`:
 
 - `detect_utility_target.py` — detects the target React project + drop directory for `utilities.css`. Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and reads the same `.acss-target.json` (with an added `utilitiesDir` field)
 - `generate_utilities.py` — reads `utilities.tokens.json` and emits per-family CSS partials + a concatenated `utilities.css`. Generator/validator contract; either streams the bundle to stdout or writes to a directory via `--out-dir`
-- `validate_utilities.py` — validates utility CSS files: kebab-case selectors, `var()` fallbacks, no duplicate selectors, responsive parity across breakpoints, bundle-size budget, and `token-bridge.css` `:root` ↔ `[data-theme="dark"]` parity. Generator/validator contract (data + reasons array on stdout, exit 0/1/2)
+- `validate_utilities.py` — validates utility CSS files: kebab-case selectors, `var()` fallbacks, no duplicate selectors, responsive parity across breakpoints, bundle-size budget, and `token-bridge.css` `:root` ↔ `[data-theme="dark"]` parity. Detector contract (JSON `{ok, reasons}` to stdout, exit 0/1/2)
 - `migrate_classnames.py` — rewrites 0.1.x colon-form utility classes (`sm:hide`) to 0.2.0 hyphen form (`sm-hide`) across source files. Default dry-run prints unified diff; `--write` applies in place. Generator/validator contract: exit 0 = success (no changes needed, or changes applied via `--write`); exit 1 = dry-run with changes pending (`--write` to apply); exit 2 = usage / IO error
 
 ## Detector contract (machine-callable, structured)
@@ -34,7 +34,7 @@ For scripts whose output is parsed by slash commands or skills.
 - Exit 0 on success, 1 on logical failure (e.g. nothing detected)
 - Always include a `"reasons"` array in the JSON — empty `[]` on success, populated on failure
 
-Detectors: `detect_target.py`, `detect_package_manager.py`, `detect_stack.py`, `detect_css_entry.py`, `verify_integration.py`, `detect_utility_target.py`.
+Detectors: `detect_target.py`, `detect_package_manager.py`, `detect_stack.py`, `detect_css_entry.py`, `verify_integration.py`, `detect_utility_target.py`, `validate_utilities.py`.
 
 ## Generator / validator contract (pipeline-friendly, human-readable)
 
@@ -44,7 +44,7 @@ For scripts that emit data or human-readable validation results.
 - Errors on stderr
 - Exit 0 on success, 1 on logical failure, 2 on usage / IO errors
 
-Generators / validators: `generate_palette.py`, `oklch_shift.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`, `generate_utilities.py`, `validate_utilities.py`, `migrate_classnames.py`.
+Generators / validators: `generate_palette.py`, `oklch_shift.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`, `generate_utilities.py`, `migrate_classnames.py`.
 
 `oklch_shift.py` follows this contract — it transforms an input hex into a shifted hex and emits structured JSON. It exits 0 whenever a usable hex was produced (even when chroma or lightness was clamped to stay in sRGB gamut — `clamped: true` and a populated `reasons` array surface the warning), reserves exit 1 for hard failures where no hex can be produced, and exits 2 on usage / IO errors.
 

--- a/.claude/rules/python-scripts.md
+++ b/.claude/rules/python-scripts.md
@@ -24,6 +24,7 @@ Current scripts in `plugins/acss-utilities/scripts/`:
 - `detect_utility_target.py` — detects the target React project + drop directory for `utilities.css`. Mirrors `acss-kit/scripts/detect_target.py`'s ancestor-walk and reads the same `.acss-target.json` (with an added `utilitiesDir` field)
 - `generate_utilities.py` — reads `utilities.tokens.json` and emits per-family CSS partials + a concatenated `utilities.css`. Generator/validator contract; either streams the bundle to stdout or writes to a directory via `--out-dir`
 - `validate_utilities.py` — validates utility CSS files: kebab-case selectors, `var()` fallbacks, no duplicate selectors, responsive parity across breakpoints, bundle-size budget, and `token-bridge.css` `:root` ↔ `[data-theme="dark"]` parity. Generator/validator contract (data + reasons array on stdout, exit 0/1/2)
+- `migrate_classnames.py` — rewrites 0.1.x colon-form utility classes (`sm:hide`) to 0.2.0 hyphen form (`sm-hide`) across source files. Default dry-run prints unified diff; `--write` applies in place. Generator/validator contract (exit 0 = no changes, 1 = dry-run pending, 2 = usage/IO)
 
 ## Detector contract (machine-callable, structured)
 
@@ -43,7 +44,7 @@ For scripts that emit data or human-readable validation results.
 - Errors on stderr
 - Exit 0 on success, 1 on logical failure, 2 on usage / IO errors
 
-Generators / validators: `generate_palette.py`, `oklch_shift.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`.
+Generators / validators: `generate_palette.py`, `oklch_shift.py`, `tokens_to_css.py`, `css_to_tokens.py`, `validate_theme.py`, `generate_utilities.py`, `validate_utilities.py`, `migrate_classnames.py`.
 
 `oklch_shift.py` follows this contract — it transforms an input hex into a shifted hex and emits structured JSON. It exits 0 whenever a usable hex was produced (even when chroma or lightness was clamped to stay in sRGB gamut — `clamped: true` and a populated `reasons` array surface the warning), reserves exit 1 for hard failures where no hex can be produced, and exits 2 on usage / IO errors.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Before committing any plugin change:
 
 ## Git workflow
 
-Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direct commits to `main` for plugin changes (a PreToolUse hook blocks them).
+Feature branches + PR. Branch from `main`, open a PR, merge when ready. A PreToolUse hook blocks all direct commits and pushes to `main` regardless of what changed.
 
 Claude Code on the web sessions develop on `claude/<slug>` branches assigned per session — push there, not to a hand-named feature branch.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,16 @@ plugins/acss-kit/
 ├── CHANGELOG.md                   # version history
 ├── commands/*.md                  # slash command definitions (YAML front-matter)
 ├── skills/components/SKILL.md     # components skill (markdown-as-source TSX/SCSS)
-├── skills/components/references/  # component reference docs (18 components)
+├── skills/components/references/  # component reference docs (see references/catalog.md)
 ├── skills/styles/SKILL.md         # styles skill (OKLCH theme generation)
 ├── skills/styles/references/      # role catalogue, palette algorithm, theme schema
 ├── skills/component-form/SKILL.md # form pilot — auto-triggers on natural language
-├── scripts/                       # Python 3 stdlib scripts (detect_target, palette, validate, etc.)
+├── scripts/                       # Python 3 stdlib scripts (see .claude/rules/python-scripts.md for inventory)
 ├── assets/                        # foundation/ui.tsx, brand template, internal schema
 └── docs/                          # developer guides (architecture, recipes, troubleshooting, tutorial)
 ```
+
+`plugins/acss-utilities/` mirrors the same shape (`.claude-plugin/`, `commands/`, `skills/`, `scripts/`, `assets/`, `docs/`) — four `/utility-*` commands plus `detect_utility_target.py`, `generate_utilities.py`, `migrate_classnames.py`, and `validate_utilities.py`. See [`plugins/acss-utilities/docs/README.md`](plugins/acss-utilities/docs/README.md) for the developer guide.
 
 ### Command file front-matter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,15 +89,28 @@ Before committing any plugin change:
 
 ## Git workflow
 
-Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direct commits to `main` for plugin changes.
+Feature branches + PR. Branch from `main`, open a PR, merge when ready. No direct commits to `main` for plugin changes (a PreToolUse hook blocks them).
+
+Claude Code on the web sessions develop on `claude/<slug>` branches assigned per session — push there, not to a hand-named feature branch.
 
 `.claude/worktrees/` is Claude Code session scratch — ignored by git.
 
 `CLAUDE.local.md` (not committed) — use for machine-local or personal overrides.
 
+## Slash commands shipped by the plugins
+
+| Plugin | Commands |
+|---|---|
+| `acss-kit` | `/kit-add`, `/kit-list`, `/setup`, `/style-tune`, `/theme-brand`, `/theme-create`, `/theme-extract`, `/theme-update` |
+| `acss-utilities` | `/utility-add`, `/utility-bridge`, `/utility-list`, `/utility-tune` |
+
+Each command's body is in `plugins/<plugin>/commands/<name>.md`; logic lives in the corresponding SKILL.md.
+
 ## Testing locally
 
 The default check is `tests/run.sh` from the repo root — automated structural validation in ~30 seconds. It extracts and syntax-checks every component reference, validates the SCSS contract, runs WCAG contrast on theme files, and replicates the manifest checks. One-time install: `npm --prefix tests ci` and `pip3 install --user tinycss2`.
+
+`tests/run.sh` and `tests/e2e.sh` orchestrate the helpers in `tests/` (`validate_components.{mjs,py}`, `validate_manifest.py`, `run_axe.mjs`, `lib/`) — call those entry scripts, not the helpers directly.
 
 For end-to-end smoke testing of slash commands (rendering output, exercising `/kit-add` and `/theme-create`), `tests/setup.sh` writes a minimal verification fixture at `tests/sandbox/` (gitignored) — `package.json` + `tsconfig.json` + ambient SCSS module declaration, no Vite, no app shell. For render-sensitive changes, `tests/e2e.sh` runs the deeper opt-in check (extracts components, runs `tsc --noEmit`, compiles SCSS, runs jsdom + axe-core a11y on rendered HTML, ~30s after `npm --prefix tests ci`). See [`tests/README.md`](./tests/README.md) for the full workflow.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ plugins/acss-kit/
 ├── CHANGELOG.md                   # version history
 ├── commands/*.md                  # slash command definitions (YAML front-matter)
 ├── skills/components/SKILL.md     # components skill (markdown-as-source TSX/SCSS)
-├── skills/components/references/  # component reference docs (see references/catalog.md)
+├── skills/components/references/  # component reference docs (see references/components/catalog.md)
 ├── skills/styles/SKILL.md         # styles skill (OKLCH theme generation)
 ├── skills/styles/references/      # role catalogue, palette algorithm, theme schema
 ├── skills/component-form/SKILL.md # form pilot — auto-triggers on natural language


### PR DESCRIPTION
## Summary
Expanded the developer documentation in CLAUDE.md to provide clearer guidance on the plugin architecture, slash commands, and testing workflows. These changes improve onboarding and reduce friction for contributors working with the acss-kit and acss-utilities plugins.

## Key changes

- **Plugin structure documentation**: Added explicit description of `plugins/acss-utilities/` mirroring the same directory shape as `acss-kit`, with references to its developer guide
- **Component and script references**: Updated references to point to catalog and inventory documentation rather than inline counts (e.g., "see references/catalog.md" instead of "(18 components)")
- **Slash commands table**: Added a new reference table listing all shipped commands by plugin (`/kit-*`, `/theme-*`, `/style-tune`, `/setup` for acss-kit; `/utility-*` for acss-utilities) with a note on where command bodies and logic live
- **Git workflow clarification**: Documented Claude Code session branch naming convention (`claude/<slug>`) and noted the PreToolUse hook that prevents direct commits to `main`
- **Testing documentation**: Expanded test section with:
  - Clarification that `tests/run.sh` and `tests/e2e.sh` are the entry points
  - Note that helpers should not be called directly
  - Reiterated the full validation workflow (review → install → smoke-test → script validation)

## Notable details

- All changes are documentation-only; no source code logic was modified
- References now point to external documentation files for maintainability (e.g., `plugins/acss-utilities/docs/README.md`, `.claude/rules/python-scripts.md`)
- The commands table serves as a quick reference for developers and users of the plugins

https://claude.ai/code/session_015JrEPaTHxBchWfyA1XAiyV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded plugin directory layout and clarified script inventory, including which generator/validator scripts and utility commands are used
  * Revised Git workflow: added "Feature branches + PR" rule and noted a pre-tool hook blocks direct commits/pushes to main; web sessions push to feature branches
  * Added a comprehensive slash‑command reference by plugin/location
  * Enhanced local testing docs to explain orchestration of test helpers and opt‑in deeper e2e behavior
  * Added migration tool guidance for classname format with dry‑run diffs and optional in‑place rewrite; clarified validator JSON output and exit codes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->