### PR TITLE
feat(style-agent): add /inline-style-to-class skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,12 +29,13 @@
     {
       "name": "style-agent",
       "source": "./plugins/style-agent",
-      "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow. Run /css-to-class to extract a list of utility classes from an HTML element or class string into a single named CSS class, with declarations resolved from your project's own CSS files.",
+      "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow. Run /css-to-class to extract a list of utility classes from an HTML element or class string into a single named CSS class, with declarations resolved from your project's own CSS files. Run /inline-style-to-class to convert inline style attributes, JSX style objects, or <style> blocks into named CSS classes appended to your project stylesheet.",
       "category": "development",
       "tags": [
         "css",
         "utilities",
         "class-extraction",
+        "inline-styles",
         "framework-agnostic",
         "scss",
         "tailwind",

--- a/docs/plans/style-agent-inline-style-to-class-skill.md
+++ b/docs/plans/style-agent-inline-style-to-class-skill.md
@@ -1,0 +1,124 @@
+# Add `/inline-style-to-class` skill to `style-agent` plugin
+
+## Context
+
+The `style-agent` plugin currently ships a single skill, `/css-to-class`, which extracts a list of utility class tokens from a `class` attribute into a single semantically-named CSS class. Authors working in the opposite direction — a codebase peppered with inline `style=""` attributes, JSX `style={{ ... }}` objects, or ad-hoc `<style>` blocks — have no symmetric tool to migrate those declarations into a reusable class. This plan adds `inline-style-to-class` as a sibling skill that converts inline style declarations into a named CSS class, **emits the result to chat, and appends it to a project stylesheet** detected from existing project conventions.
+
+The skill mirrors `css-to-class`'s shape (single-file SKILL.md, no scripts, no references, delegating command) so maintenance stays uniform across the plugin.
+
+## Objective
+
+Ship a new sibling skill + command in `plugins/style-agent/`, named `inline-style-to-class`, that:
+
+1. Accepts three input forms: inline HTML/JSX `style="..."` attributes, JSX `style={{ ... }}` objects, and `<style>...</style>` tag block contents.
+2. Normalises declarations to kebab-case CSS, with no project-CSS discovery (declarations come from the input verbatim).
+3. Emits the new CSS class block + refactored source to chat **and** appends the class block to a project stylesheet whose location and syntax (`.css` / `.scss` / Sass-indented) are auto-detected; asks if ambiguous.
+4. Reuses the sibling's name rules (max 20 chars, kebab-case, sanitisation pipeline, `AskUserQuestion` fallback).
+
+## Files to create
+
+| Path | Purpose |
+|---|---|
+| `plugins/style-agent/skills/inline-style-to-class/SKILL.md` | All skill logic — front-matter + 7-step workflow. |
+| `plugins/style-agent/commands/inline-style-to-class.md` | Thin delegating command body (3–6 lines). |
+
+## Files to edit
+
+| Path | Change |
+|---|---|
+| `plugins/style-agent/.claude-plugin/plugin.json` | Bump `version` (minor: feature addition). |
+| `plugins/style-agent/CHANGELOG.md` | Add entry under `[Unreleased] → Added`. |
+| `plugins/style-agent/README.md` | Add `### /inline-style-to-class [name]` block under `## Commands` with Input/Output examples and Name rules line. |
+| `plugins/style-agent/docs/README.md` | Add row to the Commands table. |
+| `.claude-plugin/marketplace.json` | Append `Run /inline-style-to-class to ...` to the `style-agent` entry's `description`; consider adding `inline-styles` to `tags`. |
+
+No changes to `.claude/settings.json` hooks (existing PostToolUse validators cover the new files automatically).
+
+## Steps
+
+1. **Author `skills/inline-style-to-class/SKILL.md`** with front-matter mirroring the sibling, but with `allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion` (adds `Write, Edit` because this skill saves to a stylesheet — the sibling does not). Body uses 7 numbered workflow steps with bold-lead sentences, identical structure to `css-to-class/SKILL.md`. *Why:* Surface-symmetry across sibling skills makes the plugin easier to maintain and review.
+
+2. **Define input parsing (Workflow step 1).** Three forms:
+   - **HTML/JSX inline attribute** — match `style="..."` or `style='...'`; split on `;`, trim, parse `prop: value` pairs.
+   - **JSX style object** — match `style={{ ... }}`; parse JS object literal; convert camelCase → kebab-case (e.g. `backgroundColor` → `background-color`); preserve string and numeric literals; flag any JS expression value as `/* unresolved: <expr> */`.
+   - **`<style>` block contents** — parse rules; if one rule, take its declarations; if multiple rules, prompt with `AskUserQuestion` (merge all into one class, or pick one rule).
+
+   *Why:* These three forms cover the realistic migration surface; raw CSS-property blocks were intentionally excluded by the user.
+
+3. **Define name rules and auto-name algorithm (Workflow step 2).** Reuse the sibling's 20-char kebab-case constraint and 6-step sanitisation pipeline verbatim. Auto-name source differs (no class tokens to draw from) — derive from element tag plus a salient property:
+   - `<div style="background: ...">` → `div-bg`
+   - `<button style="padding: ...">` → `btn-pad` (well-known tag abbreviations)
+   - JSX object on bare component → first declared property
+   - Fallback: `AskUserQuestion` for the name; default `custom-class`.
+
+   *Why:* Inline styles lack the semantic class-token signal `css-to-class` uses, so the auto-namer must lean on the element + first property; user can always override via the `[name]` argument.
+
+4. **Define stylesheet discovery (Workflow step 3).** Glob common locations in priority order: `src/**/*.{css,scss,sass}`, `styles/**/*.{css,scss,sass}`, `app/**/*.{css,scss,sass}`, then repo-root `*.{css,scss,sass}`. Detect:
+   - **Syntax flavor** from the file extension.
+   - **Indentation** from the first non-empty rule body (count leading whitespace).
+   - **Trailing newline** on the file.
+
+   If a single candidate clearly dominates (e.g. one `globals.css`), use it. If multiple candidates of similar standing exist, prompt with `AskUserQuestion` to pick. *Why:* The user explicitly asked for "based on project patterns" — auto-detect first, ask only when ambiguous.
+
+5. **Define CSS class block emission (Workflow step 4).** Mirror the sibling's output shape:
+   - Comment header: `/* extracted-from: <element snippet or "style block"> */`
+   - Properties one per line, kebab-case, preserve units and `var(...)` references verbatim.
+   - Unresolved JSX expressions become `/* <camelCase>: add value manually — was JSX expression */` placeholders.
+   - For Sass-indented syntax, emit without braces and with the detected indent.
+
+6. **Define stylesheet append (Workflow step 5).** Use `Edit` to append the new class block to the chosen stylesheet — preserve any trailing newline, use the detected indentation, separate from prior content with one blank line. *Why:* `Edit`-based append preserves byte-exact existing content; `Write` would risk overwriting.
+
+7. **Define refactored source emission (Workflow step 6).** Strip the migrated declarations from the source:
+   - Inline `style="..."` → remove the attribute entirely if all declarations migrated; otherwise keep only the unmigrated subset.
+   - JSX `style={{ ... }}` → same logic, JS-side.
+   - `<style>` block → emit a note that the rule was moved; do not auto-rewrite the block (out of scope).
+   - Add the new class to the existing `class` / `className` attribute (don't overwrite). Preserve all other attributes (`data-*`, `id`, `aria-*`, etc.) — same preservation rule as the sibling.
+
+8. **Define summary output (Workflow step 7).** Print: chosen name, target stylesheet path, declarations migrated count, unresolved-expression count, any coercion warnings (camelCase→kebab, numeric→px). Match the sibling's summary format.
+
+9. **Author `commands/inline-style-to-class.md`** — 4-line delegating body identical in shape to `commands/css-to-class.md`:
+   ```
+   description: Convert an inline style attribute, JSX style object, or <style> block into a named CSS class and append it to the project stylesheet
+   argument-hint: [name]
+   allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
+   ```
+   Body: one-sentence purpose, then `Follow ${CLAUDE_PLUGIN_ROOT}/skills/inline-style-to-class/SKILL.md.`, then the standard delegation line.
+
+10. **Bump `plugin.json` version** — minor bump (feature addition; no breaking change). Confirm `marketplace.json` entry has no `version` field per repo convention.
+
+11. **Update CHANGELOG, README, docs/README, marketplace description** in a single pass per the sibling's existing patterns (entries already documented in the briefing). Append `Run /inline-style-to-class to migrate inline styles into named classes.` to the marketplace description.
+
+## Critical files to read before implementing
+
+- `plugins/style-agent/skills/css-to-class/SKILL.md` — copy 7-step structure, name rules, sanitisation pipeline.
+- `plugins/style-agent/commands/css-to-class.md` — copy delegating command body shape.
+- `plugins/style-agent/README.md` — copy command-section formatting.
+- `plugins/style-agent/docs/README.md` — copy Commands-table row formatting.
+- `.claude-plugin/marketplace.json` — `style-agent` entry to amend.
+- `.claude/rules/command-authoring.md` — confirm front-matter requirements.
+
+## Verification
+
+1. **Structural validation** — run `tests/run.sh` from repo root; PostToolUse hooks will additionally validate front-matter on every Write/Edit during authoring.
+2. **Manifest sanity** — `cat plugins/style-agent/.claude-plugin/plugin.json | python3 -m json.tool` and `cat .claude-plugin/marketplace.json | python3 -m json.tool` to confirm valid JSON.
+3. **Local install smoke test** — `claude --plugin-dir ./plugins/style-agent` from repo root; confirm `/inline-style-to-class` appears in the slash-command list and its help text matches the command's `description`.
+4. **End-to-end fixture** — in a scratch directory:
+   - Run `/inline-style-to-class hero-bg` against `<div style="background: var(--surface-1); padding: 1rem">Hi</div>` with a `styles/globals.css` present; confirm:
+     - Class `.hero-bg { background: var(--surface-1); padding: 1rem; }` appended to `styles/globals.css`.
+     - Refactored output: `<div class="hero-bg">Hi</div>`.
+     - Summary lists 2 declarations migrated, 0 unresolved.
+   - Repeat with a JSX object: `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` — confirm `backgroundColor` → `background-color`, `8` → `8px` (with coercion warning), `theme.primary` → unresolved placeholder.
+   - Repeat with a `<style>` block containing two rules — confirm `AskUserQuestion` prompts for merge-vs-pick.
+5. **Multi-stylesheet ambiguity** — fixture with both `src/styles/main.scss` and `styles/globals.css`; confirm `AskUserQuestion` prompts to pick.
+6. **Sibling regression** — run `/css-to-class card-base` against a known fixture; confirm unchanged behavior.
+
+## Out of scope (Next Steps)
+
+- Auto-rewriting `<style>` block contents in place (step 7 only emits a note).
+- Coupling to `acss-kit` design tokens (would break framework-agnostic premise — explicitly rejected upstream).
+- A reverse `/class-to-style` (re-inlining a class) — unlikely to be useful but listed for completeness.
+- Python helper script for parsing — not needed; current SKILL.md tooling (Read/Grep/Bash) is sufficient and the sibling has no script either.
+
+## Unresolved Questions
+
+None — user answered all four design questions; no open items.

--- a/docs/plans/style-agent-inline-style-to-class-skill.md
+++ b/docs/plans/style-agent-inline-style-to-class-skill.md
@@ -74,10 +74,10 @@ No changes to `.claude/settings.json` hooks (existing PostToolUse validators cov
    - `<style>` block → emit a note that the rule was moved; do not auto-rewrite the block (out of scope).
    - Add the new class to the existing `class` / `className` attribute (don't overwrite). Preserve all other attributes (`data-*`, `id`, `aria-*`, etc.) — same preservation rule as the sibling.
 
-8. **Define summary output (Workflow step 7).** Print: chosen name, target stylesheet path, declarations migrated count, unresolved-expression count, any coercion warnings (camelCase→kebab, numeric→px). Match the sibling's summary format.
+8. **Define summary output (Workflow step 7).** Print: chosen name, target stylesheet path, declarations migrated count, unresolved-expression count, any coercion warnings (camelCase→kebab; numeric values preserved with `/* verify unit */` comment rather than auto-appending a unit). Match the sibling's summary format.
 
 9. **Author `commands/inline-style-to-class.md`** — 4-line delegating body identical in shape to `commands/css-to-class.md`:
-   ```
+   ```yaml
    description: Convert an inline style attribute, JSX style object, or <style> block into a named CSS class and append it to the project stylesheet
    argument-hint: [name]
    allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
@@ -107,7 +107,7 @@ No changes to `.claude/settings.json` hooks (existing PostToolUse validators cov
      - Class `.hero-bg { background: var(--surface-1); padding: 1rem; }` appended to `styles/globals.css`.
      - Refactored output: `<div class="hero-bg">Hi</div>`.
      - Summary lists 2 declarations migrated, 0 unresolved.
-   - Repeat with a JSX object: `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` — confirm `backgroundColor` → `background-color`, `8` → `8px` (with coercion warning), `theme.primary` → unresolved placeholder.
+   - Repeat with a JSX object: `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` — confirm `backgroundColor` → `background-color`, `8` preserved with `/* verify unit */` comment, `theme.primary` → unresolved placeholder.
    - Repeat with a `<style>` block containing two rules — confirm `AskUserQuestion` prompts for merge-vs-pick.
 5. **Multi-stylesheet ambiguity** — fixture with both `src/styles/main.scss` and `styles/globals.css`; confirm `AskUserQuestion` prompts to pick.
 6. **Sibling regression** — run `/css-to-class card-base` against a known fixture; confirm unchanged behavior.

--- a/plugins/style-agent/.claude-plugin/plugin.json
+++ b/plugins/style-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "style-agent",
   "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/style-agent/CHANGELOG.md
+++ b/plugins/style-agent/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `style-agent` plugin are documented here. Format foll
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-08
+
 ### Added
 - `/inline-style-to-class` — convert an inline style attribute, JSX style object, or `<style>` block into a single named CSS class and append it to the project stylesheet.
 

--- a/plugins/style-agent/CHANGELOG.md
+++ b/plugins/style-agent/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the `style-agent` plugin are documented here. Format foll
 
 ## [Unreleased]
 
+### Added
+- `/inline-style-to-class` — convert an inline style attribute, JSX style object, or `<style>` block into a single named CSS class and append it to the project stylesheet.
+
 ## [0.1.0] - 2026-05-08
 
 ### Added

--- a/plugins/style-agent/README.md
+++ b/plugins/style-agent/README.md
@@ -43,6 +43,36 @@ testimonial flex-grid py-8 items-center
 
 **Name rules** — max 20 characters, kebab-case. Omit `name` to auto-generate from the most semantic tokens in the class list.
 
+### `/inline-style-to-class [name]`
+
+Convert an inline `style` attribute, JSX `style={{ ... }}` object, or `<style>` block into a single, semantically named CSS class and append it to the project stylesheet.
+
+**Input** — paste an HTML element, JSX markup, or a `<style>` block:
+
+```html
+<div style="background: var(--surface-1); padding: 1rem">
+```
+
+```jsx
+<Button style={{ backgroundColor: theme.primary, padding: 8 }}>
+```
+
+**Output** — a ready-to-use CSS class appended to your project stylesheet, plus refactored source:
+
+```css
+/* from: style attr on <div> */
+.div-bg {
+  background: var(--surface-1);
+  padding: 1rem;
+}
+```
+
+```html
+<div class="div-bg">
+```
+
+**Name rules** — max 20 characters, kebab-case. Omit `name` to auto-generate from the element tag and first declared property.
+
 ## Developer guide
 
 See [`docs/README.md`](docs/README.md).

--- a/plugins/style-agent/commands/inline-style-to-class.md
+++ b/plugins/style-agent/commands/inline-style-to-class.md
@@ -1,0 +1,11 @@
+---
+description: Convert an inline style attribute, JSX style object, or <style> block into a named CSS class and append it to the project stylesheet
+argument-hint: [name]
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
+---
+
+Convert an inline `style` attribute, JSX `style` object, or `<style>` block into a single named CSS class appended to the project stylesheet.
+
+Follow `${CLAUDE_PLUGIN_ROOT}/skills/inline-style-to-class/SKILL.md`.
+
+All behavior — argument handling, input parsing, name rules, stylesheet discovery, class emission, file append, HTML/JSX refactoring, and summary output — is defined in the skill file above.

--- a/plugins/style-agent/docs/README.md
+++ b/plugins/style-agent/docs/README.md
@@ -16,10 +16,14 @@
 | Command | What it does |
 |---|---|
 | `/css-to-class [name]` | Extract utility classes from an HTML element or class string into a single named CSS class |
+| `/inline-style-to-class [name]` | Convert an inline style attribute, JSX style object, or `<style>` block into a named CSS class and append it to the project stylesheet |
 
-## Skill
+## Skills
 
-The plugin ships one skill: `skills/css-to-class/SKILL.md`. Command logic delegates to that file.
+The plugin ships two skills. Command logic delegates to each skill file.
+
+- `skills/css-to-class/SKILL.md`
+- `skills/inline-style-to-class/SKILL.md`
 
 ## Adding new skills
 

--- a/plugins/style-agent/skills/inline-style-to-class/SKILL.md
+++ b/plugins/style-agent/skills/inline-style-to-class/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: inline-style-to-class
+description: Convert an inline style attribute, JSX style object, or <style> block into a single named CSS class and append it to the project stylesheet. Detects the target stylesheet from project file conventions — no external processor, no framework assumption. Use when migrating inline styles to reusable, maintainable CSS classes.
+allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
+---
+
+# inline-style-to-class
+
+Convert an inline `style` attribute, JSX `style` object, or `<style>` block into a single, semantically named CSS class. Appends the result to a stylesheet detected from the project's own file conventions — works with plain CSS, SCSS, or Sass-indented syntax. The inverse operation of `/css-to-class`.
+
+---
+
+## Input forms
+
+| Form | Example |
+|---|---|
+| HTML inline attribute | `<div style="background: var(--surface-1); padding: 1rem">` |
+| JSX style object | `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` |
+| `<style>` block | `<style>.hero { color: red; padding: 2rem; }</style>` |
+
+---
+
+## Name rules
+
+- Max **20 characters**, **kebab-case** only (`[a-z][a-z0-9-]*`).
+- If `name` is supplied, apply this sanitisation pipeline in order:
+  1. Lowercase.
+  2. Replace spaces and underscores with `-`.
+  3. Strip any character not in `[a-z0-9-]`.
+  4. Strip leading hyphens and leading digits until the name starts with `[a-z]`.
+  5. Strip trailing hyphens. Collapse consecutive hyphens to one.
+  6. Truncate to 20 chars.
+  If the result is empty after step 6, ask via `AskUserQuestion` for a valid name instead of emitting an invalid identifier. Warn the user whenever any coercion occurred.
+- If `name` is omitted: auto-generate via the algorithm below. When the result is ambiguous or a single token under 4 chars, ask via `AskUserQuestion` with the generated name pre-filled as the suggestion.
+
+### Auto-name algorithm
+
+1. If an element tag is present, derive an abbreviation: `button` → `btn`, `section` → `section`, `header` → `header`, `nav` → `nav`, `ul`/`li` → `list`, `input` → `input`, `img` → `img`, `a` → `link`. All other tags use the tag name verbatim (e.g. `div` → `div`).
+2. From the first declaration in the style source, extract a role hint from the property name:
+   - `background` / `background-color` / `color` → `bg`
+   - `padding` / `padding-*` → `pad`
+   - `margin` / `margin-*` → `gap`
+   - `font-size` / `font-weight` / `font-*` → `type`
+   - `display` / `flex` / `grid` → `layout`
+   - `border` / `border-*` → `border`
+   - `width` / `height` / `min-*` / `max-*` → `size`
+   - `position` / `top` / `left` / `z-index` → `pos`
+   - Any other property — skip the role hint.
+3. Join with `-`: `<tag-abbrev>-<role>`, e.g. `div-bg`, `btn-pad`. If no tag is available, use the role hint alone.
+4. Truncate to 20 chars. Collapse double `-`. Strip leading/trailing `-`.
+5. If the result is empty or ≤ 1 char, use `custom-class` and warn.
+
+---
+
+## Stylesheet discovery
+
+1. Glob for stylesheets in priority order, excluding `**/node_modules/**`, `**/.git/**`, `**/dist/**`, `**/build/**`:
+   - `src/**/*.{css,scss,sass}`
+   - `styles/**/*.{css,scss,sass}`
+   - `app/**/*.{css,scss,sass}`
+   - `*.{css,scss,sass}` (repo root)
+2. From the matching files, detect:
+   - **Syntax flavor** — by extension (`.css`, `.scss`, `.sass`).
+   - **Indentation** — read the first non-empty rule body; count leading whitespace characters.
+   - **Trailing newline** — note whether the file ends with `\n`.
+3. Selection: if exactly one candidate exists, use it. If multiple candidates exist and one is a clear entry file (named `globals`, `main`, `index`, `styles`, `app`, or `base`), use that one. Otherwise prompt with `AskUserQuestion` to pick.
+4. If no stylesheet is found, emit the CSS block to chat only and note that no target file was detected; invite the user to paste it manually.
+
+---
+
+## Workflow
+
+1. **Parse input.** Detect the form of the input:
+   - **HTML inline attribute** — match `style="..."` or `style='...'`; split on `;`; trim; parse `property: value` pairs. Extract the surrounding element tag if present.
+   - **JSX style object** — match `style={{...}}`; extract the object literal body; split key/value pairs. Convert each camelCase key to kebab-case (insert `-` before each uppercase letter, then lowercase the whole key). For numeric literal values, emit a coercion warning: "numeric value — verify unit". For any value that is a JS expression (not a string or number literal), emit a `/* unresolved: <expr> */` placeholder.
+   - **`<style>` block** — extract content between `<style>` and `</style>`; parse rules. If one rule, use its declarations. If multiple rules, ask via `AskUserQuestion`: merge all declarations or pick a specific rule.
+
+2. **Determine the class name.** Apply the Name rules above. Use the `[name]` argument if provided. Otherwise apply the auto-name algorithm. If the generated name is ambiguous or ≤ 3 chars, ask via `AskUserQuestion` with the suggestion pre-filled.
+
+3. **Discover the target stylesheet.** Follow the Stylesheet discovery section. Confirm the chosen file with the user only when the choice is ambiguous.
+
+4. **Build the CSS class block.** Emit using the detected syntax flavor and indentation:
+   - Comment header: `/* from: <source summary — e.g. "style attr on <div>", "JSX style object", or "<style> block" */ `.
+   - One property per line.
+   - Unresolved JSX expressions: `/* <property>: unresolved — was JS expression */`.
+   - Numeric values (no unit): preserve value and append `/* verify unit */` inline comment.
+   - For Sass-indented (`.sass`) syntax, omit braces and use the detected indentation.
+
+5. **Append to the target stylesheet.** Use `Edit` to append the class block, preceded by one blank line. Preserve any trailing newline the file already had.
+
+6. **Emit refactored source.** Produce a clean version of the original input with the inline style removed:
+   - **HTML** — remove the `style="..."` attribute entirely if all declarations migrated; if some were unresolved, keep only unmigrated declarations in the attribute. Add the new class to any existing `class` attribute (append to the list); if none exists, add `class="<name>"`. Preserve all other attributes unchanged (`data-*`, `id`, `aria-*`).
+   - **JSX** — same logic using `className`. For partially-migrated objects, preserve remaining key/value pairs in the style prop.
+   - **`<style>` block** — emit a comment noting the rule was extracted: `/* rule moved to .<name> in <stylesheet path> */`; do not rewrite the `<style>` block automatically.
+
+7. **Print a summary:**
+   - Class name chosen, whether it was provided or auto-generated, and any coercion warnings.
+   - Target stylesheet path and confirmation that the class was appended (or a note if no file was found).
+   - Number of declarations migrated.
+   - Number of unresolved JS expressions (if any).
+   - Numeric-value unit warnings (if any).

--- a/plugins/style-agent/skills/inline-style-to-class/SKILL.md
+++ b/plugins/style-agent/skills/inline-style-to-class/SKILL.md
@@ -31,7 +31,7 @@ Convert an inline `style` attribute, JSX `style` object, or `<style>` block into
   5. Strip trailing hyphens. Collapse consecutive hyphens to one.
   6. Truncate to 20 chars.
   If the result is empty after step 6, ask via `AskUserQuestion` for a valid name instead of emitting an invalid identifier. Warn the user whenever any coercion occurred.
-- If `name` is omitted: auto-generate via the algorithm below. When the result is ambiguous or a single token under 4 chars, ask via `AskUserQuestion` with the generated name pre-filled as the suggestion.
+- If `name` is omitted: auto-generate via the algorithm below. When the result is ambiguous or ≤ 3 chars, ask via `AskUserQuestion` with the generated name pre-filled as the suggestion.
 
 ### Auto-name algorithm
 
@@ -48,7 +48,7 @@ Convert an inline `style` attribute, JSX `style` object, or `<style>` block into
    - Any other property — skip the role hint.
 3. Join with `-`: `<tag-abbrev>-<role>`, e.g. `div-bg`, `btn-pad`. If no tag is available, use the role hint alone.
 4. Truncate to 20 chars. Collapse double `-`. Strip leading/trailing `-`.
-5. If the result is empty or ≤ 1 char, use `custom-class` and warn.
+5. If the result is empty, use `custom-class` and warn. If the result is 1–3 chars, ask via `AskUserQuestion` with the suggestion pre-filled.
 
 ---
 
@@ -80,7 +80,7 @@ Convert an inline `style` attribute, JSX `style` object, or `<style>` block into
 3. **Discover the target stylesheet.** Follow the Stylesheet discovery section. Confirm the chosen file with the user only when the choice is ambiguous.
 
 4. **Build the CSS class block.** Emit using the detected syntax flavor and indentation:
-   - Comment header: `/* from: <source summary — e.g. "style attr on <div>", "JSX style object", or "<style> block" */ `.
+   - Comment header: `/* from: <source summary — e.g. "style attr on <div>", "JSX style object", or "<style> block" */`.
    - One property per line.
    - Unresolved JSX expressions: `/* <property>: unresolved — was JS expression */`.
    - Numeric values (no unit): preserve value and append `/* verify unit */` inline comment.


### PR DESCRIPTION
## Summary
- Adds `inline-style-to-class` as a sibling skill to `css-to-class` in the `style-agent` plugin
- Converts inline `style` attributes, JSX `style={{ ... }}` objects, and `<style>` blocks into a single named CSS class
- Auto-detects the target project stylesheet (CSS/SCSS/Sass) and appends the new class in place

## Changes
New skill mirrors the `css-to-class` SKILL.md structure (7-step workflow, same name rules and sanitisation pipeline) with two deliberate differences: declarations come verbatim from the input rather than being resolved by grepping project CSS files, and `Write`/`Edit` are added to `allowed-tools` so the skill can append to the detected stylesheet. Auto-name algorithm derives from element tag + role hint from the first declared property (e.g. `div-bg`, `btn-pad`) since there are no class tokens to extract semantic meaning from. Bumps `style-agent` to `0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `/inline-style-to-class` command to convert inline styles (HTML `style` attributes, JSX style objects, or `<style>` blocks) into named CSS classes appended to the project stylesheet.

* **Documentation**
  * Added detailed skill plan, command docs, README updates, and changelog entry; expanded marketplace description and added `inline-styles` tag.

* **Chores**
  * Bumped plugin version to 0.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->