### PR TITLE
docs(acss-kit): add v0.10→v0.11 foundation.css note to Migration section

### DIFF
--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -48,6 +48,10 @@ If you have any of the old plugins installed:
 
 Existing `.acss-target.json` files at project roots remain compatible — `/kit-add` reads the same shape.
 
+### Upgrading from 0.10.x → 0.11.x
+
+`acss-kit@0.11.0` added a vendored `foundation.css` (CSS reset, base typography, `@layer` cascade ordering). On the next `/kit-add` run in an existing project — where `ui.tsx` is present but `foundation.css` is absent — the skill prompts before copying it in alongside the SCSS source tree, so projects that intentionally avoid the foundation layer can opt out. Greenfield projects (`/setup` followed by `/kit-add`) get it automatically. See [`assets/foundation/SOURCE.md`](assets/foundation/SOURCE.md) for the upstream pin and the four documented patches (P1–P4).
+
 ## Prerequisites
 
 - React + TypeScript project

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -50,7 +50,7 @@ Existing `.acss-target.json` files at project roots remain compatible — `/kit-
 
 ### Upgrading from 0.10.x → 0.11.x
 
-`acss-kit@0.11.0` added a vendored `foundation.css` (CSS reset, base typography, `@layer` cascade ordering). On the next `/kit-add` run in an existing project — where `ui.tsx` is present but `foundation.css` is absent — the skill prompts before copying it in alongside the SCSS source tree, so projects that intentionally avoid the foundation layer can opt out. Greenfield projects (`/setup` followed by `/kit-add`) get it automatically. See [`assets/foundation/SOURCE.md`](assets/foundation/SOURCE.md) for the upstream pin and the four documented patches (P1–P4).
+`acss-kit@0.11.0` added a vendored `foundation.css` (CSS reset, base typography, `@layer` cascade ordering). On the next `/kit-add` run in an existing project — where `ui.tsx` is present but `foundation.css` is absent — the skill prompts before copying it in alongside the SCSS source tree, so projects that intentionally avoid the foundation layer can opt out. See [`assets/foundation/SOURCE.md`](assets/foundation/SOURCE.md) for the upstream pin and the four documented patches (P1–P4).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Tail-end PR closing the last open item in the phased adoption-review plan.

While auditing the merged Phase 1–3 PRs against every atomic item in the plan file, one item from **Phase 1.5.3** was found missing: the plan said to add a v0.10→v0.11 `foundation.css` note to the **Migration section** of `plugins/acss-kit/README.md` so existing-project users aren't surprised by the first-run prompt. The note exists inline in the `/kit-add` flow description (line 112) but never made it into the Migration section, which is where upgraders actually look.

This PR adds an "Upgrading from 0.10.x → 0.11.x" subsection right after the predecessor-plugins migration block.

### Changes

- **`plugins/acss-kit/README.md`** — new "Upgrading from 0.10.x → 0.11.x" subsection naming the `foundation.css` prompt explicitly, the opt-out path, and the link to `assets/foundation/SOURCE.md` for upstream pin + documented patches.

### Audit results — every other plan item shipped

Verified in main:

| Plan item | Status |
|---|---|
| Phase 1.1: 5 missing root-README commands + grouped tables + count fix | ✅ #58 |
| Phase 1.2: marketplace.json acss-kit + acss-utilities descriptions | ✅ #58 |
| Phase 1.5.1: root README Configuration section | ✅ #59 |
| Phase 1.5.2: do-this-first callout + recovery note | ✅ #59 |
| Phase 1.5.3: utilities top-level "Upgrading from 0.1.x" | ✅ #59 |
| Phase 1.5.3: acss-kit Migration foundation.css note | ⚠️ **this PR** |
| Phase 2.1: `/kit-list` HTML status (+ refactor to delegate) | ✅ #61 |
| Phase 2.2: pilot failure modes + graduation criteria | ✅ #62 |
| Phase 2.3 | (skipped — already covered) |
| Phase 2.4: "When to use what" cheat sheet + cross-links | ✅ #60 |
| Phase 3.1: `.claude/` maintainer-only label | ✅ #63 |
| Phase 3.2: canonical-source pointers in commands.md | ✅ #63 |
| Phase 3.3 + 3.4: deferred-work design notes | ✅ #63 |

## Test plan

- [x] `tests/run.sh` — all 11 steps green
- [x] No `plugin.json` version bump (docs-only)
- [x] No `marketplace.json` change

https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8nmqb2yQGLmeKtKgqMnUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guidance for acss-kit 0.11.0 outlining changed foundation CSS handling: existing projects will be prompted before the kit copies foundation assets, while new installs include them automatically; includes references to upstream sourcing and patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->