### PR TITLE
docs: extract command-authoring and fpkit-references to path-scoped rules

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -5,7 +5,7 @@ Advisory text auto-loaded into Claude's context whenever it touches a file match
 | Rule | Triggers on | Status |
 |---|---|---|
 | [`scss-conventions.md`](scss-conventions.md) | `**/*.scss`, `**/*.css` | Active — variable naming pattern, `var()` fallbacks, `[aria-disabled="true"]` for disabled state. |
-| [`python-scripts.md`](python-scripts.md) | `plugins/*/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current 6-script inventory. |
+| [`python-scripts.md`](python-scripts.md) | `plugins/*/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current multi-plugin script inventory (see rule doc). |
 | [`command-authoring.md`](command-authoring.md) | `plugins/*/commands/*.md` | Active — front-matter shape, delegate-to-SKILL.md rule. |
 | [`fpkit-references.md`](fpkit-references.md) | `plugins/*/skills/*/references/**` | Active — full GitHub URL requirement, local verification setup. |
 

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -5,7 +5,7 @@ Advisory text auto-loaded into Claude's context whenever it touches a file match
 | Rule | Triggers on | Status |
 |---|---|---|
 | [`scss-conventions.md`](scss-conventions.md) | `**/*.scss`, `**/*.css` | Active — variable naming pattern, `var()` fallbacks, `[aria-disabled="true"]` for disabled state. |
-| [`python-scripts.md`](python-scripts.md) | `plugins/acss-kit/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current 6-script inventory. |
+| [`python-scripts.md`](python-scripts.md) | `plugins/*/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current 6-script inventory. |
 | [`command-authoring.md`](command-authoring.md) | `plugins/*/commands/*.md` | Active — front-matter shape, delegate-to-SKILL.md rule. |
 | [`fpkit-references.md`](fpkit-references.md) | `plugins/*/skills/*/references/**` | Active — full GitHub URL requirement, local verification setup. |
 

--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -6,6 +6,8 @@ Advisory text auto-loaded into Claude's context whenever it touches a file match
 |---|---|---|
 | [`scss-conventions.md`](scss-conventions.md) | `**/*.scss`, `**/*.css` | Active — variable naming pattern, `var()` fallbacks, `[aria-disabled="true"]` for disabled state. |
 | [`python-scripts.md`](python-scripts.md) | `plugins/acss-kit/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current 6-script inventory. |
+| [`command-authoring.md`](command-authoring.md) | `plugins/*/commands/*.md` | Active — front-matter shape, delegate-to-SKILL.md rule. |
+| [`fpkit-references.md`](fpkit-references.md) | `plugins/*/skills/*/references/**` | Active — full GitHub URL requirement, local verification setup. |
 
 ## Rules vs. hooks vs. skills
 

--- a/.claude/rules/command-authoring.md
+++ b/.claude/rules/command-authoring.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "plugins/*/commands/*.md"
+---
+
+# Command File Conventions
+
+- Body must delegate to the master SKILL.md — never re-implement logic inline
+- Front-matter shape:
+  ```yaml
+  ---
+  description: <one-line description>
+  argument-hint: [--option] [--force]
+  allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
+  ---
+  ```

--- a/.claude/rules/fpkit-references.md
+++ b/.claude/rules/fpkit-references.md
@@ -5,5 +5,5 @@ paths:
 
 # fpkit Reference Doc Conventions
 
-- All cross-references to fpkit source must use full GitHub URLs, not repo-relative paths
+- All cross-references to fpkit source must use full GitHub URLs pinned to a tag or commit SHA (never `blob/main`), not repo-relative paths
 - For local verification, keep `shawn-sandy/acss` cloned as a sibling directory — see `CONTRIBUTING.md`

--- a/.claude/rules/fpkit-references.md
+++ b/.claude/rules/fpkit-references.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "plugins/*/skills/*/references/**"
+---
+
+# fpkit Reference Doc Conventions
+
+- All cross-references to fpkit source must use full GitHub URLs, not repo-relative paths
+- For local verification, keep `shawn-sandy/acss` cloned as a sibling directory — see `CONTRIBUTING.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,6 @@ Install from a Claude Code session:
 
 ## Plugin structure
 
-The plugin follows this layout:
-
 ```text
 plugins/acss-kit/
 ├── .claude-plugin/plugin.json     # manifest — authoritative version source
@@ -43,17 +41,9 @@ plugins/acss-kit/
 
 `plugins/acss-utilities/` mirrors the same shape (`.claude-plugin/`, `commands/`, `skills/`, `scripts/`, `assets/`, `docs/`) — four `/utility-*` commands plus `detect_utility_target.py`, `generate_utilities.py`, `migrate_classnames.py`, and `validate_utilities.py`. See [`plugins/acss-utilities/docs/README.md`](plugins/acss-utilities/docs/README.md) for the developer guide.
 
-### Command file front-matter
+### Command authoring conventions
 
-```yaml
----
-description: <one-line description>
-argument-hint: [--option] [--force]
-allowed-tools: Read, Glob, Grep, Write, Edit, Bash, AskUserQuestion
----
-```
-
-Body delegates to the master SKILL.md, never re-implements logic inline.
+See `.claude/rules/command-authoring.md` (auto-loads when editing `plugins/*/commands/*.md`).
 
 ### SKILL.md front-matter
 
@@ -81,9 +71,9 @@ Before committing any plugin change:
 
 ## Maintainer tooling
 
-**Project-level skills** (`.claude/skills/`): `add-command`, `component-author`, `component-update`, `plugin-health`, `release-check`, `release-plugin`, `style-author`, `style-update`, `validate-plugin`, `verify-plugins`. Use these for plugin maintenance tasks instead of manual steps.
+**Project-level skills** (`.claude/skills/`): `add-command`, `changelog-entry`, `component-author`, `component-update`, `plugin-health`, `release-check`, `release-plugin`, `style-author`, `style-update`, `test-component`, `validate-plugin`, `verify-plugins`. Use these for plugin maintenance tasks instead of manual steps.
 
-**Rules** (`.claude/rules/`): `scss-conventions.md` (active, fires on SCSS/CSS edits), `python-scripts.md` (active, fires on `plugins/acss-kit/scripts/**`). See `.claude/rules/README.md` for the full status table.
+**Rules** (`.claude/rules/`): `scss-conventions.md` (active, fires on SCSS/CSS edits), `python-scripts.md` (active, fires on `plugins/acss-kit/scripts/**`), `command-authoring.md` (active, fires on `plugins/*/commands/*.md`), `fpkit-references.md` (active, fires on reference docs). See `.claude/rules/README.md` for the full status table.
 
 **Hooks** (`.claude/settings.json`): PostToolUse validates JSON syntax, `plugin.json` required fields, command front-matter, and SKILL.md front-matter on every Write/Edit. PreToolUse blocks commits/pushes to `main`.
 
@@ -127,5 +117,3 @@ When adding a new script: use the detector contract if a slash command parses th
 ## fpkit/acss cross-references
 
 All references to fpkit source in SKILL.md and reference docs must use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/...`). This allows plugin users and contributors to click through without a local clone.
-
-For contributors editing reference docs: keep `shawn-sandy/acss` cloned as a sibling directory for local verification — see `CONTRIBUTING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Before committing any plugin change:
 
 **Project-level skills** (`.claude/skills/`): `add-command`, `changelog-entry`, `component-author`, `component-update`, `plugin-health`, `release-check`, `release-plugin`, `style-author`, `style-update`, `test-component`, `validate-plugin`, `verify-plugins`. Use these for plugin maintenance tasks instead of manual steps.
 
-**Rules** (`.claude/rules/`): `scss-conventions.md` (active, fires on SCSS/CSS edits), `python-scripts.md` (active, fires on `plugins/acss-kit/scripts/**`), `command-authoring.md` (active, fires on `plugins/*/commands/*.md`), `fpkit-references.md` (active, fires on reference docs). See `.claude/rules/README.md` for the full status table.
+**Rules** (`.claude/rules/`): `scss-conventions.md` (active, fires on SCSS/CSS edits), `python-scripts.md` (active, fires on `plugins/*/scripts/**`), `command-authoring.md` (active, fires on `plugins/*/commands/*.md`), `fpkit-references.md` (active, fires on reference docs). See `.claude/rules/README.md` for the full status table.
 
 **Hooks** (`.claude/settings.json`): PostToolUse validates JSON syntax, `plugin.json` required fields, command front-matter, and SKILL.md front-matter on every Write/Edit. PreToolUse blocks commits/pushes to `main`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,4 +116,4 @@ When adding a new script: use the detector contract if a slash command parses th
 
 ## fpkit/acss cross-references
 
-All references to fpkit source in SKILL.md and reference docs must use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/...`). This allows plugin users and contributors to click through without a local clone.
+All references to fpkit source in SKILL.md and reference docs must use full GitHub URLs pinned to a tag or commit SHA — never `blob/main` (e.g. `https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/...`). This allows plugin users and contributors to click through without a local clone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Plugin work often needs to reference the fpkit source — either to check what's
 └── agentic-acss-plugins/       # this repo
 ```
 
-The plugins do not assume this layout at runtime. All references to fpkit source in `SKILL.md` files and generated-code comments use full GitHub URLs (e.g. `https://github.com/shawn-sandy/acss/blob/main/packages/fpkit/src/index.ts`) so plugin users need only this repo to be installed.
+The plugins do not assume this layout at runtime. All references to fpkit source in `SKILL.md` files and generated-code comments use full GitHub URLs pinned to a tag or commit SHA — never `blob/main` (e.g. `https://github.com/shawn-sandy/acss/blob/<tag-or-sha>/packages/fpkit/src/index.ts`) so plugin users need only this repo to be installed.
 
 The sibling layout is for **contributors** editing plugin skill docs: open the fpkit source locally, verify the current exports, then update the plugin reference docs to match.
 


### PR DESCRIPTION
## Summary
- Add two new path-scoped rules: \`command-authoring.md\` (loads when editing \`plugins/*/commands/*.md\`) and \`fpkit-references.md\` (loads when editing reference docs)
- Trim CLAUDE.md by extracting the command front-matter YAML block and contributor setup line into their respective rule files
- Add missing \`changelog-entry\` and \`test-component\` to the project-level skills inventory

## Changes
Extracts 80%-rule violations from CLAUDE.md into targeted \`.claude/rules/\` files so convention reminders load only when relevant, reducing noise in sessions that don't touch those file types. CLAUDE.md shrinks from 132 to ~118 effective lines. Rules README updated with two new table entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a command-authoring guide describing required markdown conventions and YAML front-matter for plugin commands.
  * Added reference-doc conventions requiring full GitHub URLs pinned to a tag or commit SHA (no repo-relative or blob/main links).
  * Expanded maintainer tooling and rules coverage, widened script discovery to all plugins, and removed the prior local-repo cloning verification instruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->