### PR TITLE
fix(tests): address review comments on serve.sh

### DIFF
--- a/plugins/acss-kit/docs/recipes.md
+++ b/plugins/acss-kit/docs/recipes.md
@@ -208,9 +208,9 @@ An opt-in, static-HTML smoke check that exercises the *compiled CSS and `data-*`
 
    This watches SCSS and HTML files, recompiles CSS on save, and auto-reloads the browser. Prints the serving URL (`http://localhost:7743/` or next available port if 7743 is busy).
 
-3. Open the preview — manually in any browser, or in a Claude Code session via the `claude-in-chrome` MCP (`navigate` then `computer screenshot`):
+3. Open the preview — manually in any browser, or in a Claude Code session via the `claude-in-chrome` MCP (`navigate` then `computer screenshot`). Use the URL printed by `tests/serve.sh` (defaults to port `7743`, auto-increments if busy):
 
-   ```
+   ```text
    http://localhost:7743/<name>-preview.html
    ```
 
@@ -288,9 +288,17 @@ This serves your HTML and CSS statically with no auto-reload. Any change require
     <!-- aria-disabled="true" on default and one or two key variants -->
   </div>
 
-  <!-- Live-reload via esbuild's SSE endpoint (fired by tests/serve.sh). -->
+  <!-- Live-reload via esbuild's SSE endpoint (fired by tests/serve.sh).
+       No-ops gracefully under python3 http.server (no /esbuild endpoint). -->
   <script>
-    new EventSource('/esbuild').addEventListener('change', () => location.reload());
+    (function () {
+      if (typeof EventSource === 'undefined') return;
+      var opened = false;
+      var es = new EventSource('/esbuild');
+      es.addEventListener('open', function () { opened = true; });
+      es.addEventListener('change', function () { location.reload(); });
+      es.addEventListener('error', function () { if (!opened) es.close(); });
+    }());
   </script>
 </body>
 </html>

--- a/tests/README.md
+++ b/tests/README.md
@@ -213,7 +213,7 @@ To use it:
 1. Run the smoke flow above to generate components (e.g. `/kit-add button card`).
 2. Write a preview HTML file (see [Preview a generated component in a browser](../plugins/acss-kit/docs/recipes.md#preview-a-generated-component-in-a-browser)).
 3. Run `tests/serve.sh` from the repo root.
-4. Open `http://localhost:7743/<name>-preview.html` in a browser.
+4. Open the URL printed by `tests/serve.sh` (e.g. `http://localhost:7743/<name>-preview.html`) in a browser.
 5. Edit `src/components/fpkit/<name>/<name>.scss`. On save, the browser reloads with the new styles.
 
 Fallback: if Node is not available, use `python3 -m http.server 7743` from `tests/sandbox/` for a static server without hot-reload (see the recipe for details).

--- a/tests/serve.sh
+++ b/tests/serve.sh
@@ -10,8 +10,12 @@ set -euo pipefail
 #
 # Requirements:
 #   - tests/sandbox/ exists (run `tests/setup.sh` if not)
-#   - npm --prefix tests ci has been run
-#   - Port 7743 is free (or will auto-increment to 7744, etc.)
+#   - npm --prefix tests ci has been run (installs esbuild, sass into tests/node_modules)
+#   - Port 7743 is free (auto-increments to 7744…7753 if busy)
+#
+# Note: SCSS watch paths default to src/components/fpkit and src/styles/theme.
+# If .acss-target.json has set a custom componentsDir, those paths will not be
+# watched. Edit the sass invocation below to match your target directory.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SANDBOX="$REPO_ROOT/tests/sandbox"
@@ -33,30 +37,34 @@ if [[ ! -f "$SANDBOX/package.json" ]]; then
   exit 1
 fi
 
-if ! npm --prefix "$REPO_ROOT/tests" ls esbuild >/dev/null 2>&1 || \
-   ! npm --prefix "$REPO_ROOT/tests" ls sass >/dev/null 2>&1; then
-  echo "Error: esbuild or sass not installed. Run npm --prefix tests ci first." >&2
+if [[ ! -f "$REPO_ROOT/tests/node_modules/.bin/sass" ]] || \
+   [[ ! -f "$REPO_ROOT/tests/node_modules/.bin/esbuild" ]]; then
+  echo "Error: esbuild or sass not installed. Run: npm --prefix tests ci" >&2
   exit 1
 fi
 
-# --- Start watchers ---
+# --- Start SCSS watcher ---
 
 echo "Starting SCSS watcher..."
 
 (
   cd "$SANDBOX"
-  npm --prefix "$REPO_ROOT/tests" run --silent -- exec sass --watch \
+  npm --prefix "$REPO_ROOT/tests" exec -- sass --watch \
     src/components/fpkit:src/components/fpkit \
     src/styles/theme:src/styles/theme \
     --no-source-map 2>&1
 ) &
 SASS_PID=$!
 
-# Trap to kill sass watcher on exit.
+# Trap to kill watchers on exit (updated after ESBUILD_PID is known).
 trap "kill '$SASS_PID' 2>/dev/null; wait '$SASS_PID' 2>/dev/null || true" EXIT INT TERM
 
-# Give sass a moment to start watching.
+# Verify sass actually started.
 sleep 1
+if ! kill -0 "$SASS_PID" 2>/dev/null; then
+  echo "Error: SCSS watcher exited immediately. Check that src/ directories exist in tests/sandbox/." >&2
+  exit 1
+fi
 
 # --- Auto-generate index.html ---
 
@@ -69,6 +77,29 @@ generate_index() {
   done < <(find "$SANDBOX" -maxdepth 1 -name "*-preview.html" -type f | sort)
 
   if [[ ${#previews[@]} -eq 0 ]]; then
+    cat > "$index_file" <<'EOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>acss-kit Sandbox — Preview Index</title>
+  <style>
+    body { font-family: system-ui, sans-serif; background: #f8f9fa; color: #1a1a1a; padding: 2rem; margin: 0; }
+    h1 { font-size: 1.25rem; color: #444; font-weight: 500; }
+    p { color: #888; }
+    code { background: #e5e7eb; padding: 0.1em 0.4em; border-radius: 3px; font-size: 0.875em; }
+  </style>
+</head>
+<body>
+  <h1>acss-kit Sandbox — Component Previews</h1>
+  <p>No <code>*-preview.html</code> files found yet.</p>
+  <p>Generate a component with <code>/kit-add button</code>, then write a preview file using the template in
+  <a href="../plugins/acss-kit/docs/recipes.md">recipes.md</a>.</p>
+</body>
+</html>
+EOF
+    echo "Generated $index_file (no previews found)"
     return
   fi
 
@@ -107,7 +138,8 @@ generate_index() {
 EOF
 
   for file in "${previews[@]}"; do
-    local name=$(basename "$file" -preview.html)
+    local name
+    name=$(basename "$file" -preview.html)
     echo "    <li><a href=\"$(basename "$file")\">$name</a></li>" >> "$index_file"
   done
 
@@ -118,8 +150,16 @@ EOF
     <p><strong>First-time rendering:</strong> If a preview renders unstyled on first load, save any <code>.scss</code> file to trigger compilation, then refresh the browser.</p>
   </div>
   <script>
-    // Live-reload via esbuild's SSE endpoint.
-    new EventSource('/esbuild').addEventListener('change', () => location.reload());
+    (function () {
+      if (typeof EventSource === 'undefined') return;
+      var opened = false;
+      var es = new EventSource('/esbuild');
+      es.addEventListener('open', function () { opened = true; });
+      es.addEventListener('change', function () { location.reload(); });
+      // Close on first error if the endpoint was never reached — prevents
+      // reconnect spam when this page is served by python3 http.server instead.
+      es.addEventListener('error', function () { if (!opened) es.close(); });
+    }());
   </script>
 </body>
 </html>
@@ -137,12 +177,15 @@ MAX_PORT=7753
 ESBUILD_PID=""
 
 while [[ $PORT -le $MAX_PORT ]]; do
-  npm --prefix "$REPO_ROOT/tests" run --silent -- exec esbuild --servedir="$SANDBOX" --serve="$PORT" >/dev/null 2>&1 &
+  npm --prefix "$REPO_ROOT/tests" exec -- esbuild --servedir="$SANDBOX" --serve="$PORT" >/dev/null 2>&1 &
   ESBUILD_PID=$!
   sleep 0.5
   if kill -0 "$ESBUILD_PID" 2>/dev/null; then
     break
   fi
+  # Clean up the failed process before retrying.
+  wait "$ESBUILD_PID" 2>/dev/null || true
+  ESBUILD_PID=""
   PORT=$((PORT + 1))
 done
 
@@ -151,11 +194,13 @@ if [[ -z "$ESBUILD_PID" ]] || [[ $PORT -gt $MAX_PORT ]]; then
   exit 1
 fi
 
+# Re-register trap now that ESBUILD_PID is known.
 trap "kill '$ESBUILD_PID' 2>/dev/null; wait '$ESBUILD_PID' 2>/dev/null || true; kill '$SASS_PID' 2>/dev/null; wait '$SASS_PID' 2>/dev/null || true" EXIT INT TERM
 
 echo ""
 echo "════════════════════════════════════════════════════════════════"
-echo "Serving http://localhost:$PORT/ (index: http://localhost:$PORT/index.html)"
+echo "Serving http://localhost:$PORT/"
+echo "Index:   http://localhost:$PORT/index.html"
 echo "════════════════════════════════════════════════════════════════"
 echo ""
 echo "SCSS and HTML changes auto-reload. Press Ctrl+C to stop."


### PR DESCRIPTION
## Summary

Follow-up to #66 addressing Copilot and CodeRabbit review comments that were identified after the initial PR merged.

## Fixes

- **Critical:** Replace `npm run --silent -- exec sass/esbuild` with `npm exec -- sass/esbuild` — the original invocation treated `exec` as an npm script name (which doesn't exist in `tests/package.json`), causing both watchers to silently fail
- **Process hygiene:** Clean up failed esbuild PIDs in the port-retry loop before incrementing to prevent zombie process accumulation
- **Watcher health check:** Verify the sass watcher is still alive after startup; exit with a clear error if it dies immediately (e.g. missing watch paths)
- **Stale index:** `generate_index` now writes a "no previews" placeholder page when no `*-preview.html` files exist, instead of returning early and leaving a stale index from a previous run
- **EventSource guard:** Wrap the SSE reload script in a guard that closes the connection on first error if it was never opened — silences reconnect spam when the page is served by `python3 http.server` (no `/esbuild` endpoint)
- **MD040:** Add `text` language tag to bare fenced code block in `recipes.md`
- **Hard-coded port:** README now says "use the URL printed by `tests/serve.sh`" instead of hard-coding `7743`

## Test Plan

- [x] `tests/run.sh` passes
- [x] Bash syntax check passes
- [x] `npm exec -- sass` verified as correct invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Refined browser preview instructions with clearer setup guidance
  * Updated test server documentation with improved path examples

* **Tests**
  * Added stricter dependency verification for test server startup
  * Enhanced live-reload functionality with improved error handling and connection stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->