### PR TITLE
docs: add "When to use what" cheat sheet to prompt-book (phase 2.4)

### DIFF
--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -271,7 +271,7 @@ Print a copy-paste catalogue of natural-language prompts for every shipped slash
 /prompt-book 5
 ```
 
-With no argument it prints the full book. With a section number it prints only that entry. The book is bundled with the plugin at [`docs/prompt-book.md`](docs/prompt-book.md).
+With no argument it prints the full book. With a section number it prints only that entry. The book is bundled with the plugin at [`docs/prompt-book.md`](docs/prompt-book.md), which also opens with a [**When to use what**](docs/prompt-book.md#when-to-use-what) cheat sheet for picking between `/kit-add`, `/kit-create`, `/theme-create`, `/style-tune`, and friends.
 
 ## Available components
 

--- a/plugins/acss-kit/docs/prompt-book.md
+++ b/plugins/acss-kit/docs/prompt-book.md
@@ -19,6 +19,24 @@ Prompts are written as natural language for Claude Code to interpret; most resol
 
 ---
 
+## When to use what
+
+Several commands sound similar (`/kit-add`, `/kit-create`, `/theme-create`, `/style-tune`). Pick by intent, not by name:
+
+| If you want to… | Use |
+|---|---|
+| Generate a known component (Button, Dialog, …) | `/kit-add <name>` — explicit, fastest. |
+| Describe a component in prose | `/kit-create "<description>"` (or just describe in chat — `component-creator` auto-triggers on the same phrasing). |
+| Generate a form from prose | Describe the form (`component-form` auto-triggers — e.g. *"create a signup form with email, password, role select"*). |
+| Generate a new theme from a hex | `/theme-create <hex> [--mode=light\|dark\|both]`. |
+| Edit an existing theme's role values | `/theme-update <file> --color-<role>=<hex>`. |
+| Tune the visual feel of a component or theme | `/style-tune "<adjective>"` (e.g. *"warmer button"*, *"more elevated dialog"*). |
+| Adjust utility-class tokens (spacing, breakpoints, families) | `/utility-tune "<description>"`. |
+
+The rest of this book groups prompts by these intents.
+
+---
+
 ## 1. Bootstrap a new project
 
 **When to use:** First time using `acss-kit` in a React project — before generating any components or themes.

--- a/plugins/acss-kit/docs/prompt-book.md
+++ b/plugins/acss-kit/docs/prompt-book.md
@@ -26,12 +26,12 @@ Several commands sound similar (`/kit-add`, `/kit-create`, `/theme-create`, `/st
 | If you want to… | Use |
 |---|---|
 | Generate a known component (Button, Dialog, …) | `/kit-add <name>` — explicit, fastest. |
-| Describe a component in prose | `/kit-create "<description>"` (or just describe in chat — `component-creator` auto-triggers on the same phrasing). |
+| Describe a component in prose | `/kit-create <description>` (or just describe in chat — `component-creator` auto-triggers on the same phrasing). |
 | Generate a form from prose | Describe the form (`component-form` auto-triggers — e.g. *"create a signup form with email, password, role select"*). |
 | Generate a new theme from a hex | `/theme-create <hex>` (add `--mode=light` or `--mode=dark` for a single mode; default emits both). |
 | Edit an existing theme's role values | `/theme-update <file> --color-<role>=<hex>`. |
-| Tune the visual feel of a component or theme | `/style-tune "<adjective>"` (e.g. *"warmer button"*, *"more elevated dialog"*). |
-| Adjust utility-class tokens (spacing, breakpoints, families) | `/utility-tune "<description>"`. |
+| Tune the visual feel of a component or theme | `/style-tune <description>` (e.g. *warmer button*, *more elevated dialog*, *tone down the primary*). |
+| Adjust utility-class tokens (spacing, breakpoints, families) | `/utility-tune <description>`. |
 
 The rest of this book groups prompts by these intents.
 

--- a/plugins/acss-kit/docs/prompt-book.md
+++ b/plugins/acss-kit/docs/prompt-book.md
@@ -28,7 +28,7 @@ Several commands sound similar (`/kit-add`, `/kit-create`, `/theme-create`, `/st
 | Generate a known component (Button, Dialog, …) | `/kit-add <name>` — explicit, fastest. |
 | Describe a component in prose | `/kit-create "<description>"` (or just describe in chat — `component-creator` auto-triggers on the same phrasing). |
 | Generate a form from prose | Describe the form (`component-form` auto-triggers — e.g. *"create a signup form with email, password, role select"*). |
-| Generate a new theme from a hex | `/theme-create <hex> [--mode=light\|dark\|both]`. |
+| Generate a new theme from a hex | `/theme-create <hex> [--mode=light|dark|both]`. |
 | Edit an existing theme's role values | `/theme-update <file> --color-<role>=<hex>`. |
 | Tune the visual feel of a component or theme | `/style-tune "<adjective>"` (e.g. *"warmer button"*, *"more elevated dialog"*). |
 | Adjust utility-class tokens (spacing, breakpoints, families) | `/utility-tune "<description>"`. |

--- a/plugins/acss-kit/docs/prompt-book.md
+++ b/plugins/acss-kit/docs/prompt-book.md
@@ -28,7 +28,7 @@ Several commands sound similar (`/kit-add`, `/kit-create`, `/theme-create`, `/st
 | Generate a known component (Button, Dialog, …) | `/kit-add <name>` — explicit, fastest. |
 | Describe a component in prose | `/kit-create "<description>"` (or just describe in chat — `component-creator` auto-triggers on the same phrasing). |
 | Generate a form from prose | Describe the form (`component-form` auto-triggers — e.g. *"create a signup form with email, password, role select"*). |
-| Generate a new theme from a hex | `/theme-create <hex> [--mode=light|dark|both]`. |
+| Generate a new theme from a hex | `/theme-create <hex>` (add `--mode=light` or `--mode=dark` for a single mode; default emits both). |
 | Edit an existing theme's role values | `/theme-update <file> --color-<role>=<hex>`. |
 | Tune the visual feel of a component or theme | `/style-tune "<adjective>"` (e.g. *"warmer button"*, *"more elevated dialog"*). |
 | Adjust utility-class tokens (spacing, breakpoints, families) | `/utility-tune "<description>"`. |

--- a/plugins/acss-kit/docs/tutorial.md
+++ b/plugins/acss-kit/docs/tutorial.md
@@ -2,7 +2,7 @@
 
 Generate, import, and customize a Button in under five minutes. By the end you will have a working, themeable Button component you own outright — no `@fpkit/acss` npm dependency, no boilerplate.
 
-If you want the mental model first, read [concepts.md](concepts.md). If you prefer diagrams, see [visual-guide.md](visual-guide.md). Otherwise, start here.
+If you want the mental model first, read [concepts.md](concepts.md). If you prefer diagrams, see [visual-guide.md](visual-guide.md). For a cheat sheet on which command to reach for (`/kit-add` vs `/kit-create` vs `/theme-create` vs `/style-tune`), see [**When to use what**](prompt-book.md#when-to-use-what) at the top of the prompt book. Otherwise, start here.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2.4 of the adoption review (Phase 1 was #58, Phase 1.5 was #59). The plan called out verb overload across `/kit-add` / `/kit-create` / `/theme-create` / `/style-tune` as a discoverability blocker — new users can't predict which one fires for a given intent.

This PR adds a single "**When to use what**" cheat sheet at the top of the bundled prompt book and links to it from the two natural entry points (the plugin README's `/prompt-book` section and the tutorial's preamble), rather than duplicating the table.

### Changes

- **`plugins/acss-kit/docs/prompt-book.md`** — new "When to use what" section with a 7-row intent → command table covering `/kit-add`, `/kit-create`, `component-form` auto-trigger, `/theme-create`, `/theme-update`, `/style-tune`, `/utility-tune`.
- **`plugins/acss-kit/README.md`** — one-line pointer at the end of the existing `/prompt-book` section.
- **`plugins/acss-kit/docs/tutorial.md`** — one-line pointer in the "If you want X first…" intro paragraph.

### Phase 2.3 update (skipped, not deferred)

While preparing this PR I re-read `plugins/acss-utilities/docs/troubleshooting.md` and the planned "dark-mode bridge troubleshooting" entry is **already covered** by two existing sections:

- "Bridge dark-mode parity gap" — handles missing `[data-theme="dark"]` aliases and the validator catching them.
- "`var()` always resolves to the hex fallback" — handles the dark-mode-looks-broken symptom with three diagnosis paths (import order, theme not loaded, wrong element).

So Phase 2.3 is closed without a separate PR. The plan was based on a doc-coverage assumption that turned out to be wrong on closer reading.

### Out of scope (deferred)

- Phase 2.1 (`/kit-list` HTML-output column) — needs `acss-kit` patch bump
- Phase 2.2 (pilot skill troubleshooting + graduation criteria) — needs `acss-kit` patch bump
- Phase 3 (internal consolidation design notes)

## Test plan

- [x] `tests/run.sh` — all 11 steps green
- [x] All edits are additive (no existing prompt-book content removed)
- [x] Anchor `#when-to-use-what` matches the new heading

https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "When to use what" decision guide with a compact command-reference table to help choose appropriate actions.
  * Clarified prompt-book usage: how to print the full book or a specific section; removed duplicated text and linked the related cheat sheet.
  * Expanded the tutorial intro to point readers to prerequisite materials before starting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->