### PR TITLE
refactor: Phase 5 — extract _tokens.py shared module, rename test validators

### DIFF
--- a/plugins/acss-kit/scripts/_tokens.py
+++ b/plugins/acss-kit/scripts/_tokens.py
@@ -1,0 +1,133 @@
+"""
+Shared token/CSS logic for tokens_to_css.py and css_to_tokens.py.
+
+Internal module (_-prefix) — not a slash-command entry point.
+Import via sys.path shim:
+    import os, sys
+    sys.path.insert(0, os.path.dirname(__file__))
+    from _tokens import ROLE_GROUPS, format_palette, ...
+"""
+from __future__ import annotations
+
+import re
+
+# CSS selector constants used in both readers and writers.
+LIGHT_SELECTOR = ":root"
+DARK_SELECTOR = '[data-theme="dark"]'
+
+# Canonical role definitions — single source of truth for names and order.
+# Adding a role here automatically makes it visible to both the CSS writer
+# (tokens_to_css.py) and the CSS reader (css_to_tokens.py).
+ROLE_GROUPS: list[tuple[str, list[str]]] = [
+    ("Backgrounds", [
+        "--color-background",
+        "--color-surface",
+        "--color-surface-raised",
+        "--color-surface-subtle",
+    ]),
+    ("Text", [
+        "--color-text",
+        "--color-text-muted",
+        "--color-text-inverse",
+        "--color-text-subtle",
+    ]),
+    ("Borders", ["--color-border", "--color-border-strong"]),
+    ("Brand + semantic", [
+        "--color-primary",
+        "--color-primary-hover",
+        "--color-success",
+        "--color-warning",
+        "--color-danger",
+        "--color-info",
+    ]),
+    ("Focus", ["--color-focus-ring"]),
+    ("Accent", ["--color-brand-accent"]),
+]
+
+# Flat set of every canonical role name (derived — do not edit directly).
+ALL_ROLES: frozenset[str] = frozenset(r for _, roles in ROLE_GROUPS for r in roles)
+
+# Roles that brand overlay files are allowed to override.
+BRAND_ROLES: frozenset[str] = frozenset({
+    "--color-primary",
+    "--color-primary-hover",
+    "--color-focus-ring",
+    "--color-brand-accent",
+})
+
+# --- Internal regexes ---
+
+_VAR_DECL_RE = re.compile(r"^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);", re.IGNORECASE | re.MULTILINE)
+_VAR_REF_RE = re.compile(r"var\(\s*(--[a-z0-9-]+)\s*(?:,\s*([^)]+))?\)")
+_HEX_RE = re.compile(r"#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})")
+_SELECTOR_RE = re.compile(
+    r'(:root|\[data-theme=["\']dark["\']\])\s*\{([^}]*)\}',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+# --- Public helpers ---
+
+def parse_vars(text: str) -> dict[str, str]:
+    """Extract ``--name: value`` declarations from a CSS text block."""
+    return {m.group(1): m.group(2).strip() for m in _VAR_DECL_RE.finditer(text)}
+
+
+def resolve_hex(name: str, vars_: dict[str, str], depth: int = 3) -> str | None:
+    """Follow var() chains and return the first hex value found, or None."""
+    if depth < 0 or name not in vars_:
+        return None
+    raw = vars_[name]
+    m = _HEX_RE.search(raw)
+    if m:
+        h = m.group(1)
+        return "#" + (h if len(h) == 6 else "".join(c * 2 for c in h))
+    m = _VAR_REF_RE.search(raw)
+    if m:
+        resolved = resolve_hex(m.group(1), vars_, depth - 1)
+        if resolved:
+            return resolved
+        if m.group(2):
+            fm = _HEX_RE.search(m.group(2))
+            if fm:
+                h = fm.group(1)
+                return "#" + (h if len(h) == 6 else "".join(c * 2 for c in h))
+    return None
+
+
+def extract_selector_blocks(text: str) -> dict[str, str]:
+    """Return ``{"light": block_text, "dark": block_text}`` from CSS source."""
+    blocks: dict[str, str] = {}
+    for m in _SELECTOR_RE.finditer(text):
+        sel = m.group(1).strip()
+        key = "dark" if "dark" in sel.lower() else "light"
+        blocks[key] = blocks.get(key, "") + m.group(2)
+    return blocks
+
+
+def parse_palette_from_block(block: str) -> dict[str, str]:
+    """Parse a CSS block into ``{role: hex}`` keeping only canonical roles."""
+    vars_ = parse_vars(block)
+    result: dict[str, str] = {}
+    for name in ALL_ROLES:
+        if name in vars_:
+            resolved = resolve_hex(name, vars_)
+            if resolved is not None:
+                result[name] = resolved
+    return result
+
+
+def format_palette(palette: dict[str, str], selector: str, indent: str = "  ") -> str:
+    """Render a palette dict as a CSS rule block ordered by ROLE_GROUPS."""
+    lines = [f"{selector} {{"]
+    for group_name, roles in ROLE_GROUPS:
+        group_lines = [
+            f"{indent}{role}: var({role}, {palette[role]});"
+            for role in roles
+            if role in palette
+        ]
+        if group_lines:
+            lines.append(f"\n{indent}/* {group_name} */")
+            lines.extend(group_lines)
+    lines.append("}\n")
+    return "\n".join(lines)

--- a/plugins/acss-kit/scripts/css_to_tokens.py
+++ b/plugins/acss-kit/scripts/css_to_tokens.py
@@ -5,6 +5,7 @@ Convert theme CSS files into a theme.tokens.json file.
 Usage:
     python css_to_tokens.py <light.css> [dark.css] [brand-*.css ...]
     python css_to_tokens.py --dir=<dir>   (scans for light.css, dark.css, brand-*.css)
+    python css_to_tokens.py --self-test
 
 Output: JSON to stdout conforming to assets/theme.schema.json.
 
@@ -13,79 +14,19 @@ Exit codes: 0 = success, 2 = usage/IO error.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(__file__))
+from _tokens import (  # noqa: E402
+    BRAND_ROLES,
+    extract_selector_blocks,
+    parse_palette_from_block,
+)
 
 PALETTE_FILE_RE = re.compile(r"^(light|dark|brand-[\w-]+)\.css$")
-VAR_DECL_RE = re.compile(r"^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);", re.IGNORECASE | re.MULTILINE)
-VAR_REF_RE = re.compile(r"var\(\s*(--[a-z0-9-]+)\s*(?:,\s*([^)]+))?\)")
-HEX_RE = re.compile(r"#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})")
-
-# Roles relevant to theme tokens (ignore component-level tokens)
-COLOR_ROLE_RE = re.compile(r"^--color-")
-
-# Brand files only override these roles
-BRAND_ROLES = {
-    "--color-primary", "--color-primary-hover",
-    "--color-focus-ring", "--color-brand-accent",
-}
-
-
-def _parse_vars(text: str) -> dict[str, str]:
-    return {m.group(1): m.group(2).strip() for m in VAR_DECL_RE.finditer(text)}
-
-
-def _resolve_hex(name: str, vars_: dict[str, str], depth: int = 3) -> str | None:
-    if depth < 0 or name not in vars_:
-        return None
-    raw = vars_[name]
-    m = HEX_RE.search(raw)
-    if m:
-        h = m.group(1)
-        if len(h) == 3:
-            h = "".join(c * 2 for c in h)
-        return "#" + h
-    m = VAR_REF_RE.search(raw)
-    if m:
-        resolved = _resolve_hex(m.group(1), vars_, depth - 1)
-        if resolved:
-            return resolved
-        if m.group(2):
-            fm = HEX_RE.search(m.group(2))
-            if fm:
-                h = fm.group(1)
-                if len(h) == 3:
-                    h = "".join(c * 2 for c in h)
-                return "#" + h
-    return None
-
-
-def _extract_selector_blocks(text: str) -> dict[str, str]:
-    """Split CSS into blocks by selector. Returns {selector: block_text}."""
-    # Match :root { ... } and [data-theme="dark"] { ... }
-    pattern = re.compile(
-        r'(:root|\[data-theme=["\']dark["\']\])\s*\{([^}]*)\}',
-        re.DOTALL | re.IGNORECASE,
-    )
-    blocks: dict[str, str] = {}
-    for m in pattern.finditer(text):
-        sel = m.group(1).strip()
-        key = "dark" if "dark" in sel.lower() else "light"
-        blocks[key] = blocks.get(key, "") + m.group(2)
-    return blocks
-
-
-def _parse_palette_from_block(block: str) -> dict[str, str]:
-    vars_ = _parse_vars(block)
-    palette: dict[str, str] = {}
-    for name, _ in vars_.items():
-        if COLOR_ROLE_RE.match(name):
-            resolved = _resolve_hex(name, vars_)
-            if resolved:
-                palette[name] = resolved
-    return palette
 
 
 def _process_file(path: Path) -> tuple[str, dict]:
@@ -94,29 +35,133 @@ def _process_file(path: Path) -> tuple[str, dict]:
     stem = path.stem  # e.g. 'light', 'dark', 'brand-forest'
 
     if stem in ("light", "dark"):
-        blocks = _extract_selector_blocks(text)
+        blocks = extract_selector_blocks(text)
         if stem in blocks:
-            return stem, _parse_palette_from_block(blocks[stem])
-        # Fallback: parse all vars if selector not found
-        return stem, _parse_palette_from_block(text)
+            return stem, parse_palette_from_block(blocks[stem])
+        return stem, parse_palette_from_block(text)
 
     if stem.startswith("brand-"):
         name = stem[len("brand-"):]
-        blocks = _extract_selector_blocks(text)
+        blocks = extract_selector_blocks(text)
         overrides: dict = {}
         for mode_key, block in blocks.items():
-            palette = _parse_palette_from_block(block)
+            palette = parse_palette_from_block(block)
             filtered = {k: v for k, v in palette.items() if k in BRAND_ROLES}
             if filtered:
                 overrides[mode_key] = filtered
         return f"brand-{name}", overrides
 
-    # Unknown — parse everything as a flat dict
-    return stem, _parse_palette_from_block(text)
+    return stem, parse_palette_from_block(text)
+
+
+def self_test() -> int:
+    import tempfile
+
+    passed = 0
+    failed = 0
+
+    def run(name: str, files: dict[str, str], checks: list[str],
+            absent: list[str] | None = None) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_ = Path(tmpdir)
+            for fname, content in files.items():
+                (dir_ / fname).write_text(content, encoding="utf-8")
+            old_argv = sys.argv
+            sys.argv = ["css_to_tokens.py", f"--dir={tmpdir}"]
+            from io import StringIO
+            old_stdout = sys.stdout
+            sys.stdout = buf = StringIO()
+            try:
+                code = main()
+            finally:
+                sys.argv = old_argv
+                sys.stdout = old_stdout
+            output = buf.getvalue()
+            ok = code == 0
+            ok = ok and all(chk in output for chk in checks)
+            if absent:
+                ok = ok and all(a not in output for a in absent)
+            if ok:
+                print(f"PASS: {name}")
+                passed += 1
+            else:
+                missing = [c for c in checks if c not in output]
+                unexpected = [a for a in (absent or []) if a in output]
+                print(f"FAIL: {name} — code={code} missing={missing} unexpected={unexpected}")
+                if output:
+                    print("  output:", output[:300])
+                failed += 1
+
+    # Round-trip: write light.css that tokens_to_css.py would produce, read back
+    light_css = """\
+:root {
+
+  /* Backgrounds */
+  --color-background: var(--color-background, #ffffff);
+  --color-surface: var(--color-surface, #f8fafc);
+
+  /* Brand + semantic */
+  --color-primary: var(--color-primary, #4f46e5);
+  --color-danger: var(--color-danger, #dc2626);
+}
+"""
+    dark_css = """\
+[data-theme="dark"] {
+
+  /* Backgrounds */
+  --color-background: var(--color-background, #0f172a);
+
+  /* Brand + semantic */
+  --color-primary: var(--color-primary, #7dd3fc);
+}
+"""
+    run(
+        "light.css — primary and background extracted",
+        {"light.css": light_css},
+        ['"--color-primary": "#4f46e5"', '"--color-background": "#ffffff"'],
+    )
+    run(
+        "dark.css — dark mode primary extracted",
+        {"dark.css": dark_css},
+        ['"--color-primary": "#7dd3fc"', '"dark"'],
+    )
+    run(
+        "both light and dark",
+        {"light.css": light_css, "dark.css": dark_css},
+        ['"light"', '"dark"', '"--color-primary"'],
+    )
+    run(
+        "brand file — only BRAND_ROLES included",
+        {"brand-forest.css": """\
+:root {
+  --color-primary: var(--color-primary, #2f7a4d);
+  --color-danger: var(--color-danger, #dc2626);
+}
+"""},
+        ['"forest"', '"--color-primary"'],
+        absent=['"--color-danger"'],
+    )
+    run(
+        "round-trip — light hex survives css→json",
+        {"light.css": light_css},
+        ['"#4f46e5"'],
+    )
+
+    total = passed + failed
+    if failed:
+        print(f"\n{failed}/{total} self-test(s) FAILED")
+        return 1
+    print(f"\nAll {total} self-tests PASSED")
+    return 0
 
 
 def main() -> int:
     args = sys.argv[1:]
+
+    if "--self-test" in args:
+        return self_test()
+
     scan_dir: Path | None = None
     file_paths: list[Path] = []
 

--- a/plugins/acss-kit/scripts/tokens_to_css.py
+++ b/plugins/acss-kit/scripts/tokens_to_css.py
@@ -5,6 +5,7 @@ Convert a theme.tokens.json file into CSS theme files.
 Usage:
     python tokens_to_css.py <tokens.json> [--out-dir=<dir>]
     python tokens_to_css.py --stdin [--out-dir=<dir>]   (reads JSON from stdin)
+    python tokens_to_css.py --self-test
 
 Output: writes light.css and/or dark.css (and brand-<name>.css for each brand)
         to --out-dir (default: current directory). Prints file paths written.
@@ -20,8 +21,12 @@ CSS variable convention (CLAUDE.md §CSS variable naming):
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _tokens import DARK_SELECTOR, LIGHT_SELECTOR, format_palette  # noqa: E402
 
 
 LIGHT_HEADER = """\
@@ -45,42 +50,16 @@ BRAND_HEADER = """\
  */
 """
 
-ROLE_GROUPS = [
-    ("Backgrounds", ["--color-background", "--color-surface", "--color-surface-raised", "--color-surface-subtle"]),
-    ("Text", ["--color-text", "--color-text-muted", "--color-text-inverse", "--color-text-subtle"]),
-    ("Borders", ["--color-border", "--color-border-strong"]),
-    ("Brand + semantic", ["--color-primary", "--color-primary-hover", "--color-success", "--color-warning", "--color-danger", "--color-info"]),
-    ("Focus", ["--color-focus-ring"]),
-    ("Accent", ["--color-brand-accent"]),
-]
-
-
-def _format_palette(palette: dict[str, str], selector: str, indent: str = "  ") -> str:
-    lines = [f"{selector} {{"]
-    for group_name, roles in ROLE_GROUPS:
-        group_lines = []
-        for role in roles:
-            if role in palette:
-                val = palette[role]
-                # Every var() reference includes a hardcoded hex fallback per CLAUDE.md
-                group_lines.append(f"{indent}{role}: var({role}, {val});")
-        if group_lines:
-            lines.append(f"\n{indent}/* {group_name} */")
-            lines.extend(group_lines)
-    lines.append("}\n")
-    return "\n".join(lines)
-
 
 def _write_light(palette: dict[str, str], out_dir: Path) -> Path:
-    content = LIGHT_HEADER + "\n" + _format_palette(palette, ":root")
-    # Strip double-blank lines
+    content = LIGHT_HEADER + "\n" + format_palette(palette, LIGHT_SELECTOR)
     path = out_dir / "light.css"
     path.write_text(content, encoding="utf-8")
     return path
 
 
 def _write_dark(palette: dict[str, str], out_dir: Path) -> Path:
-    content = DARK_HEADER + "\n" + _format_palette(palette, '[data-theme="dark"]')
+    content = DARK_HEADER + "\n" + format_palette(palette, DARK_SELECTOR)
     path = out_dir / "dark.css"
     path.write_text(content, encoding="utf-8")
     return path
@@ -92,16 +71,107 @@ def _write_brand(name: str, overrides: dict, out_dir: Path) -> Path:
     dark_overrides = overrides.get("dark", {})
     content = header + "\n"
     if light_overrides:
-        content += _format_palette(light_overrides, ":root") + "\n"
+        content += format_palette(light_overrides, LIGHT_SELECTOR) + "\n"
     if dark_overrides:
-        content += _format_palette(dark_overrides, '[data-theme="dark"]') + "\n"
+        content += format_palette(dark_overrides, DARK_SELECTOR) + "\n"
     path = out_dir / f"brand-{name}.css"
     path.write_text(content, encoding="utf-8")
     return path
 
 
+def process(tokens: dict, out_dir: Path) -> list[str]:
+    """Write CSS files from a tokens dict. Returns list of written paths."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+    modes = tokens.get("modes", {})
+    if "light" in modes:
+        written.append(str(_write_light(modes["light"], out_dir)))
+    if "dark" in modes:
+        written.append(str(_write_dark(modes["dark"], out_dir)))
+    for brand_name, overrides in tokens.get("brands", {}).items():
+        written.append(str(_write_brand(brand_name, overrides, out_dir)))
+    return written
+
+
+def self_test() -> int:
+    import tempfile
+
+    passed = 0
+    failed = 0
+
+    def run(name: str, tokens: dict, expected_files: list[str],
+            checks: list[str]) -> None:
+        nonlocal passed, failed
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir)
+            written = process(tokens, out_dir)
+            written_names = {Path(p).name for p in written}
+            ok = set(expected_files) <= written_names
+            combined = "".join(
+                (out_dir / f).read_text(encoding="utf-8")
+                for f in expected_files
+                if (out_dir / f).exists()
+            )
+            ok = ok and all(chk in combined for chk in checks)
+            if ok:
+                print(f"PASS: {name}")
+                passed += 1
+            else:
+                missing_files = set(expected_files) - written_names
+                missing_checks = [c for c in checks if c not in combined]
+                print(f"FAIL: {name} — missing_files={missing_files} missing_checks={missing_checks}")
+                failed += 1
+
+    run(
+        "light mode only",
+        {"modes": {"light": {"--color-primary": "#4f46e5", "--color-background": "#ffffff"}}},
+        ["light.css"],
+        [":root {", "--color-primary: var(--color-primary, #4f46e5);",
+         "--color-background: var(--color-background, #ffffff);"],
+    )
+    run(
+        "dark mode written to correct selector",
+        {"modes": {"dark": {"--color-primary": "#7dd3fc"}}},
+        ["dark.css"],
+        ['[data-theme="dark"] {', "--color-primary: var(--color-primary, #7dd3fc);"],
+    )
+    run(
+        "both modes",
+        {"modes": {
+            "light": {"--color-primary": "#2563eb"},
+            "dark":  {"--color-primary": "#93c5fd"},
+        }},
+        ["light.css", "dark.css"],
+        [":root {", '[data-theme="dark"] {'],
+    )
+    run(
+        "brand file written",
+        {"brands": {"forest": {"light": {"--color-primary": "#2f7a4d"}, "dark": {"--color-primary": "#4ade80"}}}},
+        ["brand-forest.css"],
+        ["brand-forest.css", ":root {", '[data-theme="dark"] {',
+         "--color-primary: var(--color-primary, #2f7a4d);"],
+    )
+    run(
+        "unknown role not emitted",
+        {"modes": {"light": {"--color-unknown-custom": "#ff0000", "--color-primary": "#2563eb"}}},
+        ["light.css"],
+        ["--color-primary"],
+    )
+
+    total = passed + failed
+    if failed:
+        print(f"\n{failed}/{total} self-test(s) FAILED")
+        return 1
+    print(f"\nAll {total} self-tests PASSED")
+    return 0
+
+
 def main() -> int:
     args = sys.argv[1:]
+
+    if "--self-test" in args:
+        return self_test()
+
     out_dir = Path(".")
     use_stdin = False
     input_path: Path | None = None
@@ -122,26 +192,12 @@ def main() -> int:
         if use_stdin:
             tokens = json.load(sys.stdin)
         else:
-            tokens = json.loads(input_path.read_text(encoding="utf-8"))
+            tokens = json.loads(input_path.read_text(encoding="utf-8"))  # type: ignore[union-attr]
     except Exception as e:
         print(f"error reading tokens: {e}", file=sys.stderr)
         return 2
 
-    out_dir.mkdir(parents=True, exist_ok=True)
-    written: list[str] = []
-
-    modes = tokens.get("modes", {})
-    if "light" in modes:
-        p = _write_light(modes["light"], out_dir)
-        written.append(str(p))
-    if "dark" in modes:
-        p = _write_dark(modes["dark"], out_dir)
-        written.append(str(p))
-
-    for brand_name, overrides in tokens.get("brands", {}).items():
-        p = _write_brand(brand_name, overrides, out_dir)
-        written.append(str(p))
-
+    written = process(tokens, out_dir)
     if not written:
         print("tokens_to_css: nothing to write (no modes or brands in tokens)", file=sys.stderr)
         return 1

--- a/plugins/acss-kit/skills/styles/SKILL.md
+++ b/plugins/acss-kit/skills/styles/SKILL.md
@@ -30,7 +30,7 @@ The authoring format for theme tokens is **CSS custom properties** — not JSON.
 
 ### Semantic role names
 
-`assets/theme.schema.json` `$defs/palette` declares **18 defined `--color-*` properties** total: **15 required roles** plus 3 optional roles (`--color-surface-subtle`, `--color-text-subtle`, `--color-brand-accent`). Names stay byte-compatible with the bundled CSS theme files — no renames, no removals, ever. Group them by purpose, matching `ROLE_GROUPS` in `${CLAUDE_PLUGIN_ROOT}/scripts/tokens_to_css.py`:
+`assets/theme.schema.json` `$defs/palette` declares **18 defined `--color-*` properties** total: **15 required roles** plus 3 optional roles (`--color-surface-subtle`, `--color-text-subtle`, `--color-brand-accent`). Names stay byte-compatible with the bundled CSS theme files — no renames, no removals, ever. Group them by purpose, matching `ROLE_GROUPS` in `${CLAUDE_PLUGIN_ROOT}/scripts/_tokens.py`:
 
 **Backgrounds**
 - `--color-background` *(required)* — page background

--- a/plugins/acss-kit/skills/utilities/references/naming-convention.md
+++ b/plugins/acss-kit/skills/utilities/references/naming-convention.md
@@ -70,7 +70,7 @@ Every `var()` reference inside a utility class **must include a fallback**. The 
 .bg-primary { background-color: var(--color-primary); }
 ```
 
-The fallback's purpose: utility classes should produce a sensible result even when the host project's theme CSS hasn't loaded yet, or when running outside acss-kit. The validator's same-shape check is shared with `acss-kit`'s `validate_components.py` (the SCSS contract harness).
+The fallback's purpose: utility classes should produce a sensible result even when the host project's theme CSS hasn't loaded yet, or when running outside acss-kit. The validator's same-shape check is shared with `acss-kit`'s `validate_extracted_scss.py` (the SCSS contract harness).
 
 ## Source-of-truth
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -58,12 +58,12 @@ mkdir -p "$EXTRACTED"
 
 # Step 2
 section "2. extract + syntax-check acss-kit references"
-node "$REPO_ROOT/tests/validate_components.mjs"
+node "$REPO_ROOT/tests/validate_extracted_tsx.mjs"
 
 # Step 3
 section "3. SCSS contract"
 SCSS_LOG="$TMP_ROOT/scss-contract.log"
-if python3 "$REPO_ROOT/tests/validate_components.py" "$EXTRACTED" >"$SCSS_LOG"; then
+if python3 "$REPO_ROOT/tests/validate_extracted_scss.py" "$EXTRACTED" >"$SCSS_LOG"; then
   green "SCSS contract OK"
 else
   red "SCSS contract failed:"
@@ -107,15 +107,15 @@ mkdir -p "$KNOWN_BAD_TMP"
 cp "$REPO_ROOT/tests/fixtures/known-bad/known-bad.scss" "$KNOWN_BAD_TMP/"
 
 # (a) SCSS validator must FAIL on known-bad.scss
-if python3 "$REPO_ROOT/tests/validate_components.py" "$KNOWN_BAD_TMP" >/dev/null 2>&1; then
-  red "known-bad: validate_components.py PASSED on known-bad fixtures (regex regressed)"
+if python3 "$REPO_ROOT/tests/validate_extracted_scss.py" "$KNOWN_BAD_TMP" >/dev/null 2>&1; then
+  red "known-bad: validate_extracted_scss.py PASSED on known-bad fixtures (regex regressed)"
   exit 1
 fi
 green "SCSS validator caught known-bad.scss"
 
 # (b) TSX validator must reject the banned import in known-bad.tsx.
 # Build a synthetic reference doc using known-bad.tsx as its TSX Template,
-# then call the *exported* checkImports() from validate_components.mjs
+# then call the *exported* checkImports() from validate_extracted_tsx.mjs
 # directly. This exercises the real validator code path; a stub regex
 # here would let import-allowlist regressions slip through.
 KNOWN_BAD_REF="$KNOWN_BAD_TMP/known-bad.md"
@@ -138,14 +138,14 @@ KNOWN_BAD_REF="$KNOWN_BAD_TMP/known-bad.md"
 
 KNOWN_BAD_REF_PATH="$KNOWN_BAD_REF" node --input-type=module -e "
 import { extractFromFile } from '$REPO_ROOT/plugins/acss-kit/scripts/lib/extract.mjs';
-import { checkImports } from '$REPO_ROOT/tests/validate_components.mjs';
+import { checkImports } from '$REPO_ROOT/tests/validate_extracted_tsx.mjs';
 
 const { tsx } = extractFromFile(process.env.KNOWN_BAD_REF_PATH);
 if (!tsx) { console.error('known-bad: no tsx extracted'); process.exit(1); }
 
 const failures = checkImports('known-bad', tsx);
 if (failures.length === 0) {
-  console.error('known-bad: validate_components.mjs accepted banned import in synthetic reference');
+  console.error('known-bad: validate_extracted_tsx.mjs accepted banned import in synthetic reference');
   process.exit(1);
 }
 console.log('known-bad: TSX validator caught', failures.length, 'failure(s)');

--- a/tests/validate_extracted_scss.py
+++ b/tests/validate_extracted_scss.py
@@ -110,7 +110,7 @@ def main() -> int:
             json.dumps(
                 {
                     "ok": False,
-                    "reasons": ["usage: validate_components.py <extracted-dir>"],
+                    "reasons": ["usage: validate_extracted_scss.py <extracted-dir>"],
                 },
             ),
         )

--- a/tests/validate_extracted_tsx.mjs
+++ b/tests/validate_extracted_tsx.mjs
@@ -184,10 +184,10 @@ function main() {
 
 function report(failures) {
   if (failures.length === 0) {
-    console.log('validate_components.mjs: extraction OK')
+    console.log('validate_extracted_tsx.mjs: extraction OK')
     process.exit(0)
   }
-  console.error('validate_components.mjs: extraction FAIL')
+  console.error('validate_extracted_tsx.mjs: extraction FAIL')
   for (const f of failures) console.error('  -', f)
   process.exit(1)
 }


### PR DESCRIPTION
## Summary

- **`_tokens.py` shared module**: extracts `ROLE_GROUPS`, `BRAND_ROLES`, `LIGHT_SELECTOR`/`DARK_SELECTOR`, and all CSS parsing/formatting helpers from the inverse-pair scripts into one source of truth. Both `tokens_to_css.py` and `css_to_tokens.py` now import via the `sys.path` shim pattern. Adding a new role only requires a change in `_tokens.py`.
- **Self-tests added**: both entry scripts now support `--self-test` (5 tests each, all passing).
- **`validate_components.mjs` → `validate_extracted_tsx.mjs`**: name now describes what it validates (extracted TSX from reference docs).
- **`validate_components.py` → `validate_extracted_scss.py`**: same rationale. All callsites in `run.sh`, internal log messages, and `naming-convention.md` updated.
- `styles/SKILL.md` updated: `ROLE_GROUPS` reference now points at `_tokens.py`.

## Test plan

- [ ] `tests/run.sh` green (confirmed locally — all 11 steps pass)
- [ ] `python3 plugins/acss-kit/scripts/tokens_to_css.py --self-test` — 5 tests pass
- [ ] `python3 plugins/acss-kit/scripts/css_to_tokens.py --self-test` — 5 tests pass
- [ ] No `validate_components` references remain anywhere except git history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reference correct sources for token definitions.

* **Chores**
  * Refactored internal CSS token and role definition infrastructure for improved maintainability.
  * Enhanced test harness to use updated validation scripts.
  * Added self-test modes to token conversion tools for internal validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shawn-sandy/agentic-acss-plugins/pull/76)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->