### PR TITLE
docs: phase 1.5 onboarding clarity (do-this-first, config, upgrade path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then bootstrap and add your first component + theme:
 
 ### Configuration
 
-Both plugins read `.acss-target.json` at your project root — created by `/setup` and updated by detection scripts. It records the directories where commands write generated files (`componentsDir`, `stylesDir`, `utilitiesDir`) and the detected `stack` (framework, bundler, CSS pipeline, entrypoint file). Generated artifacts plus this file should be **committed**, not gitignored. If you delete or move it, re-run `/setup` — pass `--target=<dir>` again if your original custom path differed from the default `src/components/fpkit/`. Full schema: [`plugins/acss-kit/skills/setup/SKILL.md`](./plugins/acss-kit/skills/setup/SKILL.md).
+Both plugins read `.acss-target.json` at your project root — created by `/setup` and updated by detection scripts. Top-level keys: `componentsDir` (where `/kit-add` writes generated TSX/SCSS, default `src/components/fpkit`), `utilitiesDir` (where `/utility-add` writes `utilities.css` and `token-bridge.css`, default `src/styles`), and `stack` (detected framework, bundler, CSS pipeline, plus `entrypointFile` and `cssEntryFile` so `verify_integration.py` knows where theme imports live). Generated artifacts plus this file should be **committed**, not gitignored. If you delete or move it, re-run `/setup` — pass `--target=<dir>` again if your original custom path differed from the default. Full schema with field semantics: [`plugins/acss-kit/docs/architecture.md`](./plugins/acss-kit/docs/architecture.md).
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Inside any Claude Code session running in your React + TS project — register t
 /plugin install acss-utilities@shawn-sandy-agentic-acss-plugins
 ```
 
+> **Do this first:** Run `/setup` once before anything else. Subsequent `/kit-add` and `/theme-create` calls depend on the `.acss-target.json` it writes.
+
 Then bootstrap and add your first component + theme:
 
 ```text
@@ -68,6 +70,10 @@ Then bootstrap and add your first component + theme:
 - React + TypeScript project
 - `sass` or `sass-embedded` in `devDependencies` (`npm install -D sass`)
 - Claude Code 2.x with plugin support
+
+### Configuration
+
+Both plugins read `.acss-target.json` at your project root — created by `/setup` and updated by detection scripts. It records the directories where commands write generated files (`componentsDir`, `stylesDir`, `utilitiesDir`) and the detected `stack` (framework, bundler, CSS pipeline, entrypoint file). Generated artifacts plus this file should be **committed**, not gitignored. If you delete or move it, re-run `/setup` — pass `--target=<dir>` again if your original custom path differed from the default `src/components/fpkit/`. Full schema: [`plugins/acss-kit/skills/setup/SKILL.md`](./plugins/acss-kit/skills/setup/SKILL.md).
 
 ## Command reference
 

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -83,6 +83,8 @@ Pass `--no-theme` to skip theme generation, or `--target=<dir>` to override the 
 
 `/setup` is idempotent: re-running it checks each artifact and skips anything already present.
 
+If you delete `.acss-target.json`, re-run `/setup` to regenerate it. If your project originally used a custom `--target=<dir>`, pass it again — the regenerated file otherwise defaults to `src/components/fpkit/`.
+
 ## Component commands
 
 ### `/kit-list [component]`

--- a/plugins/acss-utilities/README.md
+++ b/plugins/acss-utilities/README.md
@@ -30,6 +30,10 @@ If you also want `acss-kit`:
 /plugin install acss-kit@shawn-sandy-agentic-acss-plugins
 ```
 
+## Upgrading from 0.1.x
+
+The 0.2.0 release switched responsive variants from the escaped-colon form (`.sm\:hide`) to a plain hyphen (`.sm-hide`). If you installed `acss-utilities@0.1.x` and have classnames using the old form, search-and-replace in JSX `className` strings and CSS `@apply` directives — `sm:` → `sm-`, `md:` → `md-`, `lg:` → `lg-`, `xl:` → `xl-`, `print:` → `print-`. The bundled `scripts/migrate_classnames.py` provides an automated dry-run; see [Responsive variants](#responsive-variants) below for the full migration note.
+
 ## Quick start
 
 ```shell


### PR DESCRIPTION
## Summary

Phase 1.5 of the adoption review (Phase 1 was the command-surface accuracy fix in #58). Three docs-only items, three READMEs touched, no version bumps.

### Changes

- **`README.md`**
  - Add a "**Do this first**" callout right after the install code block so `/setup` is visually elevated rather than buried in a code-block comment.
  - Add a new "**Configuration**" subsection under Quickstart explaining `.acss-target.json` — what it records (`componentsDir`, `stylesDir`, `utilitiesDir`, `stack`), the recovery path on delete, and the custom-target caveat. Links to the `setup` skill for the full schema.
- **`plugins/acss-kit/README.md`**
  - Add a recovery sentence to the First-run setup section pairing with the new root-README configuration block ("If you delete `.acss-target.json`, re-run `/setup` … pass `--target=<dir>` again if your custom path differed from the default").
- **`plugins/acss-utilities/README.md`**
  - Promote the `migrate_classnames.py` reference from buried under "Responsive variants → Migrating from 0.1.0" to a top-level "**Upgrading from 0.1.x**" section so users hitting broken classes after upgrade see it without scrolling past the families table. The existing inline mention under Responsive variants is preserved.

### Out of scope (deferred to follow-up PRs)

Per the phased plan: pilot-skill troubleshooting + graduation criteria (Phase 2.2), `/kit-list` HTML-output column (Phase 2.1), dark-mode bridge troubleshooting (Phase 2.3), disambiguation table (Phase 2.4), maintainer/user boundary docs (Phase 3).

## Test plan

- [x] `tests/run.sh` — all 11 steps green
- [x] All edits are additive; no existing content removed
- [x] Manual read-through of root README from a "first time visitor" angle — `/setup` is now visually elevated and `.acss-target.json` has a discoverable home

https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that an initial setup step must be run before using kit/theme commands.
  * Documented where the project configuration and generated artifacts live, advising committing them to source control.
  * Added instructions to rerun setup (with a custom target option) if the config is deleted or moved.
  * Added migration guidance for responsive variant renaming in v0.2.0 and referenced an automated migration tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->