### PR TITLE
feat(style-agent): add IDE selection support to /inline-style-to-class

### DIFF
--- a/plugins/style-agent/commands/inline-style-to-class.md
+++ b/plugins/style-agent/commands/inline-style-to-class.md
@@ -6,6 +6,8 @@ allowed-tools: Read, Glob, Grep, Bash, Write, Edit, AskUserQuestion
 
 Convert an inline `style` attribute, JSX `style` object, or `<style>` block into a single named CSS class appended to the project stylesheet. Hard-coded colors, units, and values are replaced with CSS variables — reusing an existing variable when one matches, creating a new one when none does.
 
+**IDE selection supported:** select an element or style block in your editor (VS Code, JetBrains), then run `/inline-style-to-class [name]`. The skill reads the selection, generates the class, and edits the source file in-place — replacing the inline style with the new class reference.
+
 Follow `${CLAUDE_PLUGIN_ROOT}/skills/inline-style-to-class/SKILL.md`.
 
 All behavior — argument handling, input parsing, name rules, stylesheet and variable discovery, value tokenizing, class emission, new-variable declaration, file append, HTML/JSX refactoring, and summary output — is defined in the skill file above.

--- a/plugins/style-agent/skills/inline-style-to-class/SKILL.md
+++ b/plugins/style-agent/skills/inline-style-to-class/SKILL.md
@@ -16,9 +16,23 @@ Every concrete value in the migrated declarations is replaced with a CSS variabl
 
 | Form | Example |
 |---|---|
+| IDE selection | Select an element or style block in your editor, then run `/inline-style-to-class` |
 | HTML inline attribute | `<div style="background: var(--surface-1); padding: 1rem">` |
 | JSX style object | `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` |
 | `<style>` block | `<style>.hero { color: red; padding: 2rem; }</style>` |
+
+### IDE selection detection
+
+When invoked from an IDE (VS Code, JetBrains), Claude Code includes the selected text along with the source file path and line range. The skill detects this by checking for file-context metadata attached to the user's prompt (a file path with a line range and the selected content).
+
+When IDE selection context is present:
+
+1. **Source file** and **line range** are captured for in-place editing in Step 7.
+2. The selected text is used as the input — no pasting or prompt content needed.
+3. If the selection is a full element (e.g. `<div style="..." class="existing">`), the element tag and existing classes are preserved during refactoring.
+4. If the selection is only a `style` attribute value (e.g. `background: red; padding: 1rem`), it is treated as an HTML inline attribute without element context.
+
+When no IDE selection context is detected, the skill falls back to parsing the input from the user's prompt text (the existing behavior).
 
 ---
 
@@ -121,7 +135,8 @@ When no existing variable matches, create one:
 
 ## Workflow
 
-1. **Parse input.** Detect the form of the input:
+1. **Parse input.** Check for IDE selection context first, then fall back to prompt text:
+   - **IDE selection** — if the user's prompt includes file-context metadata (source path + line range + selected text), use the selected text as input and record the source file path and line range for in-place editing in step 7. Determine the form (HTML attribute, JSX object, or `<style>` block) from the selected content using the same detection rules below.
    - **HTML inline attribute** — match `style="..."` or `style='...'`; split on `;`; trim; parse `property: value` pairs. Extract the surrounding element tag if present.
    - **JSX style object** — match `style={{...}}`; extract the object literal body; split key/value pairs. Convert each camelCase key to kebab-case (insert `-` before each uppercase letter, then lowercase the whole key). For numeric literal values, emit a coercion warning: "numeric value — verify unit". For any value that is a JS expression (not a string or number literal), emit a `/* unresolved: <expr> */` placeholder.
    - **`<style>` block** — extract content between `<style>` and `</style>`; parse rules. If one rule, use its declarations. If multiple rules, ask via `AskUserQuestion`: merge all declarations or pick a specific rule.
@@ -146,10 +161,12 @@ When no existing variable matches, create one:
    - **HTML** — remove the `style="..."` attribute entirely if all declarations migrated; if some were unresolved, keep only unmigrated declarations in the attribute. Add the new class to any existing `class` attribute (append to the list); if none exists, add `class="<name>"`. Preserve all other attributes unchanged (`data-*`, `id`, `aria-*`).
    - **JSX** — same logic using `className`. For partially-migrated objects, preserve remaining key/value pairs in the style prop.
    - **`<style>` block** — emit a comment noting the rule was extracted: `/* rule moved to .<name> in <stylesheet path> */`; do not rewrite the `<style>` block automatically.
+   - **In-place editing (IDE selection).** When the source file path and line range were captured in step 1, use `Edit` to replace the original selected text in the source file with the refactored version. This removes the inline style and adds the class reference directly in the user's file — no manual copy-paste needed. If the edit would be ambiguous (the selected text appears more than once in the file), fall back to emitting the refactored source in chat and note which file and line to update.
 
 8. **Print a summary:**
    - Class name chosen, whether it was provided or auto-generated, and any coercion warnings.
    - Target stylesheet path and confirmation that the class was appended (or a note if no file was found).
+   - Source file edited in-place (if IDE selection was used) — show the file path and confirmation, or note that the refactored source was emitted to chat instead.
    - Number of declarations migrated.
    - Variables reused: each `value → --name` that matched an existing variable.
    - Variables created: each `--name: value` and the file it was declared in.

--- a/plugins/style-agent/skills/inline-style-to-class/SKILL.md
+++ b/plugins/style-agent/skills/inline-style-to-class/SKILL.md
@@ -29,8 +29,8 @@ When IDE selection context is present:
 
 1. **Source file** and **line range** are captured for in-place editing in Step 7.
 2. The selected text is used as the input — no pasting or prompt content needed.
-3. If the selection is a full element (e.g. `<div style="..." class="existing">`), the element tag and existing classes are preserved during refactoring.
-4. If the selection is only a `style` attribute value (e.g. `background: red; padding: 1rem`), it is treated as an HTML inline attribute without element context.
+3. If the selection is a full element (e.g. `<div style="..." class="existing">`), the element tag and existing classes are preserved during refactoring. In-place editing is enabled — the skill can safely remove the `style` attribute and add the `class` reference.
+4. If the selection is only a `style` attribute value (e.g. `background: red; padding: 1rem`) without the enclosing element tag, the skill uses `Read` to load the surrounding lines from the source file and expand context to the full containing element. If expansion succeeds, the full element is used for in-place editing. If the element boundary cannot be determined (e.g. the tag spans many lines or is ambiguous), in-place editing is disabled for this invocation — the refactored source is emitted to chat instead, and the summary notes which file and line to update manually.
 
 When no IDE selection context is detected, the skill falls back to parsing the input from the user's prompt text (the existing behavior).
 


### PR DESCRIPTION
## Summary

- Adds IDE selection (VS Code, JetBrains) as a first-class input path for `/inline-style-to-class`
- When text is selected in the editor, the skill detects file-context metadata, uses the selection as input, and edits the source file in-place — replacing the inline style with the new class reference
- Falls back to the existing prompt-text parsing when no selection context is present

## Changes

**SKILL.md** (`plugins/style-agent/skills/inline-style-to-class/`):
- IDE selection added to the Input Forms table as the top entry
- New "IDE selection detection" subsection specifying how file-context metadata (path + line range) is captured and used
- Step 1 (Parse input) checks for IDE selection context before falling back to prompt text
- Step 7 (Emit refactored source) gains an in-place editing path that uses `Edit` on the source file, with a uniqueness fallback to chat output
- Step 8 (Print summary) reports whether the source file was edited in-place

**Command file** (`plugins/style-agent/commands/inline-style-to-class.md`):
- One-line note added so users discover the IDE selection workflow

## Test plan

- [ ] Select an HTML element with `style="..."` in VS Code, run `/inline-style-to-class`, verify the selection is used as input and the source file is edited in-place
- [ ] Select a JSX element with `style={{...}}` in JetBrains, run `/inline-style-to-class btn`, verify the named class is generated and the source file updated
- [ ] Run `/inline-style-to-class` from the CLI (no IDE) with pasted input — verify the existing prompt-text flow still works unchanged
- [ ] Select text that appears multiple times in a file — verify the skill falls back to chat output instead of an ambiguous edit

:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved `/inline-style-to-class` docs to support IDE selection: users can select an element or style block in their editor, run the command, and have a named class generated and applied directly in the source file. Workflow details added for detecting IDE selection, performing in-place edits when possible, handling ambiguous cases by emitting refactored output, and confirming edit outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->