### PR TITLE
feat(acss-kit): surface HTML output status in /kit-list (0.11.1)

### DIFF
--- a/plugins/acss-kit/.claude-plugin/plugin.json
+++ b/plugins/acss-kit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit",
   "description": "Generate accessible React components, static HTML snippets, and CSS themes for fpkit/acss projects. Markdown-as-source component templates plus OKLCH theme generation with WCAG 2.2 AA validation.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-05-08
+
+### Changed
+
+- **`/kit-list` now surfaces HTML-output status.** The no-arg listing appends `[HTML]` to each component whose row in `references/components/catalog.md`'s `## HTML Output Status` table is marked **Verified** (Button, Card, Alert, Dialog), and the per-component view (`/kit-list <name>`) prints a dedicated `HTML output:` line. Helps users discover which components `/kit-add-html` can generate before invoking it. No script or generation behavior changed.
+
 ## [0.11.0] - 2026-05-07
 
 ### Added

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 
 ### Changed
 
-- **`/kit-list` now surfaces HTML-output status.** The no-arg listing appends `[HTML]` to each component whose row in `references/components/catalog.md`'s `## HTML Output Status` table is marked **Verified** (Button, Card, Alert, Dialog), and the per-component view (`/kit-list <name>`) prints a dedicated `HTML output:` line. Helps users discover which components `/kit-add-html` can generate before invoking it. No script or generation behavior changed.
+- **`/kit-list` now surfaces HTML-output status.** The no-arg listing appends `[HTML]` to each component whose row in the components reference catalog's `## HTML Output Status` table is marked **Verified** (Button, Card, Alert, Dialog), and the per-component view (`/kit-list <name>`) prints a dedicated `HTML output:` line. Helps users discover which components `/kit-add-html` can generate before invoking it. No script or generation behavior changed.
+- **`commands/kit-list.md` slimmed to a thin entry point** that delegates to the new "`/kit-list` workflow" section in `skills/components/SKILL.md`, matching the delegation convention already followed by every other command file in the plugin.
 
 ## [0.11.0] - 2026-05-07
 

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -89,7 +89,7 @@ If you delete `.acss-target.json`, re-run `/setup` to regenerate it. If your pro
 
 ### `/kit-list [component]`
 
-List available components or inspect one without writing any files. Read-only — useful for discovering names, props, CSS variables, and dependencies before running `/kit-add`. The full reference (signature, examples, output shape) is in [`docs/commands.md`](docs/commands.md).
+List available components or inspect one without writing any files. Read-only — useful for discovering names, props, CSS variables, and dependencies before running `/kit-add`. As of `0.11.1`, the listing appends `[HTML]` to components whose static-HTML output is **Verified** (Button, Card, Alert, Dialog), and `/kit-list <name>` prints a dedicated `HTML output:` line so you can see at a glance whether `/kit-add-html` will succeed. The full reference (signature, examples, output shape) is in [`docs/commands.md`](docs/commands.md).
 
 ```
 /kit-list

--- a/plugins/acss-kit/commands/kit-list.md
+++ b/plugins/acss-kit/commands/kit-list.md
@@ -10,13 +10,14 @@ List available components or show detailed information about a specific componen
 
 ## Usage
 
-```
+```text
 /kit-list
 /kit-list <component>
 ```
 
 **Examples:**
-```
+
+```text
 /kit-list
 /kit-list badge
 /kit-list dialog
@@ -29,7 +30,7 @@ List available components or show detailed information about a specific componen
 
 Read `references/components/catalog.md` — both the per-component listing and the `## HTML Output Status` table — and display every available component organized by category. Append `[HTML]` to any component whose row in the HTML Output Status table is marked **Verified**; these are the components `/kit-add-html` can generate today. Components without the marker exist as React only and `/kit-add-html` will warn.
 
-```
+```text
 Available Components (acss-kit)
 
 Simple (no dependencies):
@@ -67,7 +68,7 @@ Read the component's reference doc (or its entry in `catalog.md`) and display:
 
 **Example output for `/kit-list badge`:**
 
-```
+```text
 Component: Badge
 File: badge.tsx + badge.scss
 Dependencies: none (simple component)

--- a/plugins/acss-kit/commands/kit-list.md
+++ b/plugins/acss-kit/commands/kit-list.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Glob, Grep
 
 # /kit-list
 
-List available components or show detailed information about a specific component.
+List available components or show detailed information about a specific component. Read-only — never writes files.
 
 ## Usage
 
@@ -26,74 +26,11 @@ List available components or show detailed information about a specific componen
 
 ## Workflow
 
-### `/kit-list` (no arguments)
+When this command is invoked, follow the **`/kit-list` workflow** documented in the `components` skill at `${CLAUDE_PLUGIN_ROOT}/skills/components/SKILL.md` (section *"`/kit-list` workflow — read-only inspection"*).
 
-Read `references/components/catalog.md` — both the per-component listing and the `## HTML Output Status` table — and display every available component organized by category. Append `[HTML]` to any component whose row in the HTML Output Status table is marked **Verified**; these are the components `/kit-add-html` can generate today. Components without the marker exist as React only and `/kit-add-html` will warn.
+### Quick reference
 
-```text
-Available Components (acss-kit)
+1. **No arguments → categorized listing** — read the catalog and the `## HTML Output Status` table, group components by category, append `[HTML]` to any component whose HTML row is marked **Verified**.
+2. **With a component name → per-component detail** — read the component's reference doc and print Generation Contract, Dependencies, HTML output, Props, CSS Variables, and a Usage Example.
 
-Simple (no dependencies):
-  badge       — Status indicator with count or text
-  tag         — Categorical label with optional removal
-  heading     — Semantic heading (h1-h6) with styles
-  text        — Inline/block text with variants
-
-Interactive (useDisabledState pattern):
-  button      — Primary interactive element (all variants)              [HTML]
-  link        — Accessible anchor with hover/visited states
-
-Layout:
-  card        — Compound component (Card.Title, Card.Content, Card.Footer)  [HTML]
-  nav         — Navigation landmark with compound Nav.List, Nav.Item
-
-Complex (multiple dependencies):
-  alert       — Severity-aware notification (needs icon)                 [HTML]
-  dialog      — Modal dialog with focus trap (needs button, icon)        [HTML]
-  form        — Form controls (input, textarea, select, checkbox, toggle)
-
-Run /kit-add <component> to generate React components, or /kit-add-html <component> for static HTML versions of the [HTML]-marked entries.
-```
-
-### `/kit-list <component>` (specific component)
-
-Read the component's reference doc (or its entry in `catalog.md`) and display:
-
-1. **Generation Contract** — What files will be created, what imports are used
-2. **Dependencies** — What other components will be co-generated
-3. **HTML output** — Read the `## HTML Output Status` table in `catalog.md`. Print `Verified` if the component has it (i.e. `/kit-add-html` can generate it), otherwise `Not yet — React only`.
-4. **Props** — TypeScript interface with descriptions
-5. **CSS Variables** — Customizable properties with defaults
-6. **Usage Example** — Import + JSX snippet
-
-**Example output for `/kit-list badge`:**
-
-```text
-Component: Badge
-File: badge.tsx + badge.scss
-Dependencies: none (simple component)
-HTML output: Not yet — React only (/kit-add-html will warn)
-
-Props:
-  children?   ReactNode   — Content (typically numbers or short text)
-  variant?    'rounded'   — Visual variant
-  ...UI props             — All HTML <sup> props
-
-CSS Variables:
-  --badge-bg              Background color (default: #e9ecef)
-  --badge-color           Text color (default: #212529)
-  --badge-fs              Font size (default: 0.75rem)
-  --badge-fw              Font weight (default: 600)
-  --badge-padding-inline  Horizontal padding (default: 0.375rem)
-  --badge-padding-block   Vertical padding (default: 0.125rem)
-  --badge-radius          Border radius (default: 0.25rem)
-
-Usage:
-  import Badge from './badge/badge'
-  import './badge/badge.scss'
-
-  <Badge aria-label="3 unread messages">3</Badge>
-  <Badge variant="rounded" aria-label="99+ notifications">99+</Badge>
-
-Run /kit-add badge to generate this component.
-```
+See `SKILL.md` for the full output format, status-resolution rules, and unknown-name handling.

--- a/plugins/acss-kit/commands/kit-list.md
+++ b/plugins/acss-kit/commands/kit-list.md
@@ -27,7 +27,7 @@ List available components or show detailed information about a specific componen
 
 ### `/kit-list` (no arguments)
 
-Read `references/components/catalog.md` and display all available components organized by category:
+Read `references/components/catalog.md` — both the per-component listing and the `## HTML Output Status` table — and display every available component organized by category. Append `[HTML]` to any component whose row in the HTML Output Status table is marked **Verified**; these are the components `/kit-add-html` can generate today. Components without the marker exist as React only and `/kit-add-html` will warn.
 
 ```
 Available Components (acss-kit)
@@ -39,19 +39,19 @@ Simple (no dependencies):
   text        — Inline/block text with variants
 
 Interactive (useDisabledState pattern):
-  button      — Primary interactive element (all variants)
+  button      — Primary interactive element (all variants)              [HTML]
   link        — Accessible anchor with hover/visited states
 
 Layout:
-  card        — Compound component (Card.Title, Card.Content, Card.Footer)
+  card        — Compound component (Card.Title, Card.Content, Card.Footer)  [HTML]
   nav         — Navigation landmark with compound Nav.List, Nav.Item
 
 Complex (multiple dependencies):
-  alert       — Severity-aware notification (needs icon)
-  dialog      — Modal dialog with focus trap (needs button, icon)
+  alert       — Severity-aware notification (needs icon)                 [HTML]
+  dialog      — Modal dialog with focus trap (needs button, icon)        [HTML]
   form        — Form controls (input, textarea, select, checkbox, toggle)
 
-Run /kit-add <component> to generate any component.
+Run /kit-add <component> to generate React components, or /kit-add-html <component> for static HTML versions of the [HTML]-marked entries.
 ```
 
 ### `/kit-list <component>` (specific component)
@@ -60,9 +60,10 @@ Read the component's reference doc (or its entry in `catalog.md`) and display:
 
 1. **Generation Contract** — What files will be created, what imports are used
 2. **Dependencies** — What other components will be co-generated
-3. **Props** — TypeScript interface with descriptions
-4. **CSS Variables** — Customizable properties with defaults
-5. **Usage Example** — Import + JSX snippet
+3. **HTML output** — Read the `## HTML Output Status` table in `catalog.md`. Print `Verified` if the component has it (i.e. `/kit-add-html` can generate it), otherwise `Not yet — React only`.
+4. **Props** — TypeScript interface with descriptions
+5. **CSS Variables** — Customizable properties with defaults
+6. **Usage Example** — Import + JSX snippet
 
 **Example output for `/kit-list badge`:**
 
@@ -70,6 +71,7 @@ Read the component's reference doc (or its entry in `catalog.md`) and display:
 Component: Badge
 File: badge.tsx + badge.scss
 Dependencies: none (simple component)
+HTML output: Not yet — React only (/kit-add-html will warn)
 
 Props:
   children?   ReactNode   — Content (typically numbers or short text)

--- a/plugins/acss-kit/commands/kit-list.md
+++ b/plugins/acss-kit/commands/kit-list.md
@@ -30,7 +30,7 @@ When this command is invoked, follow the **`/kit-list` workflow** documented in 
 
 ### Quick reference
 
-1. **No arguments → categorized listing** — read the catalog and the `## HTML Output Status` table, group components by category, append `[HTML]` to any component whose HTML row is marked **Verified**.
-2. **With a component name → per-component detail** — read the component's reference doc and print Generation Contract, Dependencies, HTML output, Props, CSS Variables, and a Usage Example.
+1. **No arguments** — Categorized listing of all components, with `[HTML]` markers on Verified entries.
+2. **With component name** — Per-component detail (Generation Contract, Dependencies, HTML output, Props, CSS Variables, Usage Example).
 
 See `SKILL.md` for the full output format, status-resolution rules, and unknown-name handling.

--- a/plugins/acss-kit/docs/commands.md
+++ b/plugins/acss-kit/docs/commands.md
@@ -167,13 +167,15 @@ List available components or inspect a specific one.
 
 **Without an argument**
 
-Reads [`references/components/catalog.md`](../skills/components/references/components/catalog.md) and prints all components grouped by category (Simple / Interactive / Layout / Complex) with a one-line description of each.
+Reads [`references/components/catalog.md`](../skills/components/references/components/catalog.md) — both the per-component listing and the `## HTML Output Status` table — and prints all components grouped by category (Simple / Interactive / Layout / Complex) with a one-line description of each. Components whose row in the HTML Output Status table is **Verified** (Button, Card, Alert, Dialog as of 0.11.1) get an `[HTML]` marker; those are the components `/kit-add-html` can generate today.
 
 **With a component name**
 
 Reads that component's reference doc (either from `catalog.md` or from a dedicated `references/components/{name}.md`) and prints:
 
 - Generation Contract (`export_name`, `file`, `scss`, `imports`, `dependencies`)
+- Dependencies that would be co-generated
+- HTML output (`Verified` if `/kit-add-html` can generate it, else `Not yet — React only`)
 - Props interface
 - CSS variables with their fallback values
 - A usage snippet

--- a/plugins/acss-kit/skills/components/SKILL.md
+++ b/plugins/acss-kit/skills/components/SKILL.md
@@ -458,6 +458,88 @@ The verifier reads `stack.entrypointFile` from `.acss-target.json`, so Step A3.1
 
 ---
 
+## `/kit-list` workflow — read-only inspection
+
+This is a separate command flow from `/kit-add` (Steps A–G above). `/kit-list` never writes files. It reads `references/components/catalog.md` and individual reference docs and prints a formatted summary.
+
+### L1. No arguments — categorized listing
+
+Read `references/components/catalog.md` — both the per-component listing and the `## HTML Output Status` table — and display every available component organized by category. Append `[HTML]` to any component whose row in the HTML Output Status table is marked **Verified**; these are the components `/kit-add-html` can generate today. Components without the marker exist as React only and `/kit-add-html` will warn.
+
+Output format:
+
+```text
+Available Components (acss-kit)
+
+Simple (no dependencies):
+  badge       — Status indicator with count or text
+  tag         — Categorical label with optional removal
+  heading     — Semantic heading (h1-h6) with styles
+  text        — Inline/block text with variants
+
+Interactive (useDisabledState pattern):
+  button      — Primary interactive element (all variants)              [HTML]
+  link        — Accessible anchor with hover/visited states
+
+Layout:
+  card        — Compound component (Card.Title, Card.Content, Card.Footer)  [HTML]
+  nav         — Navigation landmark with compound Nav.List, Nav.Item
+
+Complex (multiple dependencies):
+  alert       — Severity-aware notification (needs icon)                 [HTML]
+  dialog      — Modal dialog with focus trap (needs button, icon)        [HTML]
+  form        — Form controls (input, textarea, select, checkbox, toggle)
+
+Run /kit-add <component> to generate React components, or /kit-add-html <component> for static HTML versions of the [HTML]-marked entries.
+```
+
+### L2. With a component name — per-component detail
+
+Read the component's reference doc (or its entry in `catalog.md`) and display:
+
+1. **Generation Contract** — files that would be created, imports used
+2. **Dependencies** — other components that would be co-generated
+3. **HTML output** — read the `## HTML Output Status` table in `catalog.md`; print `Verified` if the component appears as Verified there (i.e. `/kit-add-html` can generate it), otherwise `Not yet — React only`
+4. **Props** — TypeScript interface with descriptions
+5. **CSS Variables** — customizable properties with defaults
+6. **Usage Example** — import + JSX snippet
+
+Example output for `/kit-list badge`:
+
+```text
+Component: Badge
+File: badge.tsx + badge.scss
+Dependencies: none (simple component)
+HTML output: Not yet — React only (/kit-add-html will warn)
+
+Props:
+  children?   ReactNode   — Content (typically numbers or short text)
+  variant?    'rounded'   — Visual variant
+  ...UI props             — All HTML <sup> props
+
+CSS Variables:
+  --badge-bg              Background color (default: #e9ecef)
+  --badge-color           Text color (default: #212529)
+  --badge-fs              Font size (default: 0.75rem)
+  --badge-fw              Font weight (default: 600)
+  --badge-padding-inline  Horizontal padding (default: 0.375rem)
+  --badge-padding-block   Vertical padding (default: 0.125rem)
+  --badge-radius          Border radius (default: 0.25rem)
+
+Usage:
+  import Badge from './badge/badge'
+  import './badge/badge.scss'
+
+  <Badge aria-label="3 unread messages">3</Badge>
+  <Badge variant="rounded" aria-label="99+ notifications">99+</Badge>
+
+Run /kit-add badge to generate this component.
+```
+
+If the component name is unknown, print "Component '<name>' not found. Run `/kit-list` (no args) to see the full catalog." and stop.
+
+---
+
 ## Reference Documents
 
 Read these before generating components:

--- a/plugins/acss-kit/skills/components/SKILL.md
+++ b/plugins/acss-kit/skills/components/SKILL.md
@@ -515,7 +515,7 @@ HTML output: Not yet — React only (/kit-add-html will warn)
 Props:
   children?   ReactNode   — Content (typically numbers or short text)
   variant?    'rounded'   — Visual variant
-  ...UI props             — All HTML <sup> props
+  ...UI props             — All standard <sup>-element HTML props
 
 CSS Variables:
   --badge-bg              Background color (default: #e9ecef)


### PR DESCRIPTION
## Summary

Phase 2.1 of the adoption review. The first behavior-affecting PR in the series — patch-bumps `acss-kit` from `0.11.0` → `0.11.1`.

Until now, users had to read `references/components/catalog.md` (specifically the `## HTML Output Status` table) to discover which components `/kit-add-html` can actually generate today (Button, Card, Alert, Dialog). The plan flagged this as friction: `/kit-list` is the natural discovery entry point, so the HTML status should surface there.

### Changes

- **`plugins/acss-kit/commands/kit-list.md`**
  - **No-args listing:** instructions now direct Claude to read both the per-component listing and the `## HTML Output Status` table, and append `[HTML]` to any component whose row is marked **Verified**. The example output adds the marker on Button, Card, Alert, Dialog. The footer line now points users at both `/kit-add` and `/kit-add-html`.
  - **Per-component view:** new `HTML output:` line in the example output (`Verified` or `Not yet — React only`) so users running `/kit-list <component>` can see at a glance whether `/kit-add-html` will succeed for that component.
- **`plugins/acss-kit/.claude-plugin/plugin.json`** — version `0.11.0` → `0.11.1`
- **`plugins/acss-kit/CHANGELOG.md`** — new `[0.11.1]` entry under `### Changed`

### What did NOT change

- No script logic
- No generation behavior
- No SCSS or component code
- `acss-utilities` is untouched

### Out of scope (deferred)

- Phase 2.2 (pilot skill troubleshooting + graduation criteria) — also patch-bumps `acss-kit`; ships separately
- Phase 3 (internal consolidation design notes)

## Test plan

- [x] `tests/run.sh` — all 11 steps green
- [x] `plugin.json` version field bumped, `marketplace.json` untouched (per `CLAUDE.md`: omit `version` from marketplace)
- [x] CHANGELOG entry follows the existing Keep-a-Changelog format
- [ ] (manual, post-merge) Run `/kit-list` against a sandbox fixture and confirm `[HTML]` appears

https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `/kit-list` now indicates HTML output availability: category listings append `[HTML]` for Verified components, and single-component views include an explicit "HTML output:" status.

* **Documentation**
  * Command docs, README, and workflow docs updated with guidance on HTML vs React generation, example outputs, read-only inspection behavior, and usage examples.

* **Chores**
  * Plugin version bumped to v0.11.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->