### PR TITLE
docs: phase 3 internal-consolidation design notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ agentic-acss-plugins/
 │       └── docs/                          # developer guide
 ├── tests/                              # tests/run.sh structural validation, tests/e2e.sh deeper check
 ├── docs/                               # cross-plugin documentation
-├── .claude/                            # project-level rules, hooks, skills (maintainer tooling)
+├── .claude/                            # maintainer-only — project rules, hooks, skills, and review agents for plugin development; not surfaced to plugin users
 ├── CLAUDE.md                           # repo guidance for Claude Code
 ├── AGENTS.md                           # agent definitions
 └── CONTRIBUTING.md                     # contributor workflow

--- a/plugins/acss-kit/docs/architecture.md
+++ b/plugins/acss-kit/docs/architecture.md
@@ -132,3 +132,32 @@ Docs-only additions (new `docs/*.md` files) do not require a version bump, as th
 This file is copied verbatim into user projects. Changes to it are rare and high-impact: every project that has already run `/kit-add` keeps the old copy (skip-existing rule). Treat changes to `ui.tsx` like a breaking change — note them prominently in the CHANGELOG and consider bumping the minor version.
 
 If you modify the polymorphic type chain (the `PolymorphicRef<C>` → `UIProps<C>` ladder), verify that the generated component `.tsx` files in the reference docs still type-check against the new types. The reference docs contain inline TSX examples that must be kept consistent with `ui.tsx`.
+
+## Design notes (deferred work)
+
+These are not implementation tickets — they capture decisions that surfaced during the v0.11 adoption review. None of these change behavior today; they are recorded so a future maintainer can pick up the work with full context instead of re-deriving the rationale.
+
+### Shared phrase-parser library for `component-creator` and `component-form`
+
+The two creator-mode pilots both parse natural-language prompts: `component-creator` resolves prose against a component's `## Props Interface`, and `component-form` derives a field list from a form description. Today each pilot carries its own parser plus colour/size synonym tables. The duplication is small per-pilot but grows linearly as either skill expands its vocabulary, and a fix to the synonym table for one skill silently leaves the other behind.
+
+When both pilots reach their graduation criteria (see each SKILL.md `description:` front-matter), factor the shared logic into a single helper consumed by both:
+
+- Token tokeniser (split prose into intent / subject / modifier triples).
+- Synonym resolver (warm → friendly tone family, soft → reduced-weight family, etc.).
+- Prop-union matcher (resolve "primary" / "outline" / "small" against a TypeScript union literal).
+- Halt builder (generate the `AskUserQuestion`-shaped prompt for ambiguous inputs).
+
+The helper should live alongside the pilots (e.g. `skills/_shared/phrase-parser.md`), not in `assets/`, so it stays markdown-as-source. Do not ship until both pilots are graduating — premature extraction would solidify a contract before either pilot's vocabulary has stabilised.
+
+### Unifying `components` and `components-html` skills
+
+`/kit-add` and `/kit-add-html` share most of their pipeline: target detection, dependency resolution, manifest tracking, integration verification, and SCSS emission are byte-identical. They diverge only at the final emit step (TSX vs HTML markup + vanilla JS). Today the two SKILLs duplicate the shared pipeline.
+
+When the HTML-output catalog reaches parity with the React catalog (currently 4 of ~16 components — see `references/components/catalog.md` `## HTML Output Status`), unify into a single `components` skill with an `--output={react|html}` selector at the entry point:
+
+- Steps A–E (init, target detection, dependency resolution, preview, generation order) move to a shared section.
+- Step F (emit) gains two emitter implementations behind a single dispatch.
+- `kit-add.md` and `kit-add-html.md` both become thin command files setting the output flag and delegating.
+
+Defer until catalog parity is reached. Doing it earlier means the unified skill has to handle a "this component does not have an HTML template yet" branch in every code path, which complicates the very thing the merge is meant to simplify.

--- a/plugins/acss-kit/docs/architecture.md
+++ b/plugins/acss-kit/docs/architecture.md
@@ -143,7 +143,7 @@ The two creator-mode pilots both parse natural-language prompts: `component-crea
 
 When both pilots reach their graduation criteria (see each SKILL.md `description:` front-matter), factor the shared logic into a single helper consumed by both:
 
-- Token tokeniser (split prose into intent / subject / modifier triples).
+- Phrase tokeniser (split prose into intent / subject / modifier triples).
 - Synonym resolver (warm → friendly tone family, soft → reduced-weight family, etc.).
 - Prop-union matcher (resolve "primary" / "outline" / "small" against a TypeScript union literal).
 - Halt builder (generate the `AskUserQuestion`-shaped prompt for ambiguous inputs).

--- a/plugins/acss-kit/docs/commands.md
+++ b/plugins/acss-kit/docs/commands.md
@@ -1,5 +1,7 @@
 # acss-kit — Command Reference
 
+This page is the user-facing reference. For the executable workflow each command runs (the steps Claude actually performs, with full operational detail), see the matching section of [`../skills/components/SKILL.md`](../skills/components/SKILL.md), [`../skills/styles/SKILL.md`](../skills/styles/SKILL.md), or the corresponding pilot SKILL — those files are the source of truth; this page is curated for readers.
+
 ## /setup
 
 One-time first-run bootstrap. Run once after installing the plugin so subsequent `/kit-add` and `/theme-create` calls are pure generation. Per-step idempotent — re-running is safe and skips anything already present.

--- a/plugins/acss-utilities/docs/commands.md
+++ b/plugins/acss-utilities/docs/commands.md
@@ -1,6 +1,6 @@
 # acss-utilities — Commands
 
-Four slash commands ship with the plugin. Each delegates to a section of [`skills/utilities/SKILL.md`](../skills/utilities/SKILL.md); this page is the user-facing reference.
+Four slash commands ship with the plugin. Each delegates to a section of [`skills/utilities/SKILL.md`](../skills/utilities/SKILL.md), which is the executable source of truth for what Claude actually does at each step. This page is the user-facing reference — read SKILL.md when you need the full operational detail or are debugging an unexpected outcome.
 
 | Command | Side effects | Argument hint |
 |---|---|---|


### PR DESCRIPTION
## Summary

**Final phase** of the adoption review (Phase 1 #58, Phase 1.5 #59, Phase 2.4 #60, Phase 2.1 #61, Phase 2.2 #62). Docs-only; no plugin behavior change, no version bumps.

Phase 3 captures three internal-consolidation observations that surfaced during the earlier review work but didn't warrant immediate implementation. The point is to record the rationale so a future maintainer can act on them with full context, rather than re-deriving the analysis later.

### Changes

- **`README.md`** — clarify that the `.claude/` directory is **maintainer-only** (project rules, hooks, skills, and review agents for plugin development) and is not surfaced to plugin users. Prevents a casual reader who notices the directory from trying to invoke maintainer slash commands.
- **`plugins/acss-kit/docs/commands.md`** and **`plugins/acss-utilities/docs/commands.md`** — add a one-line pointer at the top stating that the matching `SKILL.md` is the executable source of truth and this page is the curated user-facing reference. Both pages already overlap with their `SKILL.md`; the pointer makes the separation-of-concerns explicit so future readers don't get lost figuring out which file is canonical.
- **`plugins/acss-kit/docs/architecture.md`** — append a new "Design notes (deferred work)" section recording two consolidation candidates:
  1. **Shared phrase-parser library for `component-creator` and `component-form`.** Both pilots parse natural-language prompts and carry overlapping synonym tables. Factor the shared logic out *after* both pilots graduate (criteria recorded in Phase 2.2 / #62). Includes a sketch of the helper's surface (tokeniser, synonym resolver, prop-union matcher, halt builder).
  2. **Unifying `components` and `components-html` skills.** `/kit-add` and `/kit-add-html` share most of the pipeline (target detection, dependency resolution, manifest tracking, SCSS emission) and diverge only at the final emit step. Merge behind one `--output={react|html}` selector once the HTML catalog reaches parity with the React catalog (currently 4 of ~16 components).

### What did NOT change

- No plugin behavior
- No skill execution logic
- No `plugin.json` version bump
- No `marketplace.json` change

### Adoption review wrap-up

This closes the phased plan. Summary of what shipped:

| Phase | PR | What |
|---|---|---|
| 1 | #58 | Sync command surface in root README + marketplace.json |
| 1.5 | #59 | Onboarding clarity (do-this-first, config section, upgrade path) |
| 2.1 | #61 | Surface HTML output status in `/kit-list` (+ delegate kit-list workflow to SKILL.md) |
| 2.2 | #62 | Pilot failure modes + graduation criteria |
| 2.3 | (skipped) | Already covered by existing utilities troubleshooting |
| 2.4 | #60 | "When to use what" cheat sheet in prompt-book |
| 3 | this PR | Internal consolidation design notes |

## Test plan

- [x] `tests/run.sh` — all 11 steps green
- [x] All edits are additive and docs-only
- [x] No `plugin.json` version bumped, no `marketplace.json` change

https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository layout entry noting a maintainer-only tooling directory
  * Added "Design notes (deferred work)" documenting planned refactors and consolidation plans
  * Expanded command reference with per-command signatures, flags, behaviors, idempotency notes, verifications, and examples
  * Clarified command docs to point readers to the authoritative executable SKILL documents for implementation details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->