### PR TITLE
chore: raise skillListingBudgetFraction to 0.05 and optimize add-command description

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "skillListingBudgetFraction": 0.05,
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-command
-description: Scaffold a new slash command for a plugin — creates the command .md with front-matter and adds a stub section to SKILL.md.
+description: Use when the user asks to add or scaffold a new slash command for a plugin — creates the command .md with front-matter and a SKILL.md stub.
 disable-model-invocation: false
 ---
 

--- a/docs/plans/raise-skilllistingbudgetfraction-current-jiggly-pie.md
+++ b/docs/plans/raise-skilllistingbudgetfraction-current-jiggly-pie.md
@@ -1,0 +1,68 @@
+# Raise `skillListingBudgetFraction` to 0.05 (project settings)
+
+## Context
+
+Claude Code's default `skillListingBudgetFraction` is `0.01` — about 1% of the model's context window (~8K chars on a 200K-token window) is reserved for the per-turn listing of every installed skill's `description:` frontmatter. This repo's environment has ~193 SKILL.md files installed (184 cached plugin skills + 9 user skills), which leaves only ~41 chars per skill before descriptions start being truncated or dropped entirely.
+
+When a skill description is truncated, the activation triggers ("Use when…", capability verbs) get cut, which in turn causes Claude to miss skill matches that should fire. The Claude Code binary (v2.1.138) emits a runtime warning recommending `/skills` to disable some, **or raise `skillListingBudgetFraction`** — the user is acting on that hint.
+
+The setting is currently absent from every settings file in scope:
+
+<ul>
+<li><code>/Users/shawnsandy/.claude/settings.json</code> (global user)</li>
+<li><code>/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> (this project)</li>
+<li><code>/Users/shawnsandy/devbox/acss-plugins/.claude/settings.local.json</code> (project local)</li>
+</ul>
+
+So the 1% the user references is the binary's built-in default, not an explicit configuration.
+
+## Objective
+
+Add a top-level `"skillListingBudgetFraction": 0.05` key to the project's `.claude/settings.json` so that — when working in `acss-plugins` — Claude Code allocates ~5% of the context window (~40K chars) to skill listings. At ~193 installed skills, this yields ~207 chars per skill: enough headroom for the 160-char description target the `optimizing-descriptions` skill pursues, plus room for future skill installs. Cost: ~8K extra prompt-cache prefix tokens per session.
+
+## Files to modify
+
+<ul>
+<li><a href="../../.claude/settings.json">/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</a> — add one top-level key alongside the existing <code>hooks</code> block.</li>
+</ul>
+
+## Steps
+
+<ol>
+<li>
+<strong>Add the <code>skillListingBudgetFraction</code> key to <code>.claude/settings.json</code>.</strong>
+Insert <code>"skillListingBudgetFraction": 0.05</code> as a new top-level sibling of the existing <code>"hooks"</code> object (insert before <code>hooks</code> for readability — top-level scalar settings before the larger hooks block).
+<ul>
+  <li><em>Why:</em> placing it at the top level (not nested) is what Claude Code's settings loader reads. <code>0.05</code> raises the per-turn skill-listing budget from ~8K to ~40K chars, comfortably fitting all ~193 installed skills' descriptions at the 160-char target.</li>
+  <li><em>Verify:</em> run <code>jq '.skillListingBudgetFraction' /Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> and confirm the output is exactly <code>0.05</code> (not <code>null</code>, not a string).</li>
+</ul>
+</li>
+
+<li>
+<strong>Confirm the file is still valid JSON and the existing <code>hooks</code> block is intact.</strong>
+The PostToolUse JSON-validation hook on this very file (lines 27–36 of the current file) will run automatically on save; no separate command needed, but cross-check manually.
+<ul>
+  <li><em>Why:</em> a typo (trailing comma, mismatched brace) would silently disable every hook in the project — the branch-guard PreToolUse hook is what blocks commits to <code>main</code>, and losing it is a real-world risk.</li>
+  <li><em>Verify:</em> run <code>python3 -c "import json; d=json.load(open('/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json')); print(sorted(d.keys())); print(len(d['hooks']['PostToolUse']), 'PostToolUse hooks'); print(len(d['hooks']['PreToolUse']), 'PreToolUse hook(s)')"</code> and confirm: keys include both <code>hooks</code> and <code>skillListingBudgetFraction</code>, PostToolUse count is <code>6</code>, PreToolUse count is <code>1</code>.</li>
+</ul>
+</li>
+</ol>
+
+## Verification
+
+End-to-end confirmation that the change took effect:
+
+<ul>
+<li><strong>File-level:</strong> <code>jq '{skillListingBudgetFraction, hookCount: (.hooks.PostToolUse | length)}' /Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> returns <code>{"skillListingBudgetFraction": 0.05, "hookCount": 6}</code>.</li>
+<li><strong>Runtime:</strong> in a fresh Claude Code session opened in <code>/Users/shawnsandy/devbox/acss-plugins</code>, run <code>/doctor</code> and confirm no skill-listing-truncation warnings are present (the warning that prompted this change should be gone).</li>
+<li><strong>Spot-check skill activation:</strong> ask Claude something that should trigger a skill whose description sits in the 150–200 char range (e.g. <code>skill-reviewer:optimizing-descriptions</code>, whose description starts with "Rewrites <code>description:</code> frontmatter…" — this skill activated correctly in this session, but its full trigger text was previously vulnerable to truncation). Confirm the skill is offered/runs without needing to be invoked by full slug.</li>
+<li><strong>No regressions:</strong> attempt a <code>git commit</code> on a non-<code>main</code> feature branch — the PreToolUse branch-guard hook should still allow it. Attempt a <code>git commit</code> while on <code>main</code> — it should still be blocked.</li>
+</ul>
+
+## Next steps (out of scope)
+
+<ul>
+<li>If <code>/doctor</code> still shows truncation in this session despite the new setting, consider raising further to <code>0.07</code> or running the <code>skill-reviewer:optimizing-descriptions</code> skill across installed plugins to shorten descriptions.</li>
+<li>Mirror this setting into <code>~/.claude/settings.json</code> (global user) so other projects on this machine benefit — currently scoped only to <code>acss-plugins</code> per the user's choice.</li>
+<li>Document the chosen value and its rationale in the project's <code>CLAUDE.md</code> if other contributors are expected to inherit this configuration.</li>
+</ul>

--- a/docs/plans/raise-skilllistingbudgetfraction-current-jiggly-pie.md
+++ b/docs/plans/raise-skilllistingbudgetfraction-current-jiggly-pie.md
@@ -9,9 +9,9 @@ When a skill description is truncated, the activation triggers ("Use when…", c
 The setting is currently absent from every settings file in scope:
 
 <ul>
-<li><code>/Users/shawnsandy/.claude/settings.json</code> (global user)</li>
-<li><code>/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> (this project)</li>
-<li><code>/Users/shawnsandy/devbox/acss-plugins/.claude/settings.local.json</code> (project local)</li>
+<li><code>~/.claude/settings.json</code> (global user)</li>
+<li><code>.claude/settings.json</code> (this project)</li>
+<li><code>.claude/settings.local.json</code> (project local)</li>
 </ul>
 
 So the 1% the user references is the binary's built-in default, not an explicit configuration.
@@ -23,7 +23,7 @@ Add a top-level `"skillListingBudgetFraction": 0.05` key to the project's `.clau
 ## Files to modify
 
 <ul>
-<li><a href="../../.claude/settings.json">/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</a> — add one top-level key alongside the existing <code>hooks</code> block.</li>
+<li><a href="../../.claude/settings.json">.claude/settings.json</a> — add one top-level key alongside the existing <code>hooks</code> block.</li>
 </ul>
 
 ## Steps
@@ -34,7 +34,7 @@ Add a top-level `"skillListingBudgetFraction": 0.05` key to the project's `.clau
 Insert <code>"skillListingBudgetFraction": 0.05</code> as a new top-level sibling of the existing <code>"hooks"</code> object (insert before <code>hooks</code> for readability — top-level scalar settings before the larger hooks block).
 <ul>
   <li><em>Why:</em> placing it at the top level (not nested) is what Claude Code's settings loader reads. <code>0.05</code> raises the per-turn skill-listing budget from ~8K to ~40K chars, comfortably fitting all ~193 installed skills' descriptions at the 160-char target.</li>
-  <li><em>Verify:</em> run <code>jq '.skillListingBudgetFraction' /Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> and confirm the output is exactly <code>0.05</code> (not <code>null</code>, not a string).</li>
+  <li><em>Verify:</em> run <code>jq '.skillListingBudgetFraction' .claude/settings.json</code> and confirm the output is exactly <code>0.05</code> (not <code>null</code>, not a string).</li>
 </ul>
 </li>
 
@@ -43,7 +43,7 @@ Insert <code>"skillListingBudgetFraction": 0.05</code> as a new top-level siblin
 The PostToolUse JSON-validation hook on this very file (lines 27–36 of the current file) will run automatically on save; no separate command needed, but cross-check manually.
 <ul>
   <li><em>Why:</em> a typo (trailing comma, mismatched brace) would silently disable every hook in the project — the branch-guard PreToolUse hook is what blocks commits to <code>main</code>, and losing it is a real-world risk.</li>
-  <li><em>Verify:</em> run <code>python3 -c "import json; d=json.load(open('/Users/shawnsandy/devbox/acss-plugins/.claude/settings.json')); print(sorted(d.keys())); print(len(d['hooks']['PostToolUse']), 'PostToolUse hooks'); print(len(d['hooks']['PreToolUse']), 'PreToolUse hook(s)')"</code> and confirm: keys include both <code>hooks</code> and <code>skillListingBudgetFraction</code>, PostToolUse count is <code>6</code>, PreToolUse count is <code>1</code>.</li>
+  <li><em>Verify:</em> run <code>python3 -c "import json; d=json.load(open('.claude/settings.json')); print(sorted(d.keys())); print(len(d['hooks']['PostToolUse']), 'PostToolUse hooks'); print(len(d['hooks']['PreToolUse']), 'PreToolUse hook(s)')"</code> and confirm: keys include both <code>hooks</code> and <code>skillListingBudgetFraction</code>, PostToolUse count is <code>6</code>, PreToolUse count is <code>1</code>.</li>
 </ul>
 </li>
 </ol>
@@ -53,8 +53,8 @@ The PostToolUse JSON-validation hook on this very file (lines 27–36 of the cur
 End-to-end confirmation that the change took effect:
 
 <ul>
-<li><strong>File-level:</strong> <code>jq '{skillListingBudgetFraction, hookCount: (.hooks.PostToolUse | length)}' /Users/shawnsandy/devbox/acss-plugins/.claude/settings.json</code> returns <code>{"skillListingBudgetFraction": 0.05, "hookCount": 6}</code>.</li>
-<li><strong>Runtime:</strong> in a fresh Claude Code session opened in <code>/Users/shawnsandy/devbox/acss-plugins</code>, run <code>/doctor</code> and confirm no skill-listing-truncation warnings are present (the warning that prompted this change should be gone).</li>
+<li><strong>File-level:</strong> <code>jq '{skillListingBudgetFraction, hookCount: (.hooks.PostToolUse | length)}' .claude/settings.json</code> returns <code>{"skillListingBudgetFraction": 0.05, "hookCount": 6}</code>.</li>
+<li><strong>Runtime:</strong> in a fresh Claude Code session opened in <code>$(pwd)</code>, run <code>/doctor</code> and confirm no skill-listing-truncation warnings are present (the warning that prompted this change should be gone).</li>
 <li><strong>Spot-check skill activation:</strong> ask Claude something that should trigger a skill whose description sits in the 150–200 char range (e.g. <code>skill-reviewer:optimizing-descriptions</code>, whose description starts with "Rewrites <code>description:</code> frontmatter…" — this skill activated correctly in this session, but its full trigger text was previously vulnerable to truncation). Confirm the skill is offered/runs without needing to be invoked by full slug.</li>
 <li><strong>No regressions:</strong> attempt a <code>git commit</code> on a non-<code>main</code> feature branch — the PreToolUse branch-guard hook should still allow it. Attempt a <code>git commit</code> while on <code>main</code> — it should still be blocked.</li>
 </ul>
@@ -63,6 +63,6 @@ End-to-end confirmation that the change took effect:
 
 <ul>
 <li>If <code>/doctor</code> still shows truncation in this session despite the new setting, consider raising further to <code>0.07</code> or running the <code>skill-reviewer:optimizing-descriptions</code> skill across installed plugins to shorten descriptions.</li>
-<li>Mirror this setting into <code>~/.claude/settings.json</code> (global user) so other projects on this machine benefit — currently scoped only to <code>acss-plugins</code> per the user's choice.</li>
+<li>Mirror this setting into <code>~/.claude/settings.json</code> (global user) so other projects on this machine benefit — currently scoped only to this project per the user's choice.</li>
 <li>Document the chosen value and its rationale in the project's <code>CLAUDE.md</code> if other contributors are expected to inherit this configuration.</li>
 </ul>

--- a/plugins/acss-kit/skills/component-creator/SKILL.md
+++ b/plugins/acss-kit/skills/component-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-creator
-description: Use when the user describes a UI element in natural language and wants it generated — "create a primary pill button that says Add to cart", "make me a soft warning alert titled 'Heads up' with body 'Your card expires next month'", "build a card with a heading 'Plan' and a primary button labelled Upgrade", "design a small filled outline link". Triggers include "create a <component>", "make me a <component>", "build a <component>", "design a <component>", "generate a <component>", "scaffold a <component>". Dispatches against the reference-doc directory `references/components/*.md`; supports any component with a dedicated reference doc. Pilot — graduates to v1 once auto-trigger reliability is observed across a full release cycle on real user prompts and the six inline-only catalog entries (Badge, Tag, Heading, Text, Details, Progress) are promoted to dedicated reference docs. Failure-mode fallbacks documented in `docs/troubleshooting.md`.
+description: Use when the user asks to create or scaffold a UI component from a natural-language description — any acss-kit component with a dedicated reference doc.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 metadata:
   version: "0.1.0"

--- a/plugins/acss-kit/skills/component-form/SKILL.md
+++ b/plugins/acss-kit/skills/component-form/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-form
-description: Use when the user asks to create a form, scaffold a form, build a signup/contact/login form, generate form components, add form validation, or design accessible form layouts. Triggers include "create a form", "add a form", "build a form component", "scaffold a form", "form with fields", "form scaffolding". Pilot per-component skill — promoted from `references/components/form.md` because forms are high-iteration and benefit from auto-discoverable triggering. Graduates to v1 once auto-trigger reliability is observed across a full release cycle on real user prompts with the v1 field-type grammar (text, email, password, tel, url, number, date, textarea, select, checkbox, radio). Failure-mode fallbacks for unsupported field types (file, color, range) documented in `docs/troubleshooting.md`.
+description: Use when the user asks to create, scaffold, or generate a form component — signup, contact, login, or any accessible form layout with validation.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 metadata:
   version: "0.3.0"

--- a/plugins/acss-kit/skills/components-html/SKILL.md
+++ b/plugins/acss-kit/skills/components-html/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: components-html
-description: Use when generating static HTML snippets (plus optional vanilla-JS helpers) for fpkit-style components in non-React projects. Reads the same component reference docs as the React generator but emits .html + .scss + .js instead of .tsx.
+description: Use when the user asks for static HTML component snippets (plus optional vanilla JS) for fpkit-style acss-kit components in non-React projects.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 metadata:
   version: "0.1.0"

--- a/plugins/acss-kit/skills/components/SKILL.md
+++ b/plugins/acss-kit/skills/components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: components
-description: Use when generating fpkit-style React components into a developer's project. Markdown-as-source templates with embedded TSX/SCSS and accessibility patterns. No @fpkit/acss package required — only React + sass.
+description: Use when the user asks to generate fpkit-style accessible React components (TSX + SCSS) — no @fpkit/acss package required, only React + sass.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 metadata:
   version: "0.3.0"

--- a/plugins/acss-kit/skills/kit-sync/SKILL.md
+++ b/plugins/acss-kit/skills/kit-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kit-sync
-description: Use when the user wants to bulk-install every acss-kit component and theme into a project at once, or to safely re-copy unmodified components after a plugin update. Backs /kit-sync (bulk install) and /kit-update (drift-safe re-copy). Maintains .acss-kit/manifest.json as the source of truth for what was generated, and uses sha256 drift detection to skip user-modified files.
+description: Use when the user asks to bulk-install all acss-kit components and themes (/kit-sync) or re-copy unmodified components after a plugin update (/kit-update).
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 metadata:
   version: "0.1.0"

--- a/plugins/acss-kit/skills/prompt-book/SKILL.md
+++ b/plugins/acss-kit/skills/prompt-book/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prompt-book
-description: Display the bundled prompt book — a copy-paste catalogue of natural-language prompts mapped to every shipped slash command across acss-kit and acss-utilities. Use when the user runs /prompt-book or asks to see example prompts, prompt templates, or what they can ask Claude Code to do with these plugins.
+description: Display the bundled prompt book — copy-paste prompts mapped to every slash command in acss-kit and acss-utilities. Use when the user runs /prompt-book.
 ---
 
 # Prompt Book

--- a/plugins/acss-kit/skills/setup/SKILL.md
+++ b/plugins/acss-kit/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Use when the user runs /setup or asks to "set up", "bootstrap", "initialize", or "prepare" a project for acss-kit components and themes. One-time first-run init — detects package manager, prints the sass install command, writes .acss-target.json, copies ui.tsx, optionally seeds a starter theme. Cross-domain skill (touches both components and styles concerns) — deliberately not nested under either domain skill.
+description: Use when the user runs /setup or asks to set up or bootstrap a project for acss-kit — installs sass, writes config, and optionally seeds a starter theme.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 metadata:
   version: "0.5.0"

--- a/plugins/acss-kit/skills/style-tune/SKILL.md
+++ b/plugins/acss-kit/skills/style-tune/SKILL.md
@@ -22,7 +22,7 @@ from the intent vocabulary, and atomically validates before writing.
 
 ## When not to use
 
-Bare adjectives without a named component or role do not trigger — "warmer" or "softer" alone won't route here. Phrases must name a target: "warmer button", "softer card", "deeper accent".
+Bare adjectives without a named component or role (e.g. "warmer" alone) trigger disambiguation via AskUserQuestion (Step A3) rather than routing directly. For best results, name a target: "warmer button", "softer card", "deeper accent".
 
 ## Pilot status
 

--- a/plugins/acss-kit/skills/style-tune/SKILL.md
+++ b/plugins/acss-kit/skills/style-tune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: style-tune
-description: Use when the user asks to adjust visual feel of a named acss-kit component or theme role using natural language. Triggers must reference a component (button, card, alert, dialog, input, nav) or a theme role (primary, accent, danger, warning, info, success, brand) — bare adjectives in prose contexts do NOT trigger. Phrases include "warmer button", "softer card", "calmer alert", "more spacious cards", "more elevated dialog", "tone down the primary", "deeper accent for primary", "make buttons feel sharper", "give the input a quieter look", "bolder primary", "smaller buttons", "bigger dialog", "narrower dialog", "wider input", "shorter dialog", "taller dialog". Routes between theme-role edits (delegated to /theme-update with WCAG pre-validation) and component SCSS token edits (--btn-*, --card-*, --alert-*, --dialog-*, --input-*, --nav-*). Pilot per-feel skill — promoted because feel-based iteration is high-touch and benefits from auto-discoverable triggering. Graduates to v1 once auto-trigger reliability is observed across a full release cycle on real user prompts and the v2 component scope (Field, Checkbox, Icon, Link, List, Popover, Table, Tag, Badge, Img) is folded into the intent vocabulary. Failure-mode fallbacks for unsupported components and modifiers documented in `docs/troubleshooting.md`.
+description: Use when the user wants to adjust the visual feel of an acss-kit component or theme role — 'warmer button', 'softer card', 'bolder primary', 'calmer alert'.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 metadata:
   version: "0.4.1"
@@ -19,6 +19,10 @@ from the intent vocabulary, and atomically validates before writing.
 > tagged ref to npm `6.6.0`). The skill operates on the same token
 > surface as the components and styles skills — it does not introduce
 > new tokens, only adjusts existing ones.
+
+## When not to use
+
+Bare adjectives without a named component or role do not trigger — "warmer" or "softer" alone won't route here. Phrases must name a target: "warmer button", "softer card", "deeper accent".
 
 ## Pilot status
 

--- a/plugins/acss-kit/skills/styles/SKILL.md
+++ b/plugins/acss-kit/skills/styles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: styles
-description: Generate and update CSS themes for fpkit/acss projects. Creates full light/dark palettes from seed colors using OKLCH, scaffolds brand presets, edits theme roles in place with WCAG re-validation, and extracts tokens from images or Figma designs. Use when the developer wants to create a theme, customize brand colors, or update specific role values in an existing theme.
+description: Generate and update CSS themes for fpkit/acss projects — OKLCH light/dark palettes, brand presets, theme role edits, and token extraction from images or Figma.
 allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
 metadata:
   version: "0.3.0"

--- a/plugins/acss-utilities/skills/utilities/SKILL.md
+++ b/plugins/acss-utilities/skills/utilities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: utilities
-description: Generate, list, tune, and bridge Tailwind-style atomic CSS utility classes for fpkit/acss projects. Uses kebab-case class names with hyphen-prefixed responsive variants (`sm-hide`, `md-p-6`, `lg-flex-row`). Pairs with acss-kit via a token-bridge that aliases acss-kit's OKLCH role names to fpkit-style names in both light and dark modes. Use when the developer wants to add utility classes to their project, list which utilities are available, adjust the spacing baseline or breakpoints, or regenerate the bridge after a theme change.
+description: Use when the developer wants Tailwind-style atomic CSS utility classes for fpkit/acss — add, list, tune spacing/breakpoints, or regenerate the token-bridge.
 allowed-tools: AskUserQuestion, Bash, Edit, Glob, Grep, Read, Write
 metadata:
   version: "0.2.0"

--- a/plugins/style-agent/skills/css-to-class/SKILL.md
+++ b/plugins/style-agent/skills/css-to-class/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: css-to-class
-description: Extract a list of CSS utility classes from an HTML element or class string into a single named CSS class. Resolves each token to its actual declarations by grepping the project's own CSS files — no external processor, no framework assumption. Use when a developer wants to replace multi-class utility soup with a single semantic selector.
+description: Use when the developer wants to extract CSS utility classes from an HTML element into a single named class — collapsing utility soup into one semantic selector.
 allowed-tools: Read, Glob, Grep, Bash, AskUserQuestion
 ---
 

--- a/plugins/style-agent/skills/inline-style-to-class/SKILL.md
+++ b/plugins/style-agent/skills/inline-style-to-class/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inline-style-to-class
-description: Convert an inline style attribute, JSX style object, or <style> block into a single named CSS class and append it to the project stylesheet. Detects the target stylesheet from project file conventions — no external processor, no framework assumption. Use when migrating inline styles to reusable, maintainable CSS classes.
+description: Use when the developer wants to convert an inline style attribute, JSX style object, or <style> block into a named CSS class appended to the project stylesheet.
 allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary

- Adds `"skillListingBudgetFraction": 0.05` to `.claude/settings.json`, raising the per-turn skill-listing budget from the binary default of 1% (~8K chars) to 5% (~40K chars). With ~193 installed skills this yields ~207 chars per skill — enough for the 160-char description target without truncation.
- Rewrites `add-command` SKILL.md description to the `Use when the user asks to…` activation-context pattern (122 → 139 chars).
- Adds plan doc `docs/plans/raise-skilllistingbudgetfraction-current-jiggly-pie.md` tracking the rationale and verification steps.

## Test plan

- [ ] Run `/doctor` in a fresh session in this repo — skill-listing-truncation warning should be absent
- [ ] Confirm `jq '{skillListingBudgetFraction, hookCount: (.hooks.PostToolUse | length)}' .claude/settings.json` returns `{"skillListingBudgetFraction": 0.05, "hookCount": 6}`
- [ ] Verify branch-guard hook still blocks commits to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining how to set the project-level skillListingBudgetFraction to 0.05 and how to verify it.
  * Shortened and clarified many skill descriptions to improve trigger clarity and usage guidance.

* **Chores**
  * Introduced a project-level setting to increase the skillListingBudgetFraction to 0.05.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shawn-sandy/agentic-acss-plugins/pull/70)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->