### PR TITLE
chore(acss-kit): hide 15 component skills from auto-context via disable-model-invocation

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -8,6 +8,7 @@ Advisory text auto-loaded into Claude's context whenever it touches a file match
 | [`python-scripts.md`](python-scripts.md) | `plugins/*/scripts/**` | Active — stdlib-only Python 3 contract (detector vs. generator/validator), current multi-plugin script inventory (see rule doc). |
 | [`command-authoring.md`](command-authoring.md) | `plugins/*/commands/*.md` | Active — front-matter shape, delegate-to-SKILL.md rule. |
 | [`fpkit-references.md`](fpkit-references.md) | `plugins/*/skills/*/references/**` | Active — full GitHub URL requirement, local verification setup. |
+| [`skill-front-matter.md`](skill-front-matter.md) | `plugins/*/skills/**/SKILL.md` | Active — component-tier skills require `disable-model-invocation: true` and a `hint:` field; orchestrator-tier skills do not. |
 
 ## Rules vs. hooks vs. skills
 

--- a/.claude/rules/skill-front-matter.md
+++ b/.claude/rules/skill-front-matter.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "plugins/*/skills/**/SKILL.md"
+---
+
+# SKILL.md Front-Matter Conventions
+
+Two tiers of plugin skills, with different front-matter expectations:
+
+## Component-tier skills (`plugins/*/skills/component-*/SKILL.md`)
+
+- Must set `disable-model-invocation: true` — keeps the catalog out of the
+  model's initial context. Dispatch is by exact path/name from the
+  orchestrator (kit-core's lookup table, `/kit-add <name>`,
+  `/kit-list` globbing `component-*/`), not by description matching, so
+  hiding the description does not break routing.
+- Must declare a `hint:` field describing how the user (or Claude) should
+  invoke the skill once it is hidden from auto-context. Convention:
+  ```yaml
+  hint: >-
+    Invoke explicitly via `/kit-add <name>`, `/kit-create` (then ask for
+    a <component>), or call the `component-<name>` skill by name.
+    Describe <component-specific details: variant, size, state, slots>.
+  ```
+- `hint:` is a project-controlled convention. The Claude Code harness
+  silently ignores unknown front-matter keys, but tooling in this repo
+  (`/kit-list`, docs generation) can surface it.
+
+## Orchestrator-tier and cross-cutting skills (entry points)
+
+`kit-core`, `styles`, `utilities`, `setup`, `style-tune`, `kit-sync`,
+`prompt-book`, and any future entry-point skill:
+
+- Leave `disable-model-invocation` unset (defaults to `false`) — these
+  are the discoverable entry points that should appear in initial context.
+- No `hint:` required.
+
+## Validation
+
+The PostToolUse front-matter hook in `.claude/settings.json` only checks
+for presence of `name:` and `description:`. The `disable-model-invocation`
+and `hint:` fields are convention-enforced via this rule, not by the hook.

--- a/.claude/skills/acss-kit-component-author/SKILL.md
+++ b/.claude/skills/acss-kit-component-author/SKILL.md
@@ -44,7 +44,19 @@ source.
    `plugins/acss-kit/skills/component-<component-name>/` and write two files:
 
    a. **`SKILL.md`** — mirror the shape of `plugins/acss-kit/skills/component-button/SKILL.md`:
-      - frontmatter: `name: component-<component-name>`, `description:` (one line, under 160 chars, "Use when the user asks to generate, create, or scaffold a <PascalCaseName>…"), `allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion`
+      - frontmatter (in this order):
+        - `name: component-<component-name>`
+        - `description:` (one line, under 160 chars, "Use when the user asks to generate, create, or scaffold a <PascalCaseName>…")
+        - `disable-model-invocation: true` (component-tier skills are hidden from auto-context; dispatched by exact name from the orchestrator — see `.claude/rules/skill-front-matter.md`)
+        - `hint: >-` (folded scalar describing invocation surfaces and component-specific details). Template:
+          ```yaml
+          hint: >-
+            Invoke explicitly via `/kit-add <component-name>`, `/kit-create`
+            (then ask for a <component-name>), or call the
+            `component-<component-name>` skill by name. Describe
+            <component-specific details — variant, size, state, slots>.
+          ```
+        - `allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion`
       - Workflow: 5-step workflow (Read reference.md → init check → dep resolution → generate → verify)
       - Reference section linking to `reference.md` and `kit-core/references/`
 

--- a/plugins/acss-kit/.claude-plugin/plugin.json
+++ b/plugins/acss-kit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "acss-kit",
   "description": "Accessible React components, static HTML snippets, CSS themes, and Tailwind-style utility classes for fpkit/acss projects. OKLCH themes with WCAG 2.2 AA validation. Includes all /utility-* commands.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Shawn Sandy",
     "url": "https://github.com/shawn-sandy/acss"

--- a/plugins/acss-kit/CHANGELOG.md
+++ b/plugins/acss-kit/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the `acss-kit` plugin are documented here. Format follows
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-21
+
+### Added
+
+- **New `hint:` front-matter field on every component skill.** Each `skills/component-*/SKILL.md` declares a `hint:` describing the invocation surfaces (`/kit-add <name>`, `/kit-create`, direct skill name) and the component-specific details to describe (variant, size, state, slots). `hint:` is a project-controlled convention; the Claude Code harness ignores unknown front-matter keys at runtime.
+- **`.claude/rules/skill-front-matter.md` rule** codifies the component-tier vs orchestrator-tier front-matter convention (component-tier requires `disable-model-invocation: true` + `hint:`; orchestrator-tier — `kit-core`, `styles`, `utilities`, `setup`, `style-tune`, `kit-sync`, `prompt-book` — does not). Fires on `plugins/*/skills/**/SKILL.md`.
+
+### Changed
+
+- **15 component skills now set `disable-model-invocation: true`.** Each `skills/component-*/SKILL.md` is hidden from the model's initial context at session start to reduce context bloat now that acss-kit ships fifteen components. Dispatch is unchanged — `/kit-add <component>`, `/kit-create`, `/kit-list`, and the kit-core orchestrator's lookup table all route by exact path/name, not by description matching. Users invoke component skills explicitly (via the slash commands or by name); auto-routing from a vague "add a button" prompt no longer applies.
+- **`acss-kit-component-author` scaffolder updated.** Newly scaffolded `component-<name>/SKILL.md` files now include `disable-model-invocation: true` and a `hint:` template by default.
+
 ## [1.2.0] - 2026-05-21
 
 ### Added

--- a/plugins/acss-kit/README.md
+++ b/plugins/acss-kit/README.md
@@ -6,7 +6,7 @@ A Claude Code plugin for building accessible React applications with the [fpkit/
 
 Fifteen per-component skills, a `kit-core` orchestrator, a `styles` skill, a `setup` skill, and a `style-tune` pilot:
 
-- **`component-<name>`** (15 skills) — one dedicated skill per component (alert, button, card, checkbox, dialog, field, icon, icon-button, img, input, link, list, nav, popover, table). `/kit-add <component>` routes to the matching per-component skill, which reads its own `reference.md` for templates and writes self-contained TSX + SCSS into your project.
+- **`component-<name>`** (15 skills) — one dedicated skill per component (alert, button, card, checkbox, dialog, field, icon, icon-button, img, input, link, list, nav, popover, table). `/kit-add <component>` routes to the matching per-component skill, which reads its own `reference.md` for templates and writes self-contained TSX + SCSS into your project. Each per-component skill sets `disable-model-invocation: true` to keep them out of session auto-context — invoke them explicitly via `/kit-add <component>`, `/kit-create`, `/kit-list`, or by calling `component-<name>` by name and describing the variant/state you want.
 - **`kit-core`** — orchestrator for `/kit-create`, `/kit-list`, `/kit-sync`, `/kit-update`, and Form/HTML/Style-Tune modes. Does not auto-trigger for per-component requests.
 - **`styles`** — CSS theme generation. `/theme-create`, `/theme-brand`, `/theme-update`, `/theme-extract` for OKLCH palettes with WCAG 2.2 AA validation.
 - **`setup`** — cross-domain first-run skill backing `/setup`. Runs the sass check, copies `ui.tsx`, and seeds light/dark theme. Idempotent.

--- a/plugins/acss-kit/skills/component-alert/SKILL.md
+++ b/plugins/acss-kit/skills/component-alert/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-alert
 description: Use when the user asks to generate, create, or scaffold an Alert — accessible status/error/info/warning notification with ARIA live regions and icon support.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add alert`, `/kit-create` (then ask for an
+  alert), or call the `component-alert` skill by name. Describe the
+  severity (info/success/warning/error), whether it is dismissible, the
+  ARIA live politeness (polite/assertive), and any leading icon.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-button/SKILL.md
+++ b/plugins/acss-kit/skills/component-button/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-button
 description: Use when the user asks to generate, create, or scaffold a Button — accessible TSX or HTML+JS, with primary/secondary/destructive variants and a11y.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add button`, `/kit-create` (then ask for a
+  button), or call the `component-button` skill by name. Describe the
+  variant (primary/secondary/destructive/ghost), size, state
+  (loading/disabled), and any leading/trailing icon or aria-label.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-card/SKILL.md
+++ b/plugins/acss-kit/skills/component-card/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-card
 description: Use when the user asks to generate, create, or scaffold a Card — accessible content container with header/body/footer slots and interactive variant support.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add card`, `/kit-create` (then ask for a
+  card), or call the `component-card` skill by name. Describe which slots
+  you need (header/body/footer/media), whether the card is interactive
+  (link or button wrapper), and any elevation/border styling.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-checkbox/SKILL.md
+++ b/plugins/acss-kit/skills/component-checkbox/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-checkbox
 description: Use when the user asks to generate, create, or scaffold a Checkbox — accessible checkbox with indeterminate state, aria-checked, custom indicator, and Input dependency.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add checkbox`, `/kit-create` (then ask for a
+  checkbox), or call the `component-checkbox` skill by name. Describe the
+  label, the initial state (checked/unchecked/indeterminate),
+  controlled vs uncontrolled, and any error/required state.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-dialog/SKILL.md
+++ b/plugins/acss-kit/skills/component-dialog/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-dialog
 description: Use when the user asks to generate, create, or scaffold a Dialog — accessible modal dialog with focus trap, aria-modal, return-focus on close, and Button dependency.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add dialog`, `/kit-create` (then ask for a
+  dialog), or call the `component-dialog` skill by name. Describe the
+  title, modal vs non-modal, the trigger element, the body content, and
+  any footer action buttons (confirm/cancel).
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-field/SKILL.md
+++ b/plugins/acss-kit/skills/component-field/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-field
 description: Use when the user asks to generate, create, or scaffold a Field — accessible form field wrapper with label, hint, and error message association via aria-describedby.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add field`, `/kit-create` (then ask for a
+  field), or call the `component-field` skill by name. Describe the
+  label, hint text, error message, required flag, and which child input
+  control (input/checkbox/select) the field wraps.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-icon-button/SKILL.md
+++ b/plugins/acss-kit/skills/component-icon-button/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-icon-button
 description: Use when the user asks to generate, create, or scaffold an IconButton — accessible icon-only button with required aria-label, tooltip fallback, and Button dependency.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add icon-button`, `/kit-create` (then ask
+  for an icon button), or call the `component-icon-button` skill by name.
+  Describe the icon, the required aria-label (always required for icon-
+  only buttons), the variant/size, and any tooltip text.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-icon/SKILL.md
+++ b/plugins/acss-kit/skills/component-icon/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-icon
 description: Use when the user asks to generate, create, or scaffold an Icon — accessible SVG icon wrapper with aria-hidden/aria-label toggle, size variants, and decorative/semantic modes.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add icon`, `/kit-create` (then ask for an
+  icon), or call the `component-icon` skill by name. Describe the icon
+  source (name or SVG path), the size, whether it is decorative
+  (aria-hidden) or semantic (aria-label), and any color or stroke override.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-img/SKILL.md
+++ b/plugins/acss-kit/skills/component-img/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-img
 description: Use when the user asks to generate, create, or scaffold an Img — accessible image component with required alt, lazy-loading, aspect-ratio containment, and decorative mode.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add img`, `/kit-create` (then ask for an
+  image), or call the `component-img` skill by name. Describe the src,
+  the alt text (or mark decorative), the aspect ratio, lazy vs eager
+  loading, and any srcset/sizes for responsive variants.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-input/SKILL.md
+++ b/plugins/acss-kit/skills/component-input/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-input
 description: Use when the user asks to generate, create, or scaffold an Input — accessible text/number/email input with aria-invalid, error state, and controlled/uncontrolled patterns.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add input`, `/kit-create` (then ask for an
+  input), or call the `component-input` skill by name. Describe the
+  input type (text/email/number/password/...), the label, placeholder,
+  controlled vs uncontrolled, and any validation/error state.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-link/SKILL.md
+++ b/plugins/acss-kit/skills/component-link/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-link
 description: Use when the user asks to generate, create, or scaffold a Link — accessible anchor with external/new-tab detection, aria-label injection, and current-page indication.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add link`, `/kit-create` (then ask for a
+  link), or call the `component-link` skill by name. Describe the href,
+  the link text, whether it opens in a new tab/external (so rel and
+  aria-label can be set), and any current-page state.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-list/SKILL.md
+++ b/plugins/acss-kit/skills/component-list/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-list
 description: Use when the user asks to generate, create, or scaffold a List — accessible ordered/unordered list with role="list" reset, item slots, and inline/stacked layout variants.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add list`, `/kit-create` (then ask for a
+  list), or call the `component-list` skill by name. Describe ordered
+  vs unordered, the item content/shape, inline vs stacked layout, and
+  whether the list needs a marker reset (role="list").
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-nav/SKILL.md
+++ b/plugins/acss-kit/skills/component-nav/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-nav
 description: Use when the user asks to generate, create, or scaffold a Nav — accessible navigation landmark with aria-label, current-page link marking, and horizontal/vertical layout.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add nav`, `/kit-create` (then ask for a
+  nav), or call the `component-nav` skill by name. Describe the
+  aria-label for the landmark, the link items (label + href), the
+  current-page link, and horizontal vs vertical orientation.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-popover/SKILL.md
+++ b/plugins/acss-kit/skills/component-popover/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-popover
 description: Use when the user asks to generate, create, or scaffold a Popover — accessible tooltip/popover using the Popover API with focus trap, aria-expanded, and light-dismiss.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add popover`, `/kit-create` (then ask for a
+  popover), or call the `component-popover` skill by name. Describe the
+  trigger element, the popover content, anchor/positioning, and whether
+  light-dismiss and focus-trap behaviour are required.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 

--- a/plugins/acss-kit/skills/component-table/SKILL.md
+++ b/plugins/acss-kit/skills/component-table/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: component-table
 description: Use when the user asks to generate, create, or scaffold a Table — accessible data table with caption, scope headers, responsive scroll wrapper, and sortable column support.
+disable-model-invocation: true
+hint: >-
+  Invoke explicitly via `/kit-add table`, `/kit-create` (then ask for a
+  table), or call the `component-table` skill by name. Describe the
+  caption, the column headers (with scope), the row shape, whether any
+  columns are sortable, and if a responsive scroll wrapper is needed.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 


### PR DESCRIPTION
Every component-*/SKILL.md description was being loaded into the model's
initial context at session start, which had become a meaningful chunk of
context now that acss-kit ships 15 components. Component skills are
dispatched by exact name from the kit-core orchestrator (lookup table,
/kit-add, /kit-list glob) — not by description matching — so hiding the
descriptions from auto-context is safe.

Each component-*/SKILL.md now sets `disable-model-invocation: true` plus
a new `hint:` front-matter field describing the invocation surfaces
(/kit-add <name>, /kit-create, direct skill name) and the
component-specific details the user should describe (variant, size,
state, slots). The `hint:` key is a project-controlled convention; the
harness ignores unknown front-matter keys.

Also:
- New rule `.claude/rules/skill-front-matter.md` codifies the
  component-tier vs orchestrator-tier convention.
- Scaffolder `.claude/skills/acss-kit-component-author/SKILL.md` updated
  so future component skills inherit both fields.
- `plugins/acss-kit/README.md` notes that component skills are
  invocation-only and how to reach them.

tests/run.sh green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established conventions for component-tier skill documentation and invocation requirements.
  * Added invocation hints to all acss-kit component skills, guiding users on explicit invocation methods and required details for each component.

* **Chores**
  * Component skills now disabled from auto-invocation and must be explicitly requested via named commands or workflow steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shawn-sandy/agentic-acss-plugins/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->