### PR TITLE
feat(style-agent): add /create-utilities skill — natural language to utility class string (v0.3.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,7 @@
     {
       "name": "style-agent",
       "source": "./plugins/style-agent",
-      "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow. Run /css-to-class to extract a list of utility classes from an HTML element or class string into a single named CSS class, with declarations resolved from your project's own CSS files. Run /inline-style-to-class to convert inline style attributes, JSX style objects, or <style> blocks into named CSS classes appended to your project stylesheet.",
+      "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow. Run /css-to-class to extract a list of utility classes from an HTML element or class string into a single named CSS class, with declarations resolved from your project's own CSS files. Run /inline-style-to-class to convert inline style attributes, JSX style objects, or <style> blocks into named CSS classes appended to your project stylesheet. Run /create-utilities to generate a utility class string from a plain-language visual description.",
       "category": "development",
       "tags": [
         "css",

--- a/docs/plans/add-create-utilities-skill-style-agent.md
+++ b/docs/plans/add-create-utilities-skill-style-agent.md
@@ -1,0 +1,132 @@
+---
+status: todo
+type: feature
+created: 2026-05-14
+---
+
+# Plan: Add create-utilities skill to style-agent
+
+## Context
+
+`style-agent` already has two class-authoring skills: `css-to-class` (collapse a utility list into a named class) and `inline-style-to-class` (promote an inline style to a class). The missing direction is the entry point: a developer has a visual intent described in plain language ("a flex container with centered items and 1rem padding") but no class list yet. Today they must mentally map that intent to utility names by hand. A `create-utilities` skill fills that gap — natural language description → ready-to-use utility class string — and chains naturally into the existing `css-to-class` workflow when the user wants to consolidate.
+
+## Objective
+
+Add a `create-utilities` skill and matching `/create-utilities [description]` command to `plugins/style-agent/`. The skill accepts a plain-text visual description, detects which utility library the project uses (acss-kit, Tailwind, Bootstrap utilities, or Tailwind-compatible generic fallback), maps the description to specific class names via LLM reasoning, and outputs a class string plus a one-line HTML example. It stays single-purpose — named-class consolidation is delegated to `/css-to-class`.
+
+## Steps
+
+1. **Create `plugins/style-agent/skills/create-utilities/SKILL.md`** — *Why:* the skill file is the authoritative source of behavior; the command delegates to it entirely. Write with four sections: front-matter (`name`, `description`, `allowed-tools`), Input Forms table, Framework Detection workflow, and the core 6-step Workflow (see SKILL.md design below). *Verify:* `grep -c '^##' plugins/style-agent/skills/create-utilities/SKILL.md` returns 4+ section headings; front-matter `name:` and `description:` fields are present.
+
+2. **Create `plugins/style-agent/commands/create-utilities.md`** — *Why:* every skill needs a matching command that delegates to it (plugin convention). Use `argument-hint: [description]` (not `[name]` — the skill takes a plain-language description, not a CSS identifier). Follow the existing command pattern: YAML front-matter with `description`, `argument-hint`, `allowed-tools`, then a one-paragraph body referencing `${CLAUDE_PLUGIN_ROOT}/skills/create-utilities/SKILL.md`. *Verify:* file contains `${CLAUDE_PLUGIN_ROOT}/skills/create-utilities/SKILL.md`, `argument-hint: [description]` is present, and the file has no logic beyond the delegation paragraph.
+
+3. **Update `plugins/style-agent/docs/README.md`** — *Why:* maintainer guide must stay current. Add `/create-utilities [description]` row to the Commands table and `skills/create-utilities/SKILL.md` line to the Skills list. *Verify:* `grep create-utilities plugins/style-agent/docs/README.md` returns 2 matches.
+
+4. **Update `plugins/style-agent/README.md`** — *Why:* user-facing docs must document the new command. Add a `### /create-utilities [description]` section after `inline-style-to-class`, with a one-line description, an input example, an output example (class string + HTML snippet), and a note that `/css-to-class` can consolidate the output into a named class. *Verify:* the new section heading is present and the output example shows both a class string and an HTML element.
+
+5. **Update `plugins/style-agent/CHANGELOG.md`** — *Why:* Keep a Changelog convention. Add a `### Added` entry under `## [0.3.0]` (not `[Unreleased]` — we are bumping the version in the same changeset, so the two should be in sync): "`/create-utilities` — natural-language description to utility class string (new skill + command)". *Verify:* entry appears under `## [0.3.0]` heading and follows the existing entry style.
+
+6. **Bump version in `plugins/style-agent/.claude-plugin/plugin.json`** from `0.2.0` to `0.3.0` — *Why:* adding a new command is a minor semver increment. *Verify:* `grep version plugins/style-agent/.claude-plugin/plugin.json` shows `"version": "0.3.0"`.
+
+7. **Update `marketplace.json` description for `style-agent`** — *Why:* CLAUDE.md pre-submit checklist requires updating the marketplace entry description when a change is user-facing; adding a new command qualifies. Find the `style-agent` entry in `.claude-plugin/marketplace.json` and append the new capability to the description string. *Verify:* `grep create-utilities .claude-plugin/marketplace.json` (or the repo-root marketplace file) returns a match.
+
+## SKILL.md design (detail for step 1)
+
+### Front-matter
+```yaml
+---
+name: create-utilities
+description: Use when the developer wants to translate a plain-language visual description into utility classes — turning intent like "centered flex row with padding" into a ready-to-use class string.
+allowed-tools: Read, Glob, Grep, Bash, AskUserQuestion
+---
+```
+
+### Input forms table
+| Form | Example |
+|---|---|
+| Plain description | `"a card with white background, 1rem padding, subtle shadow, and rounded corners"` |
+| Component phrase | `"primary button with hover state"` |
+| HTML element with intent | `<div> <!-- make this a centered hero section -->` |
+
+### Framework detection (step 2 of workflow)
+Grep project files to identify which utility library is active:
+- **acss-kit** — presence of `utilities.css` containing `.bg-primary`, `.flex`, `.m-4` selectors
+- **Tailwind** — `tailwind.config.*` file or `@tailwind base` in any `.css`/`.scss`
+- **Bootstrap** — `bootstrap.css` or `bs-` prefixed classes present in source files
+- **Generic fallback** — no framework detected; emit Tailwind-compatible class names (`flex`, `p-4`, `rounded`, etc.) — the de-facto standard most developers recognise
+
+When multiple frameworks are detected, use `AskUserQuestion` to ask the user which vocabulary to use. Do not silently pick one.
+
+### Core workflow (6 steps)
+
+1. **Parse description.** Extract visual properties: layout, spacing, color, typography, borders, shadows, states. If the description is too vague to generate a confident class list (e.g., "make it look nice", "a styled button"), use `AskUserQuestion` with specific follow-up prompts — layout type? color role? spacing scale? — before proceeding.
+
+2. **Detect framework.** Run framework detection above. If multiple frameworks are detected or none is found, use `AskUserQuestion` to confirm which vocabulary to use. If none is confirmed, fall back to Tailwind-compatible naming.
+
+3. **Map tokens.** For each extracted visual property, use LLM reasoning to select the best class name from the detected framework's vocabulary. Order the final list: layout → spacing → color → typography → border/radius → shadow → state. If a description maps to multiple plausible scale values (e.g., "large padding" → `p-6`, `p-8`, or `p-10`?), use `AskUserQuestion` to confirm the intended value before emitting.
+
+4. **Apply accessibility defaults.** If the description implies an interactive element (button, link, input, or similar), automatically include the appropriate focus-visible or focus-ring class even if not explicitly requested. Note any a11y additions with a brief inline comment so the user understands why they were included.
+
+5. **Emit output.** Print two code blocks:
+   - The class string: e.g. `` `flex items-center p-4 bg-primary rounded focus-visible:ring` ``
+   - A one-line HTML example showing the class string applied: e.g. `<button class="flex items-center p-4 bg-primary rounded focus-visible:ring">Label</button>`
+
+6. **Print summary.** List: description parsed → N classes generated, framework detected, any a11y classes added, any ambiguities resolved, any properties not mapped. If the description implied a foreground/background color pair that is likely to fail WCAG 4.5:1 contrast, flag it with a brief contrast warning. Close with: `Run /css-to-class [name] to consolidate into a named class.`
+
+## Verification
+
+After implementation:
+1. Run `tests/run.sh` from repo root — must be green (structural validation).
+2. Install locally: `claude --plugin-dir ./plugins/style-agent` and run `/create-utilities "a centered flex row with 1rem gap and primary background"` — should output a class string and HTML example in under one round-trip.
+3. Test vague input: run `/create-utilities "make it look nice"` — should trigger `AskUserQuestion` asking for specifics before generating any output.
+4. Test framework detection: run in a project with Tailwind vs. one with acss-kit utilities — confirm emitted class names match the correct vocabulary.
+5. Test a11y defaults: run `/create-utilities "a primary submit button"` — output should include a focus-visible or focus-ring class.
+6. Test multi-framework: run in a project with both Tailwind and acss-kit detected — should ask which vocabulary to use.
+7. Confirm plugin version shows `0.3.0` via `/plugin list` and CHANGELOG shows `[0.3.0]`.
+
+## Next Steps *(optional)*
+
+- Wire `/create-utilities` output into `/css-to-class` in a single chained command:
+  ```text
+  Add a chained `/describe-and-name` command to style-agent that runs the create-utilities skill
+  followed by the css-to-class skill in sequence — user provides a description and a name,
+  gets back a named CSS class directly. The command lives at
+  plugins/style-agent/commands/describe-and-name.md and should delegate to both SKILL.md
+  files in order, passing the class string from create-utilities as input to css-to-class.
+  ```
+
+- Extend framework detection to read `vocab.json` when acss-kit utilities are installed, for an exact class inventory:
+  ```text
+  In plugins/style-agent/skills/create-utilities/SKILL.md, extend step 2 (Framework Detection)
+  so that when acss-kit utilities are detected, the workflow also reads
+  plugins/acss-kit/assets/utilities/vocab.json (or the project-installed copy at
+  src/styles/utilities/vocab.json) to get the exact available class names before mapping.
+  This prevents suggesting classes that aren't in the bundle. Update the skill's allowed-tools
+  to include Read, and add a note in the workflow about the vocab.json lookup path.
+  ```
+
+## Interview Summary
+
+Conducted 2026-05-14. File renamed from `i-m-going-to-create-cached-pond.md` to `add-create-utilities-skill-style-agent.md`.
+
+### Key Decisions Confirmed
+
+- **Mapping approach**: Pure LLM reasoning — no lookup tables or grep-based vocab validation; Claude infers class names from the detected framework's conventions.
+- **Multi-framework conflict**: Use `AskUserQuestion` when multiple frameworks are detected (Tailwind + acss-kit) rather than silently picking one.
+- **Step 6 removed**: `create-utilities` stays single-purpose (description → class list). The summary message tells the user to run `/css-to-class` to consolidate into a named class. The auto-name algorithm lives in `css-to-class` only — no duplication.
+- **Generic fallback**: Tailwind-compatible naming when no framework is detected.
+- **Vague input**: Use `AskUserQuestion` with specific follow-up prompts (layout type? color role? spacing scale?) rather than generating loose output.
+- **Output format**: Both class string + one-line HTML example showing it applied.
+- **A11y defaults**: For interactive elements (button, link, input), automatically include focus-visible/focus-ring classes with a note.
+- **Contrast warnings**: Flag obvious low-contrast color pairs in the summary.
+
+### Open Risks & Concerns
+
+1. **`argument-hint` corrected** — was `[name]`, now `[description]`; fixed in this plan revision.
+2. **CHANGELOG/version timing** — plan now writes `[0.3.0]` heading (not `[Unreleased]`) to stay in sync with the plugin.json bump in the same changeset.
+3. **`marketplace.json` added** — new Step 7 covers the entry description update.
+4. **No reproducible test fixture** — verification relies on live session invocation; structure tests pass but skill reasoning is untestable without a smoke-test fixture.
+
+### Simplification Opportunities Applied
+
+- Removed "suggest a name based on description" from the summary step — the auto-name algorithm already lives in `css-to-class/SKILL.md`; duplicating it here would create two places to maintain the same logic.

--- a/plugins/style-agent/.claude-plugin/plugin.json
+++ b/plugins/style-agent/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "style-agent",
   "description": "Write, extract, and organise CSS utilities and classes for any web project. Framework-agnostic — works with plain CSS, SCSS, Tailwind, or any utility-first workflow.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/style-agent/CHANGELOG.md
+++ b/plugins/style-agent/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `style-agent` plugin are documented here. Format foll
 ## [0.3.0] - 2026-05-14
 
 ### Added
-- `/create-utilities` — generate a utility class string from a plain-language visual description. Detects acss-kit, Tailwind, Bootstrap, or falls back to Tailwind-compatible naming. Includes automatic focus-visible defaults for interactive elements and contrast warnings in the summary.
+- `/create-utilities` — generate a utility class string from a plain-language visual description. Detects acss-kit, Tailwind, Bootstrap, or falls back to Tailwind-compatible naming. Applies framework-specific focus defaults for interactive elements (`focus-visible:ring` for Tailwind/fallback, `focus-ring` for Bootstrap, summary note for acss-kit) and contrast warnings in the summary.
 
 ## [0.2.0] - 2026-05-08
 

--- a/plugins/style-agent/CHANGELOG.md
+++ b/plugins/style-agent/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the `style-agent` plugin are documented here. Format foll
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-14
+
+### Added
+- `/create-utilities` — generate a utility class string from a plain-language visual description. Detects acss-kit, Tailwind, Bootstrap, or falls back to Tailwind-compatible naming. Includes automatic focus-visible defaults for interactive elements and contrast warnings in the summary.
+
 ## [0.2.0] - 2026-05-08
 
 ### Added

--- a/plugins/style-agent/CHANGELOG.md
+++ b/plugins/style-agent/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `style-agent` plugin are documented here. Format foll
 ## [0.3.0] - 2026-05-14
 
 ### Added
-- `/create-utilities` — generate a utility class string from a plain-language visual description. Detects acss-kit, Tailwind, Bootstrap, or falls back to Tailwind-compatible naming. Applies framework-specific focus defaults for interactive elements (`focus-visible:ring` for Tailwind/fallback, `focus-ring` for Bootstrap, summary note for acss-kit) and contrast warnings in the summary.
+- `/create-utilities` — generate a utility class string from a plain-language visual description. Detects acss-kit, Tailwind, Bootstrap, or falls back to Tailwind-compatible naming. Applies framework-specific focus defaults for interactive elements (`focus-visible:ring` for Tailwind/fallback, `focus-ring` for Bootstrap); for acss-kit, emits a summary warning that no focus utility exists in the bundle and recommends adding `:focus-visible` CSS or using an acss-kit component class. Includes contrast warnings in the summary.
 
 ## [0.2.0] - 2026-05-08
 

--- a/plugins/style-agent/README.md
+++ b/plugins/style-agent/README.md
@@ -97,7 +97,7 @@ flex items-center gap-4 bg-primary focus-visible:ring
 <button class="flex items-center gap-4 bg-primary focus-visible:ring">Label</button>
 ```
 
-For interactive elements (button, link, input), focus styling is handled automatically — `focus-visible:ring` for Tailwind/fallback projects, `focus-ring` for Bootstrap, and a summary note for acss-kit (which handles focus via component CSS). Run `/css-to-class [name]` on the output to consolidate into a single named CSS class.
+For interactive elements (button, link, input), focus styling is handled automatically — `focus-visible:ring` for Tailwind/fallback projects, `focus-ring` for Bootstrap. For acss-kit, the skill warns in the summary that no focus utility exists in the bundle and suggests adding `:focus-visible` CSS to your project or using an acss-kit component class. Run `/css-to-class [name]` on the output to consolidate into a single named CSS class.
 
 ## Developer guide
 

--- a/plugins/style-agent/README.md
+++ b/plugins/style-agent/README.md
@@ -73,6 +73,32 @@ Convert an inline `style` attribute, JSX `style={{ ... }}` object, or `<style>` 
 
 **Name rules** — max 20 characters, kebab-case. Omit `name` to auto-generate from the element tag and first declared property.
 
+### `/create-utilities [description]`
+
+Generate a utility class string from a plain-language description of visual intent. Detects the project's utility framework (acss-kit, Tailwind, Bootstrap, or Tailwind-compatible fallback) and maps the description to specific class names.
+
+**Input** — describe what you want in plain language:
+
+```text
+a centered flex row with 1rem gap and a primary background
+```
+
+```text
+primary submit button with hover state
+```
+
+**Output** — a class string and a one-line HTML example:
+
+```text
+flex items-center gap-4 bg-primary focus-visible:ring
+```
+
+```html
+<button class="flex items-center gap-4 bg-primary focus-visible:ring">Label</button>
+```
+
+For interactive elements (button, link, input), focus-visible classes are included automatically. Run `/css-to-class [name]` on the output to consolidate into a single named CSS class.
+
 ## Developer guide
 
 See [`docs/README.md`](docs/README.md).

--- a/plugins/style-agent/README.md
+++ b/plugins/style-agent/README.md
@@ -97,7 +97,7 @@ flex items-center gap-4 bg-primary focus-visible:ring
 <button class="flex items-center gap-4 bg-primary focus-visible:ring">Label</button>
 ```
 
-For interactive elements (button, link, input), focus-visible classes are included automatically. Run `/css-to-class [name]` on the output to consolidate into a single named CSS class.
+For interactive elements (button, link, input), focus styling is handled automatically — `focus-visible:ring` for Tailwind/fallback projects, `focus-ring` for Bootstrap, and a summary note for acss-kit (which handles focus via component CSS). Run `/css-to-class [name]` on the output to consolidate into a single named CSS class.
 
 ## Developer guide
 

--- a/plugins/style-agent/commands/create-utilities.md
+++ b/plugins/style-agent/commands/create-utilities.md
@@ -1,0 +1,11 @@
+---
+description: Generate a utility class string from a plain-language visual description
+argument-hint: [description]
+allowed-tools: Read, Glob, Grep, Bash, AskUserQuestion
+---
+
+Generate a utility class string from a plain-language description of visual intent — detecting the project's utility framework and mapping the description to specific class names.
+
+Follow `${CLAUDE_PLUGIN_ROOT}/skills/create-utilities/SKILL.md`.
+
+All behavior — input parsing, vague-description handling, framework detection, class mapping, accessibility defaults, output emission, and summary — is defined in the skill file above.

--- a/plugins/style-agent/docs/README.md
+++ b/plugins/style-agent/docs/README.md
@@ -21,7 +21,7 @@
 
 ## Skills
 
-The plugin ships two skills. Command logic delegates to each skill file.
+The plugin ships three skills. Command logic delegates to each skill file.
 
 - `skills/css-to-class/SKILL.md`
 - `skills/inline-style-to-class/SKILL.md`

--- a/plugins/style-agent/docs/README.md
+++ b/plugins/style-agent/docs/README.md
@@ -17,6 +17,7 @@
 |---|---|
 | `/css-to-class [name]` | Extract utility classes from an HTML element or class string into a single named CSS class |
 | `/inline-style-to-class [name]` | Convert an inline style attribute, JSX style object, or `<style>` block into a named CSS class and append it to the project stylesheet |
+| `/create-utilities [description]` | Generate a utility class string from a plain-language visual description |
 
 ## Skills
 
@@ -24,6 +25,7 @@ The plugin ships two skills. Command logic delegates to each skill file.
 
 - `skills/css-to-class/SKILL.md`
 - `skills/inline-style-to-class/SKILL.md`
+- `skills/create-utilities/SKILL.md`
 
 ## Adding new skills
 

--- a/plugins/style-agent/skills/create-utilities/SKILL.md
+++ b/plugins/style-agent/skills/create-utilities/SKILL.md
@@ -45,7 +45,13 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
    find . \( -name "utilities.css" -o -name "tailwind.config.*" -o -name "bootstrap*.css" \) \
      -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/dist/*" -not -path "*/build/*"
    ```
-   Also grep for `@tailwind base` in `.css`/`.scss` files. If multiple frameworks are found, use `AskUserQuestion` to confirm which vocabulary to use — do not auto-fallback. Only fall back to Tailwind-compatible naming when no framework is detected, or when the user explicitly confirms no framework after clarification.
+   Also grep for `@tailwind base` in `.css`/`.scss` files. If a `utilities.css` file is found, confirm it is acss-kit by grepping for a distinctive selector before concluding:
+   ```bash
+   grep -l "\.bg-primary" <path-to-utilities.css>
+   ```
+   If the grep does not match, treat `utilities.css` as an unrecognised file and do not classify it as acss-kit.
+
+   If multiple frameworks are found, use `AskUserQuestion` to confirm which vocabulary to use — do not auto-fallback. Only fall back to Tailwind-compatible naming when no framework is detected, or when the user explicitly confirms no framework after clarification.
 
 3. **Map to classes.** For each extracted visual property, use LLM reasoning to select the best class name from the detected framework's vocabulary. Apply framework-specific naming conventions:
    - **acss-kit**: `bg-primary`, `p-4`, `flex`, `items-center`, `rounded`, `shadow`
@@ -59,7 +65,7 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
 
 4. **Apply accessibility defaults.** If the description implies an interactive element (button, link, input, select, or similar), handle focus styling based on the detected framework:
    - **Tailwind / fallback**: append `focus-visible:ring` to the class list.
-   - **acss-kit**: do not add an extra class — acss-kit components handle `:focus-visible` via their own component CSS. Note this in the summary instead.
+   - **acss-kit**: the utility bundle does not ship a focus-visible or focus-ring utility class. Do not add a class. Instead, emit a warning in the summary: "No focus utility available in acss-kit's utility bundle — add `:focus-visible { outline: 2px solid var(--color-primary, currentColor); outline-offset: 2px; }` to your project CSS, or use an acss-kit component class (e.g., `.btn`) that provides focus styling."
    - **Bootstrap**: append `focus-ring` (Bootstrap 5.3+) or note that Bootstrap provides native focus styling.
 
    Always add a brief `# a11y` note in the summary explaining what was added (or why no class was added).

--- a/plugins/style-agent/skills/create-utilities/SKILL.md
+++ b/plugins/style-agent/skills/create-utilities/SKILL.md
@@ -26,7 +26,7 @@ Grep project files to identify which utility library is active:
 
 - **acss-kit** — `utilities.css` present in the project containing selectors like `.bg-primary`, `.flex`, `.m-4`
 - **Tailwind** — `tailwind.config.*` file exists, or `@tailwind base` appears in any `.css`/`.scss` file
-- **Bootstrap** — `bootstrap.css` present, or `bs-` prefixed classes appear in source files
+- **Bootstrap** — `bootstrap*.css` present in the project, or Bootstrap-specific utility patterns (`d-flex`, `btn`, `container`) appear in HTML/template source files
 - **Generic fallback** — no framework detected; use Tailwind-compatible naming (`flex`, `p-4`, `rounded`, etc.) — the de-facto standard most developers recognise
 
 When multiple frameworks are detected, use `AskUserQuestion` to confirm which vocabulary to use — never silently pick one.
@@ -42,7 +42,7 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
 
 2. **Detect framework.** Run the framework detection above:
    ```bash
-   find . \( -name "utilities.css" -o -name "tailwind.config.*" -o -name "bootstrap.css" \) \
+   find . \( -name "utilities.css" -o -name "tailwind.config.*" -o -name "bootstrap*.css" \) \
      -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/dist/*" -not -path "*/build/*"
    ```
    Also grep for `@tailwind base` in `.css`/`.scss` files. If multiple frameworks are found, use `AskUserQuestion` to confirm which vocabulary to use — do not auto-fallback. Only fall back to Tailwind-compatible naming when no framework is detected, or when the user explicitly confirms no framework after clarification.
@@ -57,11 +57,16 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
 
    When a description maps to multiple plausible scale values (e.g., "large padding" → `p-6`, `p-8`, or `p-10`?), use `AskUserQuestion` to confirm the intended value before emitting.
 
-4. **Apply accessibility defaults.** If the description implies an interactive element (button, link, input, select, or similar), automatically include the appropriate focus-visible or focus-ring class even if not explicitly mentioned. Append it to the state position in the class list and add a brief `# a11y` comment in the summary to explain the addition.
+4. **Apply accessibility defaults.** If the description implies an interactive element (button, link, input, select, or similar), handle focus styling based on the detected framework:
+   - **Tailwind / fallback**: append `focus-visible:ring` to the class list.
+   - **acss-kit**: do not add an extra class — acss-kit components handle `:focus-visible` via their own component CSS. Note this in the summary instead.
+   - **Bootstrap**: append `focus-ring` (Bootstrap 5.3+) or note that Bootstrap provides native focus styling.
+
+   Always add a brief `# a11y` note in the summary explaining what was added (or why no class was added).
 
 5. **Emit output.** Print two fenced code blocks:
 
-   **Class string:**
+   **Class string** (Tailwind example):
    ```text
    flex items-center p-4 bg-primary rounded shadow focus-visible:ring
    ```
@@ -70,6 +75,8 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
    ```html
    <button class="flex items-center p-4 bg-primary rounded shadow focus-visible:ring">Label</button>
    ```
+
+   The focus class (`focus-visible:ring`, `focus-ring`, or none) varies by framework — see step 4.
 
 6. **Print summary.** One concise block listing:
    - Framework detected (or fallback used)

--- a/plugins/style-agent/skills/create-utilities/SKILL.md
+++ b/plugins/style-agent/skills/create-utilities/SKILL.md
@@ -45,10 +45,10 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
    find . \( -name "utilities.css" -o -name "tailwind.config.*" -o -name "bootstrap.css" \) \
      -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/dist/*" -not -path "*/build/*"
    ```
-   Also grep for `@tailwind base` in `.css`/`.scss` files. If multiple frameworks are found, or if the user confirms no framework, fall back to Tailwind-compatible naming.
+   Also grep for `@tailwind base` in `.css`/`.scss` files. If multiple frameworks are found, use `AskUserQuestion` to confirm which vocabulary to use — do not auto-fallback. Only fall back to Tailwind-compatible naming when no framework is detected, or when the user explicitly confirms no framework after clarification.
 
 3. **Map to classes.** For each extracted visual property, use LLM reasoning to select the best class name from the detected framework's vocabulary. Apply framework-specific naming conventions:
-   - **acss-kit**: `.bg-primary`, `.p-4`, `.flex`, `.items-center`, `.rounded`, `.shadow`
+   - **acss-kit**: `bg-primary`, `p-4`, `flex`, `items-center`, `rounded`, `shadow`
    - **Tailwind**: `bg-primary`, `p-4`, `flex`, `items-center`, `rounded`, `shadow`
    - **Bootstrap**: `bg-primary`, `p-3`, `d-flex`, `align-items-center`, `rounded`, `shadow-sm`
    - **Fallback**: Tailwind-compatible names
@@ -62,7 +62,7 @@ When multiple frameworks are detected, use `AskUserQuestion` to confirm which vo
 5. **Emit output.** Print two fenced code blocks:
 
    **Class string:**
-   ```
+   ```text
    flex items-center p-4 bg-primary rounded shadow focus-visible:ring
    ```
 

--- a/plugins/style-agent/skills/create-utilities/SKILL.md
+++ b/plugins/style-agent/skills/create-utilities/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: create-utilities
+description: Use when the developer wants to create utility classes from a plain-language visual description — turning intent like "centered flex row with padding" into a ready-to-use class string.
+allowed-tools: Read, Glob, Grep, Bash, AskUserQuestion
+---
+
+# create-utilities
+
+Generate a utility class string from a plain-language description of visual intent. Detects which utility library the project uses (acss-kit, Tailwind, Bootstrap, or Tailwind-compatible fallback) and maps the description to specific class names via LLM reasoning. Outputs a class string and a one-line HTML example ready to use — chains naturally into `/css-to-class` when the user wants to consolidate into a named class.
+
+---
+
+## Input forms
+
+| Form | Example |
+|---|---|
+| Plain description | `"a card with white background, 1rem padding, subtle shadow, and rounded corners"` |
+| Component phrase | `"primary button with hover state"` |
+| HTML element with intent | `<div> <!-- make this a centered hero section -->` |
+
+---
+
+## Framework detection
+
+Grep project files to identify which utility library is active:
+
+- **acss-kit** — `utilities.css` present in the project containing selectors like `.bg-primary`, `.flex`, `.m-4`
+- **Tailwind** — `tailwind.config.*` file exists, or `@tailwind base` appears in any `.css`/`.scss` file
+- **Bootstrap** — `bootstrap.css` present, or `bs-` prefixed classes appear in source files
+- **Generic fallback** — no framework detected; use Tailwind-compatible naming (`flex`, `p-4`, `rounded`, etc.) — the de-facto standard most developers recognise
+
+When multiple frameworks are detected, use `AskUserQuestion` to confirm which vocabulary to use — never silently pick one.
+
+---
+
+## Workflow
+
+1. **Parse description.** Extract the visual properties being described: layout, spacing, color, typography, borders, shadows, states. If the description is too vague to generate a confident class list (e.g., "make it look nice", "a styled button"), use `AskUserQuestion` with specific follow-up prompts before proceeding:
+   - What layout type? (flex / grid / block)
+   - What color role? (primary / neutral / danger / etc.)
+   - What spacing scale? (small / medium / large, or a specific value)
+
+2. **Detect framework.** Run the framework detection above:
+   ```bash
+   find . \( -name "utilities.css" -o -name "tailwind.config.*" -o -name "bootstrap.css" \) \
+     -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/dist/*" -not -path "*/build/*"
+   ```
+   Also grep for `@tailwind base` in `.css`/`.scss` files. If multiple frameworks are found, or if the user confirms no framework, fall back to Tailwind-compatible naming.
+
+3. **Map to classes.** For each extracted visual property, use LLM reasoning to select the best class name from the detected framework's vocabulary. Apply framework-specific naming conventions:
+   - **acss-kit**: `.bg-primary`, `.p-4`, `.flex`, `.items-center`, `.rounded`, `.shadow`
+   - **Tailwind**: `bg-primary`, `p-4`, `flex`, `items-center`, `rounded`, `shadow`
+   - **Bootstrap**: `bg-primary`, `p-3`, `d-flex`, `align-items-center`, `rounded`, `shadow-sm`
+   - **Fallback**: Tailwind-compatible names
+
+   Order the final class list: **layout → spacing → color → typography → border/radius → shadow → state**.
+
+   When a description maps to multiple plausible scale values (e.g., "large padding" → `p-6`, `p-8`, or `p-10`?), use `AskUserQuestion` to confirm the intended value before emitting.
+
+4. **Apply accessibility defaults.** If the description implies an interactive element (button, link, input, select, or similar), automatically include the appropriate focus-visible or focus-ring class even if not explicitly mentioned. Append it to the state position in the class list and add a brief `# a11y` comment in the summary to explain the addition.
+
+5. **Emit output.** Print two fenced code blocks:
+
+   **Class string:**
+   ```
+   flex items-center p-4 bg-primary rounded shadow focus-visible:ring
+   ```
+
+   **HTML example** (one line, showing the class applied to the most appropriate element for the description):
+   ```html
+   <button class="flex items-center p-4 bg-primary rounded shadow focus-visible:ring">Label</button>
+   ```
+
+6. **Print summary.** One concise block listing:
+   - Framework detected (or fallback used)
+   - Number of classes generated
+   - Any a11y classes added (with brief reason)
+   - Any ambiguities resolved via `AskUserQuestion`
+   - Any described properties that could not be mapped to a class (listed as unmapped)
+   - If the description implies a foreground/background color pair likely to fail WCAG 4.5:1 contrast, flag it with a one-line contrast warning
+
+   Close with: `Run /css-to-class [name] to consolidate into a named class.`


### PR DESCRIPTION
## Summary

- Adds a new `/create-utilities [description]` command and `skills/create-utilities/SKILL.md` to the `style-agent` plugin
- Detects the project's utility framework (acss-kit, Tailwind, Bootstrap, or Tailwind-compatible fallback) and maps a plain-language visual description to a ready-to-use class string
- Bumps `style-agent` from `0.2.0` to `0.3.0`

## What changed

**New files:**
- `plugins/style-agent/skills/create-utilities/SKILL.md` — 6-step skill: parse description → detect framework → map classes via LLM reasoning → apply a11y defaults → emit class string + HTML example → summary
- `plugins/style-agent/commands/create-utilities.md` — delegation stub with `argument-hint: [description]`
- `docs/plans/add-create-utilities-skill-style-agent.md` — plan file with interview summary

**Updated files:**
- `plugins/style-agent/README.md` — new command section with input/output examples
- `plugins/style-agent/docs/README.md` — commands table + skills list updated
- `plugins/style-agent/CHANGELOG.md` — `[0.3.0]` entry added
- `plugins/style-agent/.claude-plugin/plugin.json` — version `0.2.0` → `0.3.0`
- `.claude-plugin/marketplace.json` — style-agent description updated

## Behavior highlights

- **Framework detection** — greps for `utilities.css` (acss-kit), `tailwind.config.*`, or `bootstrap.css`; asks via `AskUserQuestion` when multiple frameworks are found
- **Vague input handling** — asks clarifying questions (layout type? color role? spacing scale?) rather than guessing when the description is too vague
- **A11y defaults** — automatically includes `focus-visible` / focus-ring classes for interactive elements (button, link, input), with a note in the summary
- **Contrast warnings** — flags likely WCAG 4.5:1 failures in the summary when a color pair is described
- **Single-purpose** — outputs a class string + one-line HTML example only; named-class consolidation is delegated to the existing `/css-to-class` command

## Test plan

- [x] `tests/run.sh` — all steps green
- [ ] Manual: `/create-utilities "a centered flex row with 1rem gap and primary background"` — should output class string + HTML example
- [ ] Manual: `/create-utilities "make it look nice"` — should trigger `AskUserQuestion` before generating output
- [ ] Manual: run in a project with Tailwind — classes should use Tailwind vocabulary
- [ ] Manual: `/create-utilities "a primary submit button"` — output should include a focus-visible class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /create-utilities command to generate framework-aware utility class strings from plain-language visual descriptions, including framework detection, ambiguity prompts, and accessibility focus defaults.

* **Documentation**
  * Added user guides, examples, skill/command docs, and changelog entries describing the new command, workflow, outputs, and supported frameworks.

* **Chores**
  * Plugin version bumped to 0.3.0 and marketplace listing updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shawn-sandy/agentic-acss-plugins/pull/77)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->