### PR TITLE
Document component-creator pilot skill and /kit-create command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "acss-kit",
       "source": "./plugins/acss-kit",
-      "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Run /setup to bootstrap a new project (sass check, ui.tsx copy, starter theme). Then use /kit-add for components and /theme-create for themes. No @fpkit/acss npm package required.",
+      "description": "Generate accessible React components and CSS themes for fpkit/acss projects. Run /setup to bootstrap a new project (sass check, ui.tsx copy, starter theme). Then use /kit-add for components, /kit-create for natural-language creator mode (\"primary pill button that says 'Add to cart'\"), and /theme-create for themes. No @fpkit/acss npm package required.",
       "category": "development",
       "tags": [
         "fpkit",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,13 @@ plugins/acss-kit/
 ├── .claude-plugin/plugin.json   # manifest, authoritative version source
 ├── README.md                    # user-facing docs
 ├── commands/*.md                # slash command definitions
-├── skills/components/SKILL.md   # component generation workflow
-├── skills/styles/SKILL.md       # theme generation workflow
-├── skills/component-form/SKILL.md
-├── scripts/*.py                 # Python 3 stdlib helpers
+├── skills/components/SKILL.md         # component generation workflow
+├── skills/styles/SKILL.md             # theme generation workflow
+├── skills/setup/SKILL.md              # cross-domain bootstrap (/setup)
+├── skills/component-form/SKILL.md     # form pilot — natural-language form requests
+├── skills/component-creator/SKILL.md  # creator-mode pilot — natural-language single-component requests (/kit-create)
+├── skills/style-tune/SKILL.md         # style-feel pilot (/style-tune)
+├── scripts/*.py                       # Python 3 stdlib helpers
 └── assets/                      # templates and code snippets
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A Claude Code **plugin marketplace** — not a Node.js or Python package. There 
 
 The repo contains two plugins:
 
-- `plugins/acss-kit` — accessible React components and CSS themes for fpkit/acss projects. Two top-level skills (`components`, `styles`) plus the `component-form` pilot skill.
+- `plugins/acss-kit` — accessible React components and CSS themes for fpkit/acss projects. Two top-level skills (`components`, `styles`), a cross-domain `setup` skill, and three pilot skills (`component-form`, `component-creator`, `style-tune`).
 - `plugins/acss-utilities` — Tailwind-style atomic CSS utility classes paired with `acss-kit`'s OKLCH theme tokens via a bridge file. Generator + validator + four `/utility-*` commands. See [`plugins/acss-utilities/docs/`](plugins/acss-utilities/docs/README.md) for the developer guide.
 
 Install from a Claude Code session:
@@ -33,7 +33,10 @@ plugins/acss-kit/
 ├── skills/components/references/  # component reference docs (see references/components/catalog.md)
 ├── skills/styles/SKILL.md         # styles skill (OKLCH theme generation)
 ├── skills/styles/references/      # role catalogue, palette algorithm, theme schema
-├── skills/component-form/SKILL.md # form pilot — auto-triggers on natural language
+├── skills/component-form/SKILL.md     # form pilot — auto-triggers on natural language
+├── skills/component-creator/SKILL.md  # creator-mode pilot — auto-triggers on "create a <component>" phrasing
+├── skills/style-tune/SKILL.md         # style-feel pilot — backs /style-tune
+├── skills/setup/SKILL.md              # cross-domain bootstrap — backs /setup
 ├── scripts/                       # Python 3 stdlib scripts (see .claude/rules/python-scripts.md for inventory)
 ├── assets/                        # foundation/ui.tsx, brand template, internal schema
 └── docs/                          # developer guides (architecture, recipes, troubleshooting, tutorial)
@@ -91,7 +94,7 @@ Claude Code on the web sessions develop on `claude/<slug>` branches assigned per
 
 | Plugin | Commands |
 |---|---|
-| `acss-kit` | `/kit-add`, `/kit-list`, `/setup`, `/style-tune`, `/theme-brand`, `/theme-create`, `/theme-extract`, `/theme-update` |
+| `acss-kit` | `/kit-add`, `/kit-create`, `/kit-list`, `/setup`, `/style-tune`, `/theme-brand`, `/theme-create`, `/theme-extract`, `/theme-update` |
 | `acss-utilities` | `/utility-add`, `/utility-bridge`, `/utility-list`, `/utility-tune` |
 
 Each command's body is in `plugins/<plugin>/commands/<name>.md`; logic lives in the corresponding SKILL.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ agentic-acss-plugins/
 ├── .claude-plugin/
 │   └── marketplace.json    # catalog listing both plugins
 ├── plugins/
-│   ├── acss-kit/           # components, themes, /setup, /style-tune, form pilot
+│   ├── acss-kit/           # components, themes, /setup, /style-tune, /kit-create, form + creator pilots
 │   └── acss-utilities/     # atomic CSS utilities + token-bridge
 ├── tests/                  # tests/run.sh and tests/e2e.sh validation harness
 ├── README.md

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then bootstrap and add your first component + theme:
 | [`/setup`](./plugins/acss-kit/commands/setup.md) | Bootstrap a project — package-manager detection, sass install hint, `.acss-target.json`, `ui.tsx` copy, optional starter theme. |
 | [`/kit-list [component]`](./plugins/acss-kit/commands/kit-list.md) | List available component references or inspect one in detail. |
 | [`/kit-add <component> ...`](./plugins/acss-kit/commands/kit-add.md) | Generate accessible React components using local imports only. No `@fpkit/acss` package. |
-| [`/kit-create <description>`](./plugins/acss-kit/commands/kit-create.md) | Creator mode — generate a paste-ready TSX snippet (or standalone component file) from a natural-language description (`"primary pill button that says 'Add to cart'"`). Auto-triggers on the same phrasing. |
+| [`/kit-create <description>`](./plugins/acss-kit/commands/kit-create.md) | Explicit command path into creator mode — generate a paste-ready TSX snippet (or standalone component file) from a natural-language description (`"primary pill button that says 'Add to cart'"`). The underlying `component-creator` skill also auto-triggers on the same phrasing without the slash command. |
 | [`/theme-create <hex> [--mode=light\|dark\|both]`](./plugins/acss-kit/commands/theme-create.md) | Generate semantic CSS theme files from a seed color and validate required WCAG contrast pairs. |
 | [`/theme-brand <name> [--from=<hex>]`](./plugins/acss-kit/commands/theme-brand.md) | Scaffold a `brand-<name>.css` preset that layers over light/dark. |
 | [`/theme-update <file> <--color-role=#hex> ...`](./plugins/acss-kit/commands/theme-update.md) | Edit role values in an existing theme file and re-validate contrast. |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Claude Code **plugin marketplace** for building accessible React applications 
 
 | Plugin | Version | What it ships |
 |---|---|---|
-| [`acss-kit`](./plugins/acss-kit) | 0.7.0 | Accessible React components and OKLCH CSS themes. Three skills (`components`, `styles`, plus the `component-form` pilot) and 8 slash commands covering setup, component generation, theme creation, brand presets, image/Figma extraction, and natural-language style tuning. |
+| [`acss-kit`](./plugins/acss-kit) | 0.7.0 | Accessible React components and OKLCH CSS themes. Two top-level skills (`components`, `styles`), a cross-domain `setup` skill, and three pilot skills (`component-form`, `component-creator`, `style-tune`); 9 slash commands covering setup, component generation, natural-language creator mode, theme creation, brand presets, image/Figma extraction, and natural-language style tuning. |
 | [`acss-utilities`](./plugins/acss-utilities) | 0.4.0 | Tailwind-style atomic CSS utility classes (`.bg-primary`, `.mt-4`, `.sm-hide`) generated from a token source-of-truth. Hyphen-prefix responsive variants — no CSS escaping. Pairs with `acss-kit` via a token-bridge so utility colors resolve against the same OKLCH roles. |
 
 The two plugins are **decoupled** — install one, both, or use `acss-utilities` standalone with a hand-written theme.
@@ -51,6 +51,7 @@ Then bootstrap and add your first component + theme:
 | [`/setup`](./plugins/acss-kit/commands/setup.md) | Bootstrap a project — package-manager detection, sass install hint, `.acss-target.json`, `ui.tsx` copy, optional starter theme. |
 | [`/kit-list [component]`](./plugins/acss-kit/commands/kit-list.md) | List available component references or inspect one in detail. |
 | [`/kit-add <component> ...`](./plugins/acss-kit/commands/kit-add.md) | Generate accessible React components using local imports only. No `@fpkit/acss` package. |
+| [`/kit-create <description>`](./plugins/acss-kit/commands/kit-create.md) | Creator mode — generate a paste-ready TSX snippet (or standalone component file) from a natural-language description (`"primary pill button that says 'Add to cart'"`). Auto-triggers on the same phrasing. |
 | [`/theme-create <hex> [--mode=light\|dark\|both]`](./plugins/acss-kit/commands/theme-create.md) | Generate semantic CSS theme files from a seed color and validate required WCAG contrast pairs. |
 | [`/theme-brand <name> [--from=<hex>]`](./plugins/acss-kit/commands/theme-brand.md) | Scaffold a `brand-<name>.css` preset that layers over light/dark. |
 | [`/theme-update <file> <--color-role=#hex> ...`](./plugins/acss-kit/commands/theme-update.md) | Edit role values in an existing theme file and re-validate contrast. |
@@ -62,6 +63,7 @@ Then bootstrap and add your first component + theme:
 - **`components`** — markdown-as-source TSX/SCSS templates with embedded accessibility patterns. 16 component references plus a `catalog` index and a shared `foundation` doc.
 - **`styles`** — OKLCH theme generation, role catalogue, palette algorithm, brand presets, WCAG 2.2 AA validation.
 - **`component-form`** — pilot per-component skill that auto-triggers on natural-language form requests (e.g. *"Create a signup form with email and password"*) and vendors form dependencies via `/kit-add`.
+- **`component-creator`** — pilot creator-mode skill backing `/kit-create`. Auto-triggers on phrases like *"create a primary pill button that says 'Add to cart'"* / *"make me a soft warning alert titled 'Heads up'"*. Loads the matched component's reference doc at runtime, parses its Props Interface, resolves user phrases against the declared prop set, and emits a paste-ready TSX snippet (or a standalone component file). Works with any component that has a dedicated `references/components/<name>.md` doc.
 - **`setup`** — cross-domain init skill backing `/setup`.
 - **`style-tune`** — pilot per-feel skill backing `/style-tune`.
 
@@ -86,8 +88,8 @@ agentic-acss-plugins/
 ├── plugins/
 │   ├── acss-kit/
 │   │   ├── .claude-plugin/plugin.json     # version source of truth
-│   │   ├── commands/*.md                  # 8 slash commands
-│   │   ├── skills/{components,styles,component-form,setup,style-tune}/SKILL.md
+│   │   ├── commands/*.md                  # 9 slash commands
+│   │   ├── skills/{components,styles,component-form,component-creator,setup,style-tune}/SKILL.md
 │   │   ├── scripts/                       # Python 3 stdlib (palette, validate, detect_target, …)
 │   │   ├── assets/                        # ui.tsx foundation, brand template, theme schema
 │   │   └── docs/                          # architecture, recipes, troubleshooting, tutorial

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -117,6 +117,19 @@ Generate one or more components into your project.
 8. **Summary** — displays created/skipped files and an import/usage snippet.
 9. **Verify integration** — runs `scripts/verify_integration.py` against the recorded `stack.entrypointFile`. Missing imports are surfaced as a numbered fix-up list; the plugin never auto-edits the entrypoint.
 
+### `/kit-create <description>`
+
+Creator mode — generate any acss-kit component from a natural-language description. The underlying `component-creator` skill also auto-triggers on the same phrasing without the slash command.
+
+```text
+/kit-create primary pill button that says "Add to cart"
+/kit-create soft warning alert titled "Heads up" with body "Your card expires next month"
+/kit-create card with a heading "Plan" and content "Premium tier with all features"
+/kit-create small outline icon-button with aria-label "Close"
+```
+
+Loads the matched component's reference doc at runtime, parses its `## Props Interface`, resolves the user's phrases against the declared prop set, and emits a paste-ready TSX snippet (default) or a standalone component file. Works with any component that has a dedicated `references/components/<name>.md` doc — Button, Alert, Card, Dialog, Link, Input, Field, Checkbox, IconButton, Img, Icon, List, Table, Popover, Nav. Refinement turns ("make it larger", "swap to secondary", "change the title to 'Save'") merge into the in-memory spec and re-emit. Full reference in [`docs/commands.md`](docs/commands.md#kit-create).
+
 ### Auto-trigger: form generation
 
 The `component-form` skill auto-triggers when you ask for a form in plain English:
@@ -315,10 +328,12 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
     setup.md                               # /setup  ← start here after install
     kit-list.md                            # /kit-list
     kit-add.md                             # /kit-add
+    kit-create.md                          # /kit-create  (creator mode)
     theme-create.md                        # /theme-create
     theme-brand.md                         # /theme-brand
     theme-update.md                        # /theme-update
     theme-extract.md                       # /theme-extract
+    style-tune.md                          # /style-tune
   scripts/
     detect_target.py                       # Manages .acss-target.json
     detect_package_manager.py             # Detects pnpm/yarn/bun/npm from lockfile
@@ -347,6 +362,8 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
         theme-schema.md                    # Internal JSON schema reference
     component-form/
       SKILL.md                             # Form pilot — auto-triggers on natural language
+    component-creator/
+      SKILL.md                             # Creator-mode pilot — backs /kit-create; auto-triggers on "create a <component>" phrasing
     style-tune/
       SKILL.md                             # Style-feel pilot — auto-triggers on adjective + component
       references/
@@ -361,7 +378,7 @@ For end-to-end smoke testing — confirming `/kit-add <component>` actually writ
 Detailed guides are in [`docs/`](docs/):
 
 - [concepts.md](docs/concepts.md) — mental model: UI base, data-\* variants, CSS-var fallbacks, aria-disabled, generation flow
-- [commands.md](docs/commands.md) — full `/kit-add` and `/kit-list` reference
+- [commands.md](docs/commands.md) — full reference for every slash command (`/setup`, `/kit-list`, `/kit-add`, `/kit-create`, `/style-tune`, `/theme-create`, `/theme-brand`, `/theme-update`, `/theme-extract`)
 - [recipes.md](docs/recipes.md) — step-by-step walkthroughs for common tasks
 - [troubleshooting.md](docs/troubleshooting.md) — concrete failure modes and fixes
 - [architecture.md](docs/architecture.md) — contributor guide: adding components, version-bump checklist


### PR DESCRIPTION
## Summary
Updated documentation across AGENTS.md, CLAUDE.md, and README.md to reflect the addition of the `component-creator` pilot skill and its corresponding `/kit-create` command to the acss-kit plugin.

## Key Changes
- **Added `component-creator` skill documentation** — New pilot skill that auto-triggers on natural-language component creation phrases (e.g., "create a primary pill button that says 'Add to cart'"). Generates paste-ready TSX snippets or standalone component files by parsing component reference docs and resolving user descriptions against declared prop sets.
- **Added `/kit-create` command** — New slash command for creator-mode component generation from natural-language descriptions.
- **Updated skill inventory** — Clarified the plugin now ships two top-level skills (`components`, `styles`), a cross-domain `setup` skill, and three pilot skills (`component-form`, `component-creator`, `style-tune`).
- **Updated command count** — Incremented from 8 to 9 slash commands in the acss-kit plugin.
- **Improved documentation structure** — Added alignment and descriptive comments in file tree listings for better readability.

## Notable Details
- The `component-creator` skill works with any component that has a dedicated `references/components/<name>.md` reference doc.
- Auto-triggering behavior mirrors the existing `component-form` pilot pattern.
- Documentation emphasizes the distinction between the new creator-mode skill and the existing form-generation skill.

https://claude.ai/code/session_01NHjLY7gaQ89WQcQjT6XqoC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded acss-kit docs to include new pilot skills: component-form, component-creator, style-tune, plus a setup skill.
  * Added user guidance and examples for a new /kit-create slash command and updated command reference across README and plugin docs.
  * Updated marketplace and contribution docs and repository layout to reflect the expanded skill/command listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->