### PR TITLE
docs(plans): reviewed plan for popover anchor positioning

### DIFF
--- a/docs/plans/add-popover-anchor-positioning.html
+++ b/docs/plans/add-popover-anchor-positioning.html
@@ -1,0 +1,1876 @@
+<!DOCTYPE html>
+<html lang="en" data-status="todo" data-effort="high">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="plan-status" content="todo">
+<meta name="plan-effort" content="high">
+<meta name="plan-type" content="feature">
+<meta name="plan-created" content="2026-07-07">
+<meta name="plan-repo" content="agentic-acss-plugins">
+<meta name="plan-file" content="add-popover-anchor-positioning.html">
+<meta name="plan-path" content="docs/plans/add-popover-anchor-positioning.html">
+<meta name="plan-implement" content="Read and implement all steps in the plan at docs/plans/add-popover-anchor-positioning.html — Add CSS anchor positioning + dropdown/tooltip presets to component-popover">
+<meta name="plan-goal" content="Achieve this goal: Add CSS anchor positioning + tooltip/menu role presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome">
+<title>Plan: Enhance component-popover with anchor positioning + dropdown/tooltip presets</title>
+<style>
+  /* ── Design tokens ─────────────────────────────────────────────── */
+  :root {
+    --bg:         #ffffff;
+    --surface:    #ffffff;
+    --border:     #e5e7eb;
+    --border-mid: #d1d5db;
+    --text:       #111827;
+    --muted:      #6b7280;
+    --subtle:     #9ca3af;
+    --accent:     #2563eb;
+    --accent-bg:  #eff6ff;
+    --green:      #16a34a;
+    --green-bg:   #f0fdf4;
+    --green-border:#bbf7d0;
+    --amber:      #d97706;
+    --amber-bg:   #fffbeb;
+    --amber-border:#fde68a;
+    --red:        #dc2626;
+    --red-bg:     #fef2f2;
+    --red-border: #fecaca;
+    --purple:     #a21caf;
+    --purple-bg:  #fdf4ff;
+    --purple-border:#f0abfc;
+    --grey-bg:    #f9fafb;
+    --wish-bg:    #fdf8ff;
+    --wish-border:#d8b4fe;
+    --radius:     4px;
+    --shadow:     0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+  }
+
+  /* ── Reset & base ──────────────────────────────────────────────── */
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--text);
+    background: var(--bg);
+  }
+  a { color: var(--accent); }
+  code, pre {
+    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, monospace;
+    font-size: .875em;
+  }
+  pre {
+    background: var(--grey-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: .75rem 1rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  /* ── SVG icon helper ────────────────────────────────────────────── */
+  .icon {
+    width: 1rem;
+    height: 1rem;
+    display: inline-block;
+    vertical-align: middle;
+    flex-shrink: 0;
+  }
+
+  /* ── Skip link ─────────────────────────────────────────────────── */
+  .skip-link {
+    position: absolute;
+    left: -9999px; top: auto;
+    width: 1px; height: 1px;
+    overflow: hidden;
+  }
+  .skip-link:focus {
+    position: fixed;
+    left: 1rem; top: 1rem;
+    width: auto; height: auto;
+    overflow: visible;
+    background: var(--accent);
+    color: #fff;
+    padding: .5rem 1rem;
+    border-radius: var(--radius);
+    font-weight: 700;
+    z-index: 9999;
+    text-decoration: none;
+  }
+
+  /* ── Header — document cover ────────────────────────────────────── */
+  .plan-header {
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    padding: 0;
+  }
+  .plan-header::before {
+    content: "";
+    display: block;
+    height: 3px;
+    background: var(--accent);
+  }
+  .plan-header-inner {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 1.75rem 1.5rem 1.5rem;
+  }
+  .plan-doc-type {
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: .6rem;
+  }
+  .plan-header-top {
+    display: block;
+  }
+  .plan-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: -.025em;
+    line-height: 1.2;
+    color: var(--text);
+  }
+  .plan-header-actions {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    flex-wrap: wrap;
+    margin-top: .75rem;
+  }
+
+  /* Status badge */
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    padding: .25rem .75rem;
+    border-radius: 999px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    color: #fff;
+  }
+  .status-badge::before {
+    content: "";
+    display: inline-block;
+    width: .45em;
+    height: .45em;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+  [data-status="todo"]        .status-badge { background: #6b7280; }
+  [data-status="in-progress"] .status-badge { background: #d97706; }
+  [data-status="completed"]   .status-badge { background: #16a34a; }
+
+  /* Effort badge — color tracks the data-effort attribute, mirroring .status-badge */
+  .effort-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    font-size: .7rem;
+    font-weight: 700;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    padding: .25rem .75rem;
+    border-radius: 999px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    color: #fff;
+  }
+  .effort-badge::before { content: "Effort "; opacity: .7; }
+  [data-effort="low"]    .effort-badge { background: #16a34a; }
+  [data-effort="medium"] .effort-badge { background: #d97706; }
+  [data-effort="high"]   .effort-badge { background: #dc2626; }
+
+  @keyframes pulse-dot { 0%, 100% { opacity: 1; } 50% { opacity: .3; } }
+  [data-status="in-progress"] .status-badge::before {
+    animation: pulse-dot 1.4s ease-in-out infinite;
+  }
+
+  /* Save as PDF button */
+  .save-pdf-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .4rem 1rem;
+    font-size: .8rem;
+    font-weight: 600;
+    color: #fff;
+    background: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    line-height: 1.4;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: filter .15s, box-shadow .15s;
+  }
+  .save-pdf-btn:hover { filter: brightness(.85); box-shadow: 0 2px 6px rgba(0,0,0,.2); }
+  .save-pdf-btn:active { filter: brightness(.75); }
+  .save-pdf-btn:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
+  @media (prefers-reduced-motion: reduce) { .save-pdf-btn { transition: none; } }
+
+  /* Meta row */
+  .plan-meta {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: .8rem;
+    color: var(--muted);
+  }
+  .plan-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+  }
+  .plan-meta .icon { opacity: .55; }
+
+  /* ── Layout ────────────────────────────────────────────────────── */
+  .layout {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 3rem;
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 5rem;
+    align-items: start;
+  }
+  @media (max-width: 720px) {
+    .layout { grid-template-columns: 1fr; padding: 1.5rem .75rem 4rem; gap: 0; }
+  }
+
+  /* ── Sidebar — table of contents ───────────────────────────────── */
+  .plan-nav {
+    position: sticky;
+    top: 1.5rem;
+    align-self: start;
+    overflow: hidden;
+  }
+  @media (max-width: 720px) {
+    .plan-nav {
+      position: static;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 1.5rem;
+      margin-bottom: 2rem;
+    }
+  }
+  .nav-heading {
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--subtle);
+    padding: 0 1rem .6rem;
+    margin-bottom: .25rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .scroll-rail {
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 2px;
+    background: var(--border);
+    border-radius: 1px;
+    overflow: hidden;
+    pointer-events: none;
+  }
+  .scroll-rail::after {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: calc(var(--scroll-pct, 0) * 1%);
+    background: var(--accent);
+    transition: height .1s linear;
+  }
+  @media (prefers-reduced-motion: reduce) { .scroll-rail::after { transition: none; } }
+  .plan-nav ul { list-style: none; padding: 0; margin: 0; }
+  .plan-nav li a {
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: .125rem 1rem .125rem 1.25rem;
+    font-size: .825rem;
+    color: var(--muted);
+    text-decoration: none;
+    gap: .5rem;
+    border-left: 2px solid transparent;
+    transition: color .12s, border-color .12s;
+  }
+  .plan-nav li a:hover { color: var(--text); border-left-color: var(--border-mid); }
+  .plan-nav li a.active { color: var(--accent); font-weight: 600; border-left-color: var(--accent); }
+  .plan-nav li a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .plan-nav .icon { opacity: .5; }
+  .plan-nav li a.active .icon,
+  .plan-nav li a:hover .icon { opacity: .8; }
+
+  /* ── Objective card — executive summary ────────────────────────── */
+  .objective-card {
+    background: var(--accent-bg);
+    border: 1px solid #bfdbfe;
+    border-left: 4px solid var(--accent);
+    border-radius: var(--radius);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 2.5rem;
+    font-size: 1.05rem;
+    font-weight: 500;
+    color: #1e3a5f;
+    line-height: 1.6;
+  }
+  .objective-card .section-label {
+    font-size: .65rem;
+    font-weight: 700;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: .5rem;
+  }
+
+  /* ── Progress bar ──────────────────────────────────────────────── */
+  .progress-wrap {
+    margin-bottom: 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: .6rem;
+    font-size: .75rem;
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+  }
+  .progress-bar-bg { height: 6px; background: var(--border); border-radius: 999px; overflow: hidden; }
+  @keyframes shimmer { 0% { background-position: 200% center; } 100% { background-position: -200% center; } }
+  .progress-bar-fill {
+    height: 100%;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--accent), #60a5fa, var(--accent));
+    background-size: 200% 100%;
+    animation: shimmer 2.5s linear infinite;
+    transition: width .5s cubic-bezier(.4,0,.2,1);
+    width: 0%;
+  }
+  .progress-bar-fill.has-progress { animation: none; background: var(--accent); }
+  @media (prefers-reduced-motion: reduce) {
+    .progress-bar-fill { animation: none; transition: none; }
+  }
+
+  /* ── Document sections ─────────────────────────────────────────── */
+  .section-card {
+    background: transparent;
+    border: none;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+    padding: 2rem 0 1.25rem;
+    margin-bottom: 0;
+    box-shadow: none;
+  }
+  .section-card:first-of-type { border-top: none; }
+  .section-card h2 {
+    font-size: .9rem;
+    font-weight: 700;
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+  }
+  .section-card h2 .icon { opacity: .6; }
+  .section-card p { margin-bottom: .75rem; color: var(--text); }
+  .section-card p:last-child { margin-bottom: 0; }
+  .section-card ul, .section-card ol {
+    padding-left: 1.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+  }
+
+  /* ── Step timeline ──────────────────────────────────────────────── */
+  .steps-list {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+    position: relative;
+  }
+  .steps-list::before {
+    content: "";
+    position: absolute;
+    left: .9rem;
+    top: 1.75rem;
+    bottom: 1.75rem;
+    width: 1px;
+    background: var(--border);
+  }
+
+  /* ── Step cards ────────────────────────────────────────────────── */
+  .step-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    box-shadow: var(--shadow);
+    position: relative;
+    margin-left: 2.25rem;
+    transition: border-color .15s;
+  }
+  .step-card:hover { border-color: var(--border-mid); }
+  @media (prefers-reduced-motion: reduce) { .step-card { transition: none; } }
+  .step-card::before {
+    content: "";
+    position: absolute;
+    left: -1.6rem; top: 1.1rem;
+    width: .75rem; height: .75rem;
+    border-radius: 50%;
+    background: var(--border);
+    border: 2px solid var(--bg);
+    transition: background .15s;
+  }
+  .step-card.completed::before { background: var(--green); }
+  @media (prefers-reduced-motion: reduce) { .step-card::before { transition: none; } }
+
+  .step-card-header { display: flex; align-items: flex-start; gap: .75rem; }
+  .step-number {
+    flex-shrink: 0;
+    width: 1.75rem; height: 1.75rem;
+    background: var(--grey-bg);
+    color: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: .75rem;
+    font-weight: 700;
+    margin-top: .1rem;
+  }
+  .step-card.completed .step-number { background: var(--green-bg); color: var(--green); border-color: #bbf7d0; }
+  .step-body { flex: 1; min-width: 0; }
+  .step-action {
+    font-weight: 600;
+    margin-bottom: .3rem;
+    display: flex;
+    align-items: baseline;
+    gap: .45rem;
+    flex-wrap: wrap;
+    color: var(--text);
+  }
+  .step-chip {
+    display: inline-block;
+    font-size: .6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    padding: .1em .5em;
+    border-radius: 999px;
+    background: var(--grey-bg);
+    color: var(--subtle);
+    border: 1px solid var(--border);
+    vertical-align: middle;
+    user-select: none;
+    flex-shrink: 0;
+  }
+  .step-card.completed .step-chip {
+    background: var(--green-bg);
+    color: var(--green);
+    border-color: #bbf7d0;
+  }
+  .step-chip-text { flex: 1; }
+  .step-why { font-size: .875rem; color: var(--muted); margin-bottom: .4rem; }
+  .step-why::before { content: "Why: "; font-weight: 600; color: var(--text); }
+  .step-verify-toggle {
+    margin-top: .5rem;
+    border: 0;
+    border-top: 1px solid var(--border);
+    padding-top: .4rem;
+  }
+  .step-verify-toggle summary {
+    font-size: .8rem;
+    font-weight: 600;
+    color: var(--accent);
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: .35rem;
+    user-select: none;
+  }
+  .step-verify-toggle summary::before { content: "▶"; font-size: .55em; transition: transform .2s; }
+  .step-verify-toggle[open] summary::before { transform: rotate(90deg); }
+  .step-verify-toggle .verify-body {
+    font-size: .875rem;
+    color: var(--text);
+    margin-top: .4rem;
+    padding-left: .5rem;
+    border-left: 2px solid var(--accent);
+  }
+  @media (prefers-reduced-motion: reduce) { .step-verify-toggle summary::before { transition: none; } }
+
+  /* ── Acceptance criteria ───────────────────────────────────────── */
+  .criteria-list {
+    list-style: none; padding: 0;
+    display: flex; flex-direction: column; gap: .6rem;
+  }
+  .criteria-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: .75rem;
+    padding: .6rem .75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    transition: background .12s;
+  }
+  .criteria-list li:has(input:checked) { background: var(--grey-bg); }
+  .criteria-list input[type="checkbox"] {
+    flex-shrink: 0;
+    width: 1rem; height: 1rem;
+    margin-top: .2rem;
+    accent-color: var(--green);
+    cursor: pointer;
+  }
+  .criteria-list label { cursor: pointer; font-size: .9rem; }
+  .criteria-list input:checked + label { text-decoration: line-through; color: var(--muted); }
+
+  /* ── Completion checklist ────────────────────────────────────── */
+  .completion-checklist {
+    background: var(--surface);
+    border: 2px solid var(--amber);
+    border-radius: var(--radius);
+    padding: 1.25rem 1.5rem;
+    margin-top: 1rem;
+  }
+  .completion-checklist.all-complete { border-color: var(--green); }
+  .completion-header {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    margin-bottom: 1rem;
+  }
+  .completion-badge {
+    font-size: .6rem;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    padding: .15rem .6rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: var(--amber);
+    border: 1px solid #fde68a;
+  }
+  .completion-checklist.all-complete .completion-badge {
+    background: var(--green-bg);
+    color: var(--green);
+    border-color: #bbf7d0;
+  }
+  .completion-list {
+    list-style: none; padding: 0;
+    display: flex; flex-direction: column; gap: .6rem;
+  }
+  .completion-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: .75rem;
+    padding: .6rem .75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    transition: background .12s;
+  }
+  .completion-list li:has(input:checked) { background: var(--grey-bg); }
+  .completion-list input[type="checkbox"] {
+    flex-shrink: 0;
+    width: 1rem; height: 1rem;
+    margin-top: .2rem;
+    accent-color: var(--green);
+  }
+  .completion-list label { font-size: .9rem; }
+  .completion-list input:checked + label { text-decoration: line-through; color: var(--muted); }
+  @media (prefers-reduced-motion: reduce) {
+    .completion-list li { transition: none; }
+  }
+
+  /* ── Completion report ─────────────────────────────────────── */
+  .completion-report {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+  }
+  .report-heading {
+    font-size: .75rem;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: .75rem;
+  }
+  .report-empty {
+    font-style: italic;
+    color: var(--subtle);
+    font-size: .875rem;
+  }
+  .report-list { margin: 0; padding: 0; }
+  .report-list dt {
+    font-weight: 600;
+    color: var(--text);
+    font-size: .875rem;
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    margin-top: .75rem;
+  }
+  .report-list dt:first-child { margin-top: 0; }
+  .report-list dt::before {
+    content: "";
+    display: inline-block;
+    width: .5rem; height: .5rem;
+    border-radius: 50%;
+    background: #dc2626;
+    flex-shrink: 0;
+  }
+  .report-list dd {
+    color: var(--muted);
+    font-size: .85rem;
+    margin-left: .9rem;
+    margin-top: .2rem;
+    margin-bottom: 0;
+  }
+
+  /* ── Next steps ────────────────────────────────────────────────── */
+  .next-steps-list { padding: 0; display: flex; flex-direction: column; gap: .75rem; }
+  .next-step-item {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--surface);
+  }
+  .next-step-item summary {
+    font-weight: 600;
+    font-size: .9rem;
+    padding: .75rem 1rem;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    background: var(--surface);
+    user-select: none;
+    min-height: 44px;
+  }
+  .next-step-item summary::before { content: "▶"; font-size: .55em; color: var(--subtle); transition: transform .2s; }
+  .next-step-item[open] summary::before { transform: rotate(90deg); }
+  .next-step-prompt { padding: .75rem 1rem 1rem; background: var(--grey-bg); border-top: 1px solid var(--border); }
+  .next-step-prompt p { font-size: .8rem; color: var(--muted); margin-bottom: .5rem; }
+  .next-step-prompt pre { margin: 0; }
+  @media (prefers-reduced-motion: reduce) { .next-step-item summary::before { transition: none; } }
+
+  /* ── Copy prompt button ─────────────────────────────────────── */
+  .copy-prompt-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    margin-top: .6rem;
+    padding: .3rem .75rem;
+    font-size: .775rem;
+    font-weight: 500;
+    color: var(--accent);
+    background: var(--accent-bg);
+    border: 1px solid #bfdbfe;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background .12s, color .12s, border-color .12s;
+    font-family: inherit;
+    line-height: 1.4;
+  }
+  .copy-prompt-btn:hover { background: #dbeafe; border-color: var(--accent); }
+  .copy-prompt-btn:active { background: #bfdbfe; }
+  .copy-prompt-btn.copied { color: var(--green); background: var(--green-bg); border-color: #bbf7d0; }
+  .copy-prompt-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  @media print { .copy-prompt-btn { display: none !important; } }
+  @media (prefers-reduced-motion: reduce) { .copy-prompt-btn { transition: none; } }
+  /* Shared clipboard-failure state for every copy button */
+  .copy-failed { color: var(--red) !important; background: var(--red-bg) !important; border-color: var(--red-border) !important; white-space: normal; }
+
+  /* Wish list variant */
+  .wish-list-header {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: #7c3aed;
+    margin: 1.5rem 0 .75rem;
+  }
+  .wish-list-header::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--wish-border);
+    opacity: .5;
+  }
+  .wish-item { border: 1px dashed var(--wish-border) !important; background: var(--wish-bg) !important; }
+  .wish-item summary { background: var(--wish-bg) !important; color: #6d28d9; }
+  .wish-badge {
+    font-size: .6rem;
+    background: #f3e8ff;
+    color: #6d28d9;
+    padding: .1rem .5rem;
+    border-radius: 999px;
+    font-weight: 700;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    margin-left: auto;
+    border: 1px solid #ddd6fe;
+  }
+
+  /* ── Collapsible optional sections ─────────────────────────────── */
+  .optional-section {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-top: 1.5rem;
+    overflow: hidden;
+    background: var(--surface);
+  }
+  .optional-section > summary {
+    padding: .875rem 1.25rem;
+    font-weight: 600;
+    font-size: .9rem;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    user-select: none;
+    min-height: 44px;
+  }
+  .optional-section > summary::before { content: "▶"; font-size: .55em; color: var(--subtle); transition: transform .2s; }
+  .optional-section[open] > summary::before { transform: rotate(90deg); }
+  .optional-body { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--border); padding-top: 1rem; }
+  .unresolved-list { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 1rem; }
+  .unresolved-item summary { font-weight: 600; padding: .35rem 0; cursor: pointer; list-style: none; user-select: none; font-size: .9rem; }
+  .unresolved-prompt { margin-top: .5rem; }
+  @media (prefers-reduced-motion: reduce) { .optional-section > summary::before { transition: none; } }
+
+  /* ── Implement prompt ─────────────────────────────────────────── */
+  .plan-implement {
+    display: flex;
+    align-items: flex-start;
+    gap: .6rem;
+    margin-bottom: 1.5rem;
+    padding: .45rem .75rem;
+    background: var(--green-bg);
+    border: 1px solid #bbf7d0;
+    border-radius: var(--radius);
+    font-size: .8rem;
+  }
+  .plan-implement-label {
+    font-size: .65rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--green);
+    flex-shrink: 0;
+    margin-top: .1rem;
+  }
+  .plan-implement code {
+    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, monospace;
+    font-size: .82rem;
+    color: var(--text);
+    flex: 1;
+    word-break: break-all;
+  }
+  .copy-cmd-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    padding: .2rem .6rem;
+    font-size: .72rem;
+    font-weight: 500;
+    color: var(--muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background .12s, color .12s, border-color .12s;
+    font-family: inherit;
+    line-height: 1.4;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .copy-cmd-btn:hover { background: var(--accent-bg); color: var(--accent); border-color: #bfdbfe; }
+  .copy-cmd-btn.copied { color: var(--green); background: var(--green-bg); border-color: #bbf7d0; }
+  .copy-cmd-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  [data-status="completed"] .copy-cmd-btn { display: none; }
+  @media print { .plan-implement { display: none !important; } }
+  @media (prefers-reduced-motion: reduce) { .copy-cmd-btn { transition: none; } }
+
+  /* ── Plan source (file name + relative path) ──────────────────── */
+  .plan-source {
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+    margin: -.5rem 0 1.5rem;
+    padding: .55rem .75rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: .8rem;
+  }
+  .plan-source-row { display: flex; align-items: center; gap: .6rem; }
+  .plan-source-label {
+    font-size: .65rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    flex-shrink: 0;
+    width: 2.4rem;
+  }
+  .plan-source code {
+    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, monospace;
+    font-size: .82rem;
+    color: var(--text);
+    flex: 1;
+    word-break: break-all;
+  }
+  .copy-src-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    padding: .2rem .6rem;
+    font-size: .72rem;
+    font-weight: 500;
+    color: var(--muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background .12s, color .12s, border-color .12s;
+    font-family: inherit;
+    line-height: 1.4;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .copy-src-btn:hover { background: var(--accent-bg); color: var(--accent); border-color: #bfdbfe; }
+  .copy-src-btn.copied { color: var(--green); background: var(--green-bg); border-color: #bbf7d0; }
+  .copy-src-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  @media print { .copy-src-btn { display: none !important; } }
+  @media (prefers-reduced-motion: reduce) { .copy-src-btn { transition: none; } }
+
+  /* ── Goal prompt (outcome-driven — always present) ────────────── */
+  .plan-goal {
+    margin: -.5rem 0 1.5rem;
+    font-size: .8rem;
+  }
+  .plan-goal summary {
+    font-size: .7rem;
+    font-weight: 600;
+    color: var(--purple);
+    cursor: pointer;
+    padding: .25rem 0;
+    user-select: none;
+  }
+  .plan-goal summary:hover { text-decoration: underline; }
+  .plan-goal-inner {
+    display: flex;
+    align-items: flex-start;
+    gap: .6rem;
+    margin-top: .4rem;
+    padding: .45rem .75rem;
+    background: var(--purple-bg);
+    border: 1px solid var(--purple-border);
+    border-radius: var(--radius);
+  }
+  .plan-goal code {
+    font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, monospace;
+    font-size: .82rem;
+    color: var(--text);
+    flex: 1;
+    word-break: break-all;
+  }
+  .copy-goal-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    padding: .2rem .6rem;
+    font-size: .72rem;
+    font-weight: 500;
+    color: var(--muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background .12s, color .12s, border-color .12s;
+    font-family: inherit;
+    line-height: 1.4;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .copy-goal-btn:hover { background: var(--accent-bg); color: var(--accent); border-color: #bfdbfe; }
+  .copy-goal-btn.copied { color: var(--green); background: var(--green-bg); border-color: #bbf7d0; }
+  .copy-goal-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  [data-status="completed"] .plan-goal { display: none; }
+  @media print { .plan-goal { display: none !important; } }
+  @media (prefers-reduced-motion: reduce) { .copy-goal-btn { transition: none; } }
+
+  /* ── Tests section ──────────────────────────────────────────────── */
+  .test-list {
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+  }
+  .test-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    box-shadow: var(--shadow);
+  }
+  .test-card-header {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    margin-bottom: .5rem;
+    flex-wrap: wrap;
+  }
+  .test-badge {
+    display: inline-block;
+    font-size: .6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    padding: .15em .55em;
+    border-radius: 999px;
+    flex-shrink: 0;
+  }
+  .test-badge-unit        { background: var(--accent-bg); color: var(--accent); border: 1px solid #bfdbfe; }
+  .test-badge-integration { background: var(--amber-bg);  color: var(--amber);  border: 1px solid var(--amber-border); }
+  .test-badge-e2e         { background: var(--purple-bg);  color: var(--purple);  border: 1px solid var(--purple-border); }
+  .test-badge-objective   { background: var(--green-bg);  color: var(--green);  border: 1px solid var(--green-border); }
+  .test-card-title {
+    font-weight: 600;
+    font-size: .95rem;
+    color: var(--text);
+    flex: 1;
+  }
+  .test-card-body { font-size: .875rem; color: var(--muted); }
+  .test-card-body p { margin-bottom: .4rem; }
+  .test-card-body p:last-child { margin-bottom: 0; }
+  .test-card-body code { font-size: .85em; }
+  .test-card-body strong { color: var(--text); font-weight: 600; }
+  .test-tier-label {
+    font-size: .68rem;
+    font-weight: 700;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: .75rem;
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+  }
+  .test-tier-label::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+  }
+  .objective-test-card {
+    background: var(--green-bg);
+    border: 1px solid var(--green-border);
+    border-left: 4px solid var(--green);
+    border-radius: var(--radius);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+    box-shadow: var(--shadow);
+  }
+  .objective-test-card .test-card-header { margin-bottom: .6rem; }
+  .objective-test-card .test-card-title { color: #14532d; }
+  .objective-test-card .test-card-body { color: #166534; }
+  .objective-test-card .test-card-body strong { color: #14532d; }
+  /* ── Footer ────────────────────────────────────────────────────── */
+  .plan-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .4rem;
+    font-size: .75rem;
+    color: var(--subtle);
+    margin-top: 3rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+  .plan-footer .icon { opacity: .35; }
+
+  /* ── Focus styles ───────────────────────────────────────────────── */
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* ── Print styles ───────────────────────────────────────────────── */
+  @media print {
+    .plan-nav, .scroll-rail, .progress-wrap, .save-pdf-btn { display: none !important; }
+    .layout { display: block !important; }
+    .step-card, .section-card { box-shadow: none !important; break-inside: avoid; }
+    .step-chip { display: none !important; }
+    a[href]::after { content: " (" attr(href) ")"; font-size: .8em; }
+  }
+
+  /* ── Files file-tree ────────────────────────────────────────────── */
+  .file-tree { font-family: ui-monospace, "SF Mono", "Fira Code", Consolas, monospace; font-size: .85rem; }
+  .file-tree-root { font-weight: 700; color: var(--text); margin-bottom: .5rem; display: flex; align-items: center; gap: .35rem; }
+  .file-list, .file-list ul { list-style: none; padding-left: 1.25rem; margin: 0; border-left: 1px dashed var(--border); }
+  .file-list li { padding: .2rem 0; display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; color: var(--muted); }
+  .file-list li.file-dir { color: var(--text); font-weight: 600; }
+  .file-list li.file-dir > ul { flex-basis: 100%; }
+  .file-badge { font-size: .6rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; padding: .1em .45em; border-radius: 999px; }
+  .file-badge-new       { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+  .file-badge-modified  { background: var(--amber-bg); color: var(--amber); border: 1px solid var(--amber-border); }
+  .file-badge-deleted   { background: var(--red-bg);   color: var(--red);   border: 1px solid var(--red-border); }
+  .file-badge-generated { background: var(--accent-bg); color: var(--accent); border: 1px solid #bfdbfe; }
+  .file-note { font-size: .75rem; color: var(--subtle); font-style: italic; font-family: system-ui, sans-serif; }
+
+  /* ── Data table ─────────────────────────────────────────────────── */
+  .plan-table { width: 100%; border-collapse: collapse; font-size: .85rem; margin-top: .5rem; }
+  .plan-table caption { text-align: left; font-size: .78rem; color: var(--subtle); font-style: italic; margin-bottom: .5rem; }
+  .plan-table th, .plan-table td { text-align: left; padding: .5rem .75rem; border: 1px solid var(--border); vertical-align: top; }
+  .plan-table thead th { background: var(--grey-bg); font-weight: 700; color: var(--muted); text-transform: uppercase; font-size: .66rem; letter-spacing: .05em; }
+  .plan-table tbody tr:nth-child(even) { background: var(--grey-bg); }
+  .plan-table code { font-size: .8em; }
+
+  .diagram-subheading { font-size: .78rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); margin: 1.75rem 0 .75rem; }
+
+  .plan-back-nav { margin-bottom: .5rem; }
+  .plan-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: .3125rem;
+    font-size: .8125rem;
+    color: var(--muted);
+    text-decoration: none;
+    transition: color .15s;
+  }
+  .plan-back-link:hover { color: var(--accent); }
+  .plan-back-link svg { width: 14px; height: 14px; flex-shrink: 0; }
+</style>
+<style id="plan-responsive-fix" data-version="1">
+body { overflow-wrap: anywhere; }
+main, nav, aside { min-width: 0; }
+.layout > *, .wrap > *, .compare-grid > * { min-width: 0; }
+pre { white-space: pre-wrap; max-width: 100%; }
+table { max-width: 100%; }
+img, video { max-width: 100%; height: auto; }
+@media (max-width: 600px) { .compare-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none" aria-hidden="true">
+  <symbol id="ic-bolt" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"/></symbol>
+  <symbol id="ic-chart-bar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></symbol>
+  <symbol id="ic-document-text" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"/></symbol>
+  <symbol id="ic-folder" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"/></symbol>
+  <symbol id="ic-list-bullet" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"/></symbol>
+  <symbol id="ic-check-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></symbol>
+  <symbol id="ic-magnifying-glass" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/></symbol>
+  <symbol id="ic-arrow-right-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12.75 15 3-3m0 0-3-3m3 3h-7.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></symbol>
+  <symbol id="ic-calendar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"/></symbol>
+  <symbol id="ic-code-bracket" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"/></symbol>
+  <symbol id="ic-tag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3Z"/><path d="M6 6h.008v.008H6V6Z"/></symbol>
+  <symbol id="ic-sparkles" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 0 0-2.456 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"/></symbol>
+  <symbol id="ic-clipboard-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11.35 3.836c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15a2.25 2.25 0 0 1 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m8.9-4.414c.376.023.75.05 1.124.08 1.131.094 1.976 1.057 1.976 2.192V16.5A2.25 2.25 0 0 1 18 18.75h-2.25m-7.5-10.5H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V18.75m-7.5-10.5h6.375c.621 0 1.125.504 1.125 1.125v9.375m-8.25-3 1.5 1.5 3-3.75"/></symbol>
+  <symbol id="ic-beaker" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"/></symbol>
+</svg>
+
+<a href="#main" class="skip-link">Skip to content</a>
+
+<header class="plan-header">
+  <div class="plan-header-inner">
+    <div class="plan-back-nav">
+      <a href="./index.html" class="plan-back-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"/></svg>
+        Plans
+      </a>
+    </div>
+    <div class="plan-doc-type">Implementation Plan</div>
+    <div class="plan-header-top">
+      <h1 class="plan-title">Enhance component-popover with anchor positioning + dropdown/tooltip presets</h1>
+      <div class="plan-header-actions">
+        <button class="save-pdf-btn" type="button" onclick="savePDF()" aria-label="Save this plan as PDF">Save as PDF</button>
+        <span class="effort-badge" aria-label="Effort level">High</span>
+        <span class="status-badge">todo</span>
+      </div>
+    </div>
+    <div class="plan-meta">
+      <span><svg class="icon" aria-hidden="true"><use href="#ic-calendar"/></svg> 2026-07-07</span>
+      <span><svg class="icon" aria-hidden="true"><use href="#ic-code-bracket"/></svg> agentic-acss-plugins</span>
+      <span><svg class="icon" aria-hidden="true"><use href="#ic-tag"/></svg> feature</span>
+      <span><svg class="icon" aria-hidden="true"><use href="#ic-bolt"/></svg> High effort</span>
+    </div>
+  </div>
+</header>
+
+<div class="layout">
+
+  <nav class="plan-nav" aria-label="Plan sections">
+    <div class="scroll-rail" aria-hidden="true"></div>
+    <div class="nav-heading">On this page</div>
+    <ul>
+      <li><a href="#objective"><svg class="icon" aria-hidden="true"><use href="#ic-bolt"/></svg> Objective</a></li>
+      <li><a href="#progress"><svg class="icon" aria-hidden="true"><use href="#ic-chart-bar"/></svg> Progress</a></li>
+      <li><a href="#context"><svg class="icon" aria-hidden="true"><use href="#ic-document-text"/></svg> Context</a></li>
+      <li><a href="#files"><svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg> Files</a></li>
+      <li><a href="#diagram"><svg class="icon" aria-hidden="true"><use href="#ic-chart-bar"/></svg> Diagram</a></li>
+      <li><a href="#steps"><svg class="icon" aria-hidden="true"><use href="#ic-list-bullet"/></svg> Steps</a></li>
+      <li><a href="#tests"><svg class="icon" aria-hidden="true"><use href="#ic-beaker"/></svg> Tests</a></li>
+      <li><a href="#criteria"><svg class="icon" aria-hidden="true"><use href="#ic-check-circle"/></svg> Criteria</a></li>
+      <li><a href="#verification"><svg class="icon" aria-hidden="true"><use href="#ic-magnifying-glass"/></svg> Verification</a></li>
+      <li><a href="#completion"><svg class="icon" aria-hidden="true"><use href="#ic-clipboard-check"/></svg> Completion</a></li>
+      <li><a href="#next-steps"><svg class="icon" aria-hidden="true"><use href="#ic-arrow-right-circle"/></svg> Next Steps</a></li>
+    </ul>
+  </nav>
+
+  <main id="main">
+
+    <div class="objective-card" id="objective">
+      <div class="section-label">Objective</div>
+      <p>Tether the popover to its trigger with CSS Anchor Positioning (plus a Firefox fallback) and ship <code>tooltip</code> and <code>menu</code> role presets — so <code>component-popover</code> works for dropdown nav and tooltips, not just centered cards — editing <code>popover.component.md</code> and <code>reference.md</code> in lockstep so the golden parity test stays green.</p>
+    </div>
+
+    <div class="plan-implement">
+      <span class="plan-implement-label">Implement</span>
+      <code id="implement-cmd" aria-label="Implement prompt">Read and implement all steps in the plan at docs/plans/add-popover-anchor-positioning.html — Add CSS anchor positioning + dropdown/tooltip presets to component-popover</code>
+      <button class="copy-cmd-btn" type="button" onclick="copyCmd(this)" aria-label="Copy implement prompt to clipboard">Copy</button>
+    </div>
+
+    <details class="plan-goal">
+      <summary>Pursue as goal — optimize for the outcome</summary>
+      <div class="plan-goal-inner">
+        <code id="goal-cmd" aria-label="Goal prompt">Achieve this goal: Add CSS anchor positioning + tooltip/menu role presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome</code>
+        <button class="copy-goal-btn" type="button" onclick="copyGoal(this)" aria-label="Copy goal prompt to clipboard">Copy</button>
+      </div>
+    </details>
+
+    <div class="plan-source">
+      <div class="plan-source-row">
+        <span class="plan-source-label">File</span>
+        <code id="plan-file" aria-label="Plan file name">add-popover-anchor-positioning.html</code>
+        <button class="copy-src-btn" type="button" onclick="copyPath(this, 'plan-file')" aria-label="Copy plan file name to clipboard">Copy</button>
+      </div>
+      <div class="plan-source-row">
+        <span class="plan-source-label">Path</span>
+        <code id="plan-path" aria-label="Plan relative path">docs/plans/add-popover-anchor-positioning.html</code>
+        <button class="copy-src-btn" type="button" onclick="copyPath(this, 'plan-path')" aria-label="Copy plan relative path to clipboard">Copy</button>
+      </div>
+    </div>
+
+    <div class="progress-wrap" id="progress">
+      <div class="progress-header">
+        <span>Acceptance criteria</span>
+        <span id="progress-label">0 / 11 done</span>
+      </div>
+      <div class="progress-bar-bg">
+        <div class="progress-bar-fill" id="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="Plan progress" style="width:0%"></div>
+      </div>
+    </div>
+
+    <section class="section-card card-context" id="context" aria-labelledby="h-context">
+      <h2 id="h-context">
+        <svg class="icon" aria-hidden="true"><use href="#ic-document-text"/></svg>
+        Context
+      </h2>
+      <p>The repo already ships a native-popover component (<code>plugins/acss-kit/skills/component-popover/</code>) built on the exact HTML Popover API in the reference links — <code>popover</code> attribute + <code>popovertarget</code> + <code>showPopover()</code>/<code>hidePopover()</code>, auto/manual modes, light-dismiss, top-layer. So this is an <strong>enhancement</strong>, not a new build.</p>
+      <p>Reviewing it against the goal ("reusable for dropdown nav and tooltips") surfaced four real gaps: (1) <strong>no real positioning</strong> — the component fakes placement with a <code>data-placement</code> arrow but never tethers the popover, so an <code>auto</code> popover lands in the viewport's top-layer center, broken for a dropdown or tooltip; (2) <strong>no role semantics</strong> — the reference explicitly punts <code>role</code> to the consumer; (3) <strong>no hover/focus open</strong> for tooltips — native <code>popovertarget</code> is click-toggle only; (4) <strong>the arrow doesn't track flips</strong> when <code>position-try</code> repositions the popover.</p>
+      <p><strong>Hard constraint — dual-source parity.</strong> The generator source of truth is the neutral <code>popover.component.md</code>; <code>reference.md</code> is its byte-identical fallback. Every template edit must land in <strong>both files</strong>. The real enforcement (corrected after review): <code>tests/run.sh</code> step 2a diffs the <em>extracted SCSS</em> of both files against the golden fixture <code>tests/fixtures/golden/component-popover/popover.scss</code> — so SCSS drift is caught automatically, but <strong>TSX parity is not</strong> (that guard was deferred), so the TSX-touching steps must be diffed by hand. Editing the SCSS also means the golden fixture has to be regenerated, or <code>tests/run.sh</code> goes red.</p>
+      <p><strong>Browser support</strong> (drives the fallback choice): CSS Anchor Positioning ships in Chrome/Edge 125+ and Safari 26+ but <strong>not yet Firefox</strong>. So anchor positioning is the modern path wrapped in <code>@supports (anchor-name: --a)</code>, with a <code>@supports not (...)</code> fallback that keeps the popover usable where anchoring is absent.</p>
+    </section>
+
+    <section class="section-card card-files" id="files" aria-labelledby="h-files">
+      <h2 id="h-files">
+        <svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg>
+        Files to Modify
+      </h2>
+      <div class="file-tree">
+        <div class="file-tree-root"><svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg> agentic-acss-plugins/</div>
+        <ul class="file-list">
+          <li class="file-dir"><svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg> plugins/acss-kit/skills/component-popover/
+            <ul class="file-list">
+              <li><code>popover.component.md</code> <span class="file-badge file-badge-modified">modified</span> <span class="file-note">neutral source: styles, props, behavior, a11y prose, token table, examples, react adapter</span></li>
+              <li><code>reference.md</code> <span class="file-badge file-badge-modified">modified</span> <span class="file-note">byte-identical fallback templates + docs</span></li>
+              <li><code>SKILL.md</code> <span class="file-badge file-badge-modified">modified</span> <span class="file-note">description + hint for the new role/positioning surface</span></li>
+            </ul>
+          </li>
+          <li class="file-dir"><svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg> plugins/acss-kit/
+            <ul class="file-list">
+              <li><code>.claude-plugin/plugin.json</code> <span class="file-badge file-badge-modified">modified</span> <span class="file-note">version bump — repositioning is a breaking visual change for existing installs</span></li>
+              <li><code>CHANGELOG.md</code> <span class="file-badge file-badge-modified">modified</span> <span class="file-note">note the anchor-positioning behavior change</span></li>
+            </ul>
+          </li>
+          <li class="file-dir"><svg class="icon" aria-hidden="true"><use href="#ic-folder"/></svg> tests/
+            <ul class="file-list">
+              <li><code>fixtures/golden/component-popover/popover.scss</code> <span class="file-badge file-badge-generated">generated</span> <span class="file-note">regenerate after SCSS edits or run.sh golden guard fails</span></li>
+              <li><code>e2e/popover-anchor.spec.ts</code> <span class="file-badge file-badge-new">new</span> <span class="file-note">committed Playwright spec — anchoring, flip, hover, aria-expanded (only layer that evaluates anchor positioning)</span></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section-card card-diagram" id="diagram" aria-labelledby="h-diagram">
+      <h2 id="h-diagram">
+        <svg class="icon" aria-hidden="true"><use href="#ic-chart-bar"/></svg>
+        Diagram
+      </h2>
+
+      <div class="diagram-subheading">Review findings — gap vs. fix</div>
+      <table class="plan-table">
+        <caption>What component-popover is missing today and the fix each step delivers, in priority order.</caption>
+        <thead>
+          <tr>
+            <th scope="col">Gap</th>
+            <th scope="col">Fix</th>
+            <th scope="col">Priority</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>No real positioning — <code>data-placement</code> only draws an arrow; an <code>auto</code> popover lands viewport-center</td>
+            <td>CSS Anchor Positioning (<code>anchor-name</code> / <code>position-anchor</code> / <code>position-area</code> / <code>position-try</code>) + <code>@supports not</code> fallback</td>
+            <td>High</td>
+          </tr>
+          <tr>
+            <td>No role semantics — reference punts <code>role</code> to the consumer</td>
+            <td><code>role="tooltip"</code> (+ <code>aria-describedby</code>) and <code>role="menu"</code> (+ <code>aria-haspopup</code> / <code>aria-expanded</code>) presets</td>
+            <td>High</td>
+          </tr>
+          <tr>
+            <td>Tooltips can't hover-open — native <code>popovertarget</code> is click-only</td>
+            <td>Small hover/focus JS scoped to the tooltip preset; <code>interestfor</code> noted as the future zero-JS path</td>
+            <td>Medium</td>
+          </tr>
+          <tr>
+            <td>Arrow doesn't track <code>position-try</code> flips</td>
+            <td>Anchor the arrow to the same trigger anchor</td>
+            <td>Low</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section-card card-steps" id="steps" aria-labelledby="h-steps">
+      <h2 id="h-steps">
+        <svg class="icon" aria-hidden="true"><use href="#ic-list-bullet"/></svg>
+        Steps
+      </h2>
+      <div class="steps-list">
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">1</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Add positioning tokens + anchor CSS to the <code>## Styles</code> block (both files). Introduce <code>--popover-anchor-gap</code> (with a hardcoded <code>var()</code> fallback per the SCSS convention), map each <code>data-placement</code> to a <code>position-area</code>, wrap the anchored rules in <code>@supports (anchor-name: --a)</code>, and add a <code>@supports not</code> fallback that keeps the current absolute offset. <strong>Per-instance anchoring (review fix):</strong> derive <code>anchor-name</code> on the trigger and <code>position-anchor</code> on the popover from the component's already-generated unique <code>id</code> (via inline style), <em>not</em> a shared class-level name — otherwise multiple popovers on one page (dropdown nav, the headline use case) bind to the wrong trigger. While editing this section, reconcile the SCSS filename mismatch: <code>SKILL.md</code> Step 4 emits <code>popover.module.scss</code> but the Generation Contract says <code>popover.scss</code> — pick one and make all three references agree.</span>
+              </div>
+              <div class="step-why">This is gap #1 — the core value. Anchoring is what makes dropdowns/tooltips sit at their trigger; the <code>@supports</code> split honors the anchor+fallback choice without breaking non-supporting browsers. Per-instance names are required or the anchor resolves to the nearest matching trigger, breaking multi-instance layouts.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Extract the SCSS via <code>tests/run.sh</code>; confirm it compiles, both <code>@supports</code> branches are present, and every new <code>var(--popover-*)</code> has a comma-separated fallback. Diff <code>popover.component.md</code> <code>## Styles</code> against <code>reference.md</code> <code>## SCSS Template</code> — identical. Render two popovers on one page and confirm each anchors to its own trigger.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">2</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Anchor the arrow so it tracks flips (both files). Position <code>.popover-arrow</code> relative to the same anchor inside the <code>@supports</code> block so a <code>flip-block</code>/<code>flip-inline</code> reposition moves the arrow with it; keep the existing <code>data-placement</code> transforms as the fallback-branch behavior.</span>
+              </div>
+              <div class="step-why">Gap #4 — a flipped popover with a wrong-way arrow reads as a bug. Cheap to fix once anchoring exists.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Compile SCSS (no errors). Visual check in the preview: arrow points at the trigger before and after a viewport-edge flip.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">3</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Add a <code>role</code> preset prop to <code>## Props</code> + Props Interface (both files). Default <code>undefined</code> (current behavior). <strong>ARIA corrected after review:</strong> for the dropdown-nav case use the WAI-ARIA <em>Disclosure Navigation</em> pattern — trigger with <code>aria-expanded</code> over a plain <code>&lt;ul&gt;</code> of links — <em>not</em> <code>role="menu"</code>/<code>menuitem</code>, which promises arrow-key roving-tabindex this plan does not ship (shipping the role without the behavior is a 4.1.2 anti-pattern). <code>tooltip</code> sets <code>role="tooltip"</code> + <code>aria-describedby</code> and documents a text-only content contract (no focusable children). <code>dialog</code> ships only if paired with focus-into-on-open and focus-return-on-close (see new Step 8); otherwise defer the <code>dialog</code> preset rather than ship a role with no focus management.</span>
+              </div>
+              <div class="step-why">Gap #2 — the goal names tooltips and dropdown nav explicitly, so the component should make their required ARIA a one-prop choice. But a role must not out-run the interaction it implies: <code>role="menu"</code> without roving tabindex, or <code>role="dialog"</code> without focus management, is worse than no role.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Extract TSX via <code>tests/run.sh</code>; <code>tsc --noEmit</code> (in <code>tests/e2e.sh</code>) passes. Grep the generated TSX for <code>aria-expanded</code> (disclosure), <code>aria-describedby</code> (tooltip). Confirm no <code>role="menu"</code>/<code>menuitem</code> is emitted for the nav example. Parity diff between the two files' TSX blocks (manual — TSX parity is not automated).</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">4</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Sync <code>aria-expanded</code> on the trigger via the existing <code>toggle</code> listener (react adapter + neutral <code>init()</code> in <code>## Behavior</code>). Extend the handler already listening for <code>onToggle</code> to set <code>aria-expanded</code> on the trigger when <code>role="menu"</code>.</span>
+              </div>
+              <div class="step-why">A dropdown-nav trigger with a stale/absent <code>aria-expanded</code> fails 4.1.2. Reuse the listener already there — no new effect, no new dependency.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">jsdom/axe pass in <code>tests/e2e.sh</code>; the E2E test asserts the trigger's <code>aria-expanded</code> flips <code>false</code>→<code>true</code> on open.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">5</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Add opt-in hover/focus open for tooltips (<code>## Behavior</code>, both files), meeting WCAG 1.4.13 (review-hardened). For <code>role="tooltip"</code>: open on trigger <code>mouseenter</code>/<code>focus</code> after a short intent delay (~300ms) and close on <code>mouseleave</code>/<code>blur</code> — but keep it open while the pointer is over the trigger <em>or</em> the popover (bind the listeners on the popover surface too → <strong>hoverable</strong>), and close on <code>Escape</code> without moving the pointer (→ <strong>dismissible</strong>). Provide a touch path: since hover never fires on touch, a tap toggles the tooltip via the native click path. State whether the tooltip uses <code>popover="manual"</code> (hover-controlled) or <code>auto</code>. Gate all of this behind <code>role="tooltip"</code> so click-popovers keep zero JS. Document <code>interestfor</code> as the future zero-JS path.</span>
+              </div>
+              <div class="step-why">Gap #3 — tooltips that only open on click aren't tooltips, but a naive mouseenter/mouseleave handler flickers, traps content behind a vanishing tooltip, and excludes touch and keyboard users. WCAG 1.4.13 requires hoverable + dismissible + persistent. This is the one spot JS earns its place; keep it scoped to the tooltip preset only.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">The committed E2E test drives hover (with the intent delay), pointer-into-popover (stays open), Escape (dismisses), keyboard-focus open/close, and tap-to-toggle. Confirm click-mode popovers still bind no hover listeners (jsdom assertion + grep the non-tooltip branch). Re-run the golden SCSS diff since <code>## Behavior</code> edits sit beside the styles.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">6</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Add <code>## Examples</code> for dropdown-nav (<code>role="menu"</code>) and tooltip (<code>role="tooltip"</code>) to both files; drop the dead <code>--popover-z</code> reliance and note that <code>z-index</code> is inert in the top layer.</span>
+              </div>
+              <div class="step-why">The examples are the acceptance surface for "reusable for dropdown nav and tooltips." The <code>--popover-z</code> note is a cleanup — the top layer ignores <code>z-index</code>, so the token is misleading.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Both examples appear in both files, byte-identical; they render in the preview.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">7</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Update <code>SKILL.md</code> <code>description</code> + <code>hint</code> to name the new role presets (tooltip / disclosure-menu / dialog) and anchor positioning. This is unconditional — the current <code>hint</code> enumerates trigger/content/dismiss but has zero mention of the plan's new headline use cases.</span>
+              </div>
+              <div class="step-why">The <code>hint</code> tells users what to specify; without the new positioning/role surface the skill can't be invoked for the two use cases the objective names.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Re-read <code>SKILL.md</code>; front-matter still has <code>name</code>/<code>description</code> (PostToolUse hook) and <code>disable-model-invocation: true</code> + <code>hint</code> (component-tier rule), and the hint now lists the role presets.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">8</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Update the docs that the feature makes stale (both files). Rewrite the <code>## Accessibility</code> prose — the current "the popover does not get <code>role</code> automatically… user must add <code>role</code>" sentence (and its 4.1.2 bullet) becomes false once presets exist. Add <code>--popover-anchor-gap</code> to the <code>## Tokens &amp; CSS Variables</code> / <code>## CSS Variables</code> tables and resolve <code>--popover-z</code>'s listed status. Note that anchor positioning + role presets are acss-kit additions beyond the pinned fpkit <code>@6.5.0</code> tag. For the <code>dialog</code> preset, add focus-into-on-open and focus-return-on-close to <code>## Behavior</code>, or drop the preset.</span>
+              </div>
+              <div class="step-why">Shipping a feature while the docs still say it's impossible leaves self-contradicting guidance in both source files; the token tables drift from the SCSS; and a <code>dialog</code> role with no focus management is an a11y trap.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body">Grep both files for the old "user must add <code>role</code>" sentence — gone. Both token tables list <code>--popover-anchor-gap</code>. Parity diff of the two files — identical.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">9</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Regenerate the golden SCSS fixture and author the committed E2E spec. Run the repo's fixture generator to refresh <code>tests/fixtures/golden/component-popover/popover.scss</code> after the SCSS edits land, and write <code>tests/e2e/popover-anchor.spec.ts</code> as a real Playwright file wired into <code>tests/e2e.sh</code> (not just an ad-hoc MCP session) — it is the only layer that evaluates CSS anchor positioning, so it owns the anchoring/flip/hover/aria-expanded assertions plus a Firefox context exercising the <code>@supports not</code> fallback.</span>
+              </div>
+              <div class="step-why">Without regenerating the fixture, <code>tests/run.sh</code> step 2a fails on golden DRIFT the moment the SCSS changes. And jsdom has no layout engine — anchor positioning is inert there — so a committed browser spec is the only repeatable guard for the runtime claims (AC2–AC5, AC8).</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body"><code>tests/run.sh</code> golden guard is green after regeneration. <code>tests/e2e.sh</code> (or the new npm script) runs the Playwright spec headlessly and passes in both Chromium and Firefox contexts.</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+        <div class="step-card">
+          <div class="step-card-header">
+            <div class="step-number">10</div>
+            <div class="step-body">
+              <div class="step-action">
+                <span class="step-chip">todo</span>
+                <span class="step-chip-text">Bump the plugin version and record the change. Bump <code>plugins/acss-kit/.claude-plugin/plugin.json</code> and add a <code>CHANGELOG.md</code> entry that explicitly calls out the repositioning behavior change, so users who <code>/kit-update</code> or <code>/kit-sync</code> are warned that anchored placement is a visual change from the prior viewport-centered default. Use <code>/release-plugin acss-kit</code> per the repo's pre-submit checklist.</span>
+              </div>
+              <div class="step-why">The anchor CSS changes where existing popovers render on re-sync — a breaking visual change. The repo's own pre-submit checklist requires a version bump + changelog for user-facing behavior changes; without it, re-syncing users get the shift with no signal.</div>
+              <details class="step-verify-toggle">
+                <summary>Verify</summary>
+                <div class="verify-body"><code>plugin.json</code> version is higher than the prior release; <code>CHANGELOG.md</code> names the positioning change; <code>marketplace.json</code> carries no <code>version</code> key (manifest wins).</div>
+              </details>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <section class="section-card card-tests" id="tests" aria-labelledby="h-tests">
+      <h2 id="h-tests">
+        <svg class="icon" aria-hidden="true"><use href="#ic-beaker"/></svg>
+        Tests
+      </h2>
+      <div class="test-tier-label">Tier 1 — Code-touching plan</div>
+
+      <div class="objective-test-card">
+        <div class="test-card-header">
+          <span class="test-badge test-badge-objective">Objective</span>
+          <span class="test-card-title">Anchored, accessible dropdown + tooltip render and pass axe</span>
+        </div>
+        <div class="test-card-body">
+          <p><strong>File:</strong> <code>tests/run.sh</code> (structural) + <code>tests/e2e.sh</code> (render) — existing entry scripts, no new harness.</p>
+          <p><strong>Type:</strong> smoke / integration test</p>
+          <p><strong>Asserts:</strong> the enhanced popover extracts, <code>tsc --noEmit</code> is clean, SCSS compiles, the golden fixture matches, and jsdom + axe-core find zero a11y violations on the rendered tooltip and disclosure-nav examples. <strong>Scope caveat (review):</strong> jsdom has no layout engine, so this layer verifies markup/ARIA shape only — the <em>anchored</em> half of the objective is owned by the committed Playwright spec (E2E card below), which is the true objective-verification test for positioning.</p>
+          <p><strong>Run:</strong> <code>npm --prefix tests ci &amp;&amp; tests/run.sh &amp;&amp; tests/e2e.sh</code></p>
+        </div>
+      </div>
+
+      <div class="test-list">
+
+        <div class="test-card">
+          <div class="test-card-header">
+            <span class="test-badge test-badge-unit">Unit</span>
+            <span class="test-card-title">Golden parity guard — neutral source vs. fallback</span>
+          </div>
+          <div class="test-card-body">
+            <p><strong>File:</strong> <code>tests/validate_extracted_tsx.mjs</code> (existing).</p>
+            <p><strong>Targets:</strong> byte-identical parity between the <code>popover.component.md</code> react adapter and the <code>reference.md</code> templates after every edit.</p>
+            <p><strong>Key cases:</strong> TSX blocks match; SCSS blocks match; no drift introduced by the dual-file edits.</p>
+          </div>
+        </div>
+
+        <div class="test-card">
+          <div class="test-card-header">
+            <span class="test-badge test-badge-integration">Integration</span>
+            <span class="test-card-title">Rendered popover a11y (jsdom + axe)</span>
+          </div>
+          <div class="test-card-body">
+            <p><strong>File:</strong> <code>tests/e2e.sh</code> → <code>tests/run_axe.mjs</code>.</p>
+            <p><strong>Targets:</strong> generated TSX + SCSS working together in jsdom (synthetic events, no real layout).</p>
+            <p><strong>Key cases:</strong> tooltip has <code>role="tooltip"</code> + <code>aria-describedby</code>; disclosure trigger has synced <code>aria-expanded</code> and emits <em>no</em> <code>role="menu"</code>; hover/focus and <code>aria-expanded</code> transitions fire via dispatched <code>mouseenter</code>/<code>focus</code>/<code>click</code> events; non-tooltip roles attach no hover listener; contrast/border pass axe.</p>
+          </div>
+        </div>
+
+        <div class="test-card">
+          <div class="test-card-header">
+            <span class="test-badge test-badge-e2e">E2E</span>
+            <span class="test-card-title">Positioning + dismiss + tooltip behavior in a real browser</span>
+          </div>
+          <div class="test-card-body">
+            <p><strong>File:</strong> <code>tests/e2e/popover-anchor.spec.ts</code> — a committed Playwright spec wired into <code>tests/e2e.sh</code> (not an ad-hoc MCP session), so it re-runs in CI.</p>
+            <p><strong>Targets:</strong> the popover in a real browser — Chromium (anchor positioning) <strong>and</strong> a Firefox context (fallback branch).</p>
+            <p><strong>Key cases:</strong> dropdown opens tethered below its trigger; two instances on one page each anchor to their own trigger; <code>position-try</code> flips it near the viewport edge and the arrow tracks; Escape + outside-click dismiss; tooltip opens on hover (after intent delay) and keyboard focus, stays open when the pointer moves onto it, dismisses on Escape, and toggles by tap; <code>aria-expanded</code> flips on the disclosure trigger; Firefox <code>@supports not</code> branch still renders a usable popover.</p>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <section class="section-card card-criteria" id="criteria" aria-labelledby="h-criteria">
+      <h2 id="h-criteria">
+        <svg class="icon" aria-hidden="true"><use href="#ic-check-circle"/></svg>
+        Acceptance Criteria
+      </h2>
+      <ul class="criteria-list" id="criteria-list">
+        <li>
+          <input type="checkbox" id="ac1">
+          <label for="ac1"><code>popover.component.md</code> and <code>reference.md</code> are byte-identical (parity test green) after all edits.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac2">
+          <label for="ac2">Anchored popover sits at its trigger in Chromium (asserted by the Playwright spec) and the Firefox context confirms the <code>@supports not</code> fallback still renders a usable popover; Safari is confirmed by a one-time manual check (no automated Safari runner in-repo).</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac3">
+          <label for="ac3"><code>position-try</code> flips the popover at a viewport edge and the arrow points the right way.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac4">
+          <label for="ac4"><code>role="tooltip"</code> emits <code>role="tooltip"</code> + <code>aria-describedby</code> and opens on hover <strong>and</strong> keyboard focus.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac5">
+          <label for="ac5">The dropdown-nav example uses the disclosure pattern (trigger <code>aria-expanded</code> synced to open state over a plain link list) and emits <strong>no</strong> <code>role="menu"</code>/<code>menuitem</code> without the keyboard model to back it.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac6">
+          <label for="ac6"><code>tests/run.sh</code> and <code>tests/e2e.sh</code> are green; the golden SCSS fixture matches; axe reports zero violations on both new examples.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac7">
+          <label for="ac7">Non-tooltip (click) popovers bind no hover JS — the native-first path is preserved (asserted in jsdom).</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac8">
+          <label for="ac8">Two or more popovers on one page each anchor to their own trigger (per-instance <code>anchor-name</code>, not a shared class-level name).</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac9">
+          <label for="ac9">The <code>role="tooltip"</code> preset meets WCAG 1.4.13 — hoverable (pointer can move onto the tooltip), dismissible (Escape), and reachable on touch via tap.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac10">
+          <label for="ac10">The stale "user must add <code>role</code>" prose is removed from both files, and <code>--popover-anchor-gap</code> appears in both token tables.</label>
+        </li>
+        <li>
+          <input type="checkbox" id="ac11">
+          <label for="ac11"><code>plugin.json</code> version is bumped and <code>CHANGELOG.md</code> calls out the repositioning behavior change; the SCSS filename is consistent across <code>SKILL.md</code> and the Generation Contract.</label>
+        </li>
+      </ul>
+      <span id="criteria-status" aria-live="polite" aria-atomic="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"></span>
+    </section>
+
+    <section class="section-card card-verification" id="verification" aria-labelledby="h-verification">
+      <h2 id="h-verification">
+        <svg class="icon" aria-hidden="true"><use href="#ic-magnifying-glass"/></svg>
+        Verification
+      </h2>
+      <p>Run <code>tests/run.sh &amp;&amp; tests/e2e.sh</code> — all green, parity guard passes. Run <code>acss-kit-test-component</code> (or <code>tests/serve.sh</code>) and visually confirm the dropdown-nav and tooltip examples: anchored placement, edge-flip, arrow tracking, hover/focus tooltip, and Escape/outside-click dismiss. Diff the <code>popover.component.md</code> react adapter blocks against <code>reference.md</code> — no divergence. Confirm <code>SKILL.md</code> front-matter is unchanged in its required keys and the description/hint reflect the new role/positioning surface.</p>
+    </section>
+
+    <section class="section-card card-completion" id="completion" aria-labelledby="h-completion">
+      <h2 id="h-completion">
+        <svg class="icon" aria-hidden="true"><use href="#ic-clipboard-check"/></svg>
+        Completion Checklist
+      </h2>
+      <div class="completion-checklist" id="completion-checklist">
+        <div class="completion-header">
+          <span class="completion-badge" id="completion-badge">Required</span>
+        </div>
+        <ul class="completion-list" id="completion-list">
+          <li>
+            <input type="checkbox" id="cc1" disabled>
+            <label for="cc1">All step TODOs marked as done</label>
+          </li>
+          <li>
+            <input type="checkbox" id="cc2" disabled>
+            <label for="cc2">All acceptance criteria verified and checked off</label>
+          </li>
+          <li>
+            <input type="checkbox" id="cc3" disabled>
+            <label for="cc3">Plan status updated to completed</label>
+          </li>
+        </ul>
+        <div class="completion-report" id="completion-report">
+          <h3 class="report-heading">Completion Report</h3>
+          <p class="report-empty">No items to report — all requirements met.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card card-next-steps" id="next-steps" aria-labelledby="h-next-steps">
+      <h2 id="h-next-steps">
+        <svg class="icon" aria-hidden="true"><use href="#ic-arrow-right-circle"/></svg>
+        Next Steps
+      </h2>
+      <div class="next-steps-list">
+
+        <details class="next-step-item">
+          <summary>Fold the dropdown pattern into component-nav</summary>
+          <div class="next-step-prompt">
+            <p>Paste this prompt into Claude to execute this follow-up:</p>
+            <pre>Add a dropdown submenu pattern to component-nav (plugins/acss-kit/skills/component-nav/) that composes the enhanced Popover's role="menu" preset for expandable nav items, with roving-tabindex keyboard support (Arrow keys, Home/End) per the WAI-ARIA menu-button pattern. Keep it opt-in so the base Nav stays a plain landmark. Update both the neutral component.md source and the reference.md fallback in lockstep, and re-run the golden parity test.</pre>
+            <button class="copy-prompt-btn" type="button" onclick="copyPrompt(this)" aria-label="Copy prompt to clipboard">Copy prompt</button>
+          </div>
+        </details>
+
+        <div class="wish-list-header">
+          <svg class="icon" aria-hidden="true"><use href="#ic-sparkles"/></svg>
+          Wish List
+        </div>
+
+        <details class="next-step-item wish-item">
+          <summary>
+            Zero-JS tooltips via Interest Invokers
+            <span class="wish-badge">Wish List</span>
+          </summary>
+          <div class="next-step-prompt">
+            <p>Speculative / blue-sky idea — not on the critical path. Paste into Claude when ready to explore:</p>
+            <pre>Once the interestfor / interesttarget Interest Invoker API ships in Chrome stable and Safari, revisit component-popover's tooltip preset (plugins/acss-kit/skills/component-popover/) and replace the hover/focus JS handlers with the declarative interestfor attribute, keeping the JS only as a @supports/feature-detect fallback. Update both popover.component.md and reference.md in lockstep and re-run the golden parity test.</pre>
+            <button class="copy-prompt-btn" type="button" onclick="copyPrompt(this)" aria-label="Copy prompt to clipboard">Copy prompt</button>
+          </div>
+        </details>
+
+      </div>
+    </section>
+
+    <details id="team-review-2026-07-07" class="optional-section">
+      <summary>
+        <svg class="icon" aria-hidden="true"><use href="#ic-clipboard-check"/></svg>
+        Team Review (2026-07-07) — 7 reviewers
+      </summary>
+      <div class="optional-body">
+        <p><strong>Executive summary:</strong> Sound direction, sound with revisions. Seven reviewers (architecture, completeness, testability, risk, conventions, UX, accessibility) agreed the plan targets the right primitives but shipped four classes of defect the original draft would have carried into implementation: (1) a shared vs. per-instance anchor-name bug that breaks the headline multi-instance dropdown case; (2) a missing golden-fixture regeneration that would leave <code>tests/run.sh</code> red; (3) two ARIA anti-patterns — <code>role="menu"</code> on nav links without roving tabindex, and <code>role="dialog"</code> with no focus management; and (4) an incomplete WCAG 1.4.13 tooltip (no hoverable/dismissible/touch/intent-delay). All were applied to the plan above.</p>
+
+        <p><strong>Confirmed concerns (multiple reviewers):</strong></p>
+        <ul>
+          <li><strong>Golden fixture / parity mechanism</strong> (Completeness ⚠ critical, Risk, Architecture, Conventions) — the plan misattributed parity to <code>validate_extracted_tsx.mjs</code>; the real guard is <code>tests/run.sh</code> §2a diffing extracted SCSS against <code>tests/fixtures/golden/component-popover/popover.scss</code>, TSX parity is <em>not</em> automated. → Context corrected; new Step 9 regenerates the fixture; Files list updated.</li>
+          <li><strong>Per-instance anchoring</strong> (Architecture ⚠ high) — a shared <code>anchor-name</code> binds to the nearest trigger, breaking dropdown nav. → Folded into Step 1 + AC8.</li>
+          <li><strong>role="menu" anti-pattern</strong> (Accessibility ⚠ critical, UX high) — use the Disclosure Navigation pattern instead. → Step 3 rewritten; AC5 rewritten.</li>
+          <li><strong>Tooltip WCAG 1.4.13</strong> (Accessibility high, UX high) — hoverable, dismissible (Escape), intent-delay, touch/tap path. → Step 5 rewritten; AC9 added.</li>
+          <li><strong>Breaking change unversioned</strong> (Risk ⚠ high) — anchor CSS shifts existing installs on re-sync; repo checklist requires a version bump + CHANGELOG. → New Step 10 + AC11; Files list updated.</li>
+          <li><strong>Committed E2E + jsdom can't anchor</strong> (Testability ⚠ critical) — the "E2E test" was an ad-hoc MCP session; jsdom has no layout engine. → E2E card now a committed Playwright spec (Chromium + Firefox); objective card scoped to markup; new Step 9.</li>
+          <li><strong>Stale docs / SCSS filename</strong> (Completeness high, Conventions high) — the "user must add role" prose becomes false; <code>popover.module.scss</code> vs <code>popover.scss</code> mismatch. → New Step 8 (a11y prose + token tables + dialog focus); filename reconcile folded into Step 1; AC10 added.</li>
+        </ul>
+
+        <p><strong>Conflicts / judgment calls:</strong> The only real tension was ship-<code>role="menu"</code>-now vs. defer. Resolution taken: adopt the disclosure pattern as the nav default (no <code>role="menu"</code> until the component-nav follow-up ships full arrow-key support), and gate the <code>dialog</code> preset on focus management. This keeps the plan honest about what it actually implements.</p>
+
+        <p><strong>Triage outcome:</strong> all high-consensus findings applied as-is (Steps 1, 3, 5, 7 revised; Steps 8–10 added; Files, Context, Tests, and AC2/AC5–AC11 updated). Lower-severity notes (target-size on new examples, prefers-reduced-motion guard for any future transition, per-step parity re-checks) are captured in the revised step verify lines rather than as separate steps. Nothing was rejected; the <code>interestfor</code> wish-list item was already correctly quarantined.</p>
+      </div>
+    </details>
+
+    <footer class="plan-footer">
+      <svg class="icon" aria-hidden="true"><use href="#ic-sparkles"/></svg>
+      Generated by plan-agent · reviewed 2026-07-07 · agentic-acss-plugins
+    </footer>
+
+  </main>
+</div><!-- /.layout -->
+
+<script>
+function savePDF() { window.print(); }
+
+function buildImplementPrompt() {
+  var cmdEl = document.getElementById('implement-cmd');
+  var status = document.documentElement.getAttribute('data-status') || 'todo';
+  var stepCards = Array.prototype.slice.call(document.querySelectorAll('.step-card'));
+  var criteriaItems = Array.prototype.slice.call(document.querySelectorAll('#criteria-list li'));
+
+  var totalSteps = stepCards.length;
+  var doneSteps = stepCards.filter(function(c) { return c.classList.contains('completed'); }).length;
+  var totalCriteria = criteriaItems.length;
+  var checkedCriteria = criteriaItems.filter(function(li) {
+    var cb = li.querySelector('input[type="checkbox"]');
+    return cb && cb.checked;
+  }).length;
+
+  var planPathMeta = document.querySelector('meta[name="plan-path"]');
+  var planPath = (planPathMeta && planPathMeta.getAttribute('content')) || '<plan-file>';
+
+  var lines = [];
+  lines.push(cmdEl ? cmdEl.textContent.trim() : 'Implement the plan');
+  lines.push('');
+  lines.push('Status: ' + status + ' (' + doneSteps + '/' + totalSteps + ' steps done, ' + checkedCriteria + '/' + totalCriteria + ' criteria met)');
+  lines.push('');
+  lines.push('Instructions:');
+  lines.push('1. Read the plan at ' + planPath + ' (a self-contained HTML file).');
+  lines.push('2. Implement every step marked todo; after completing each step, mark it done in the plan.');
+  lines.push('3. When all steps are done, verify each acceptance criterion and check it off in the plan.');
+  lines.push('4. Complete the completion checklist to update the plan status to completed.');
+
+  return lines.join('\n');
+}
+
+function clipboardCopy(text, btn, restoreLabel) {
+  function show(labelText, cls, delay) {
+    if (btn._copyTimer) clearTimeout(btn._copyTimer);
+    btn.textContent = labelText;
+    btn.classList.remove('copied', 'copy-failed');
+    if (cls) btn.classList.add(cls);
+    btn._copyTimer = setTimeout(function () {
+      btn.textContent = restoreLabel;
+      btn.classList.remove('copied', 'copy-failed');
+      btn._copyTimer = null;
+    }, delay);
+  }
+  function flash() { show('Copied ✓', 'copied', 2000); }
+  function fail()  { show('Copy failed — select manually', 'copy-failed', 4000); }
+  function fallback() {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.cssText = 'position:fixed;left:-9999px;top:-9999px;opacity:0';
+    document.body.appendChild(ta);
+    ta.select();
+    var ok = false;
+    try { ok = document.execCommand('copy'); } catch (e) {}
+    document.body.removeChild(ta);
+    if (ok) flash(); else fail();
+  }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(flash).catch(fallback);
+  } else {
+    fallback();
+  }
+}
+
+function copyCmd(btn) { clipboardCopy(buildImplementPrompt(), btn, 'Copy'); }
+function copyGoal(btn) {
+  var code = document.getElementById('goal-cmd');
+  if (!code) return;
+  clipboardCopy(code.textContent, btn, 'Copy');
+}
+function copyPath(btn, id) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  clipboardCopy(el.textContent.trim(), btn, 'Copy');
+}
+function copyPrompt(btn) {
+  var pre = btn.previousElementSibling;
+  if (!pre || pre.tagName !== 'PRE') {
+    pre = btn.parentElement && btn.parentElement.querySelector('pre');
+  }
+  if (!pre) return;
+  clipboardCopy(pre.textContent, btn, 'Copy prompt');
+}
+
+(function () {
+  'use strict';
+
+  var bar        = document.getElementById('progress-bar');
+  var label      = document.getElementById('progress-label');
+  var liveRegion = document.getElementById('criteria-status');
+  var checkboxes = Array.prototype.slice.call(
+    document.querySelectorAll('#criteria-list input[type="checkbox"]')
+  );
+  var total = checkboxes.length;
+
+  function updateProgress() {
+    var done = checkboxes.filter(function (cb) { return cb.checked; }).length;
+    var pct  = total ? Math.round(done / total * 100) : 0;
+    if (bar) {
+      bar.style.width = pct + '%';
+      bar.setAttribute('aria-valuenow', pct);
+      if (pct > 0) bar.classList.add('has-progress');
+      else         bar.classList.remove('has-progress');
+    }
+    if (label) label.textContent = done + ' / ' + total + ' done';
+  }
+
+  checkboxes.forEach(function (cb, i) {
+    cb.addEventListener('change', function () {
+      cb.toggleAttribute('checked', cb.checked);
+      updateProgress();
+      if (liveRegion) {
+        liveRegion.textContent = 'Criterion ' + (i + 1) +
+          ' marked as ' + (cb.checked ? 'complete' : 'incomplete');
+      }
+    });
+  });
+
+  updateProgress();
+
+  var ccCheckboxes = Array.prototype.slice.call(
+    document.querySelectorAll('#completion-list input[type="checkbox"]')
+  );
+  var completionCard = document.getElementById('completion-checklist');
+
+  function updateCompletion() {
+    var stepCards = document.querySelectorAll('.step-card');
+    var allStepsDone = stepCards.length > 0 &&
+      Array.prototype.slice.call(stepCards).every(function(c) {
+        return c.classList.contains('completed');
+      });
+    if (ccCheckboxes[0]) ccCheckboxes[0].checked = allStepsDone;
+
+    var allCriteriaChecked = total > 0 &&
+      checkboxes.every(function(cb) { return cb.checked; });
+    if (ccCheckboxes[1]) ccCheckboxes[1].checked = allCriteriaChecked;
+
+    var metaStatus = document.querySelector('meta[name="plan-status"]');
+    var statusIsCompleted =
+      document.documentElement.getAttribute('data-status') === 'completed' &&
+      (!metaStatus || metaStatus.getAttribute('content') === 'completed');
+    if (ccCheckboxes[2]) ccCheckboxes[2].checked = statusIsCompleted;
+
+    var allComplete = allStepsDone && allCriteriaChecked && statusIsCompleted;
+    if (completionCard) {
+      if (allComplete) completionCard.classList.add('all-complete');
+      else completionCard.classList.remove('all-complete');
+    }
+  }
+
+  updateCompletion();
+
+  checkboxes.forEach(function(cb) {
+    cb.addEventListener('change', updateCompletion);
+  });
+
+  if ('MutationObserver' in window) {
+    new MutationObserver(updateCompletion).observe(
+      document.documentElement, { attributes: true, attributeFilter: ['data-status'] }
+    );
+  }
+
+  var rail = document.querySelector('.scroll-rail');
+  if (rail) {
+    function updateRail() {
+      var maxY = document.documentElement.scrollHeight - window.innerHeight;
+      var pct  = maxY > 0 ? (window.scrollY / maxY * 100).toFixed(1) : 0;
+      rail.style.setProperty('--scroll-pct', pct);
+    }
+    window.addEventListener('scroll', updateRail, { passive: true });
+    updateRail();
+  }
+
+  var navLinks = Array.prototype.slice.call(
+    document.querySelectorAll('.plan-nav a[href^="#"]')
+  );
+  if (navLinks.length && 'IntersectionObserver' in window) {
+    var sectionIds = navLinks.map(function (a) { return a.getAttribute('href').slice(1); });
+    var sections   = sectionIds.map(function (id) { return document.getElementById(id); })
+                               .filter(Boolean);
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        var id = entry.target.id;
+        navLinks.forEach(function (a) {
+          var isActive = a.getAttribute('href') === '#' + id;
+          a.classList.toggle('active', isActive);
+          if (isActive) a.setAttribute('aria-current', 'true');
+          else          a.removeAttribute('aria-current');
+        });
+      });
+    }, { threshold: 0, rootMargin: '-20% 0px -70% 0px' });
+    sections.forEach(function (el) { observer.observe(el); });
+  }
+})();
+</script>
+</body>
+</html>

--- a/docs/plans/add-popover-anchor-positioning.html
+++ b/docs/plans/add-popover-anchor-positioning.html
@@ -1621,6 +1621,21 @@ img, video { max-width: 100%; height: auto; }
           </div>
         </details>
 
+        <details class="next-step-item">
+          <summary>Document the OddBird anchor-positioning polyfill as an opt-in Firefox upgrade</summary>
+          <div class="next-step-prompt">
+            <p>Paste this prompt into Claude to execute this follow-up:</p>
+            <pre>In plugins/acss-kit/skills/component-popover/ (both popover.component.md and reference.md, kept byte-identical), add a short "Optional: real anchoring in Firefox" note to the ## Behavior or ## Accessibility section documenting the @oddbird/css-anchor-positioning polyfill as a CONSUMER opt-in — NOT a dependency of the generated component. Keep the shipped default as the zero-dependency CSS @supports/@supports-not fallback; dependencies stays []. The note should show the feature-detected dynamic import the consumer adds in their own app entry:
+
+  if (!('anchorName' in document.documentElement.style)) {
+    import('https://unpkg.com/@oddbird/css-anchor-positioning');
+  }
+
+and state the caveats: it responds to anchor dimension changes but needs polyfill() re-invoked for popovers added later (SPA routing/lists); it reads inline styles so the per-instance anchor-name works; supporting browsers never load it. Do not add the polyfill to plugin.json or any generated package.json. Re-run the golden parity test after editing both files.</pre>
+            <button class="copy-prompt-btn" type="button" onclick="copyPrompt(this)" aria-label="Copy prompt to clipboard">Copy prompt</button>
+          </div>
+        </details>
+
         <div class="wish-list-header">
           <svg class="icon" aria-hidden="true"><use href="#ic-sparkles"/></svg>
           Wish List

--- a/docs/plans/add-popover-anchor-positioning.html
+++ b/docs/plans/add-popover-anchor-positioning.html
@@ -1285,7 +1285,7 @@ img, video { max-width: 100%; height: auto; }
             <div class="step-body">
               <div class="step-action">
                 <span class="step-chip">todo</span>
-                <span class="step-chip-text">Add positioning tokens + anchor CSS to the <code>## Styles</code> block (both files). Introduce <code>--popover-anchor-gap</code> (with a hardcoded <code>var()</code> fallback per the SCSS convention), map each <code>data-placement</code> to a <code>position-area</code>, wrap the anchored rules in <code>@supports (anchor-name: --a)</code>, and add a <code>@supports not</code> fallback that keeps the current absolute offset. <strong>Per-instance anchoring (review fix):</strong> derive <code>anchor-name</code> on the trigger and <code>position-anchor</code> on the popover from the component's already-generated unique <code>id</code> (via inline style), <em>not</em> a shared class-level name — otherwise multiple popovers on one page (dropdown nav, the headline use case) bind to the wrong trigger. While editing this section, reconcile the SCSS filename mismatch: <code>SKILL.md</code> Step 4 emits <code>popover.module.scss</code> but the Generation Contract says <code>popover.scss</code> — pick one and make all three references agree.</span>
+                <span class="step-chip-text">Add positioning tokens + anchor CSS to the <code>## Styles</code> block (both files). Introduce <code>--popover-anchor-gap</code> (with a hardcoded <code>var()</code> fallback per the SCSS convention), map each <code>data-placement</code> to a <code>position-area</code>, wrap the anchored rules in <code>@supports (anchor-name: --a)</code>, and add a <code>@supports not</code> fallback that keeps the current absolute offset. <strong>Per-instance anchoring (review fix):</strong> derive <code>anchor-name</code> on the trigger and <code>position-anchor</code> on the popover from the component's already-generated unique <code>id</code> (via inline style), <em>not</em> a shared class-level name — otherwise multiple popovers on one page (dropdown nav, the headline use case) bind to the wrong trigger. <strong>Sanitize the id first:</strong> <code>useId()</code> emits colons (e.g. <code>:r0:</code>) which are invalid in a CSS dashed-ident, so the raw id would produce invalid inline CSS and silently disable the anchored branch — map it to a CSS-safe token (e.g. replace non-word chars) before building <code>--pop-&lt;token&gt;</code>. While editing this section, reconcile the SCSS filename mismatch: <code>SKILL.md</code> Step 4 emits <code>popover.module.scss</code> but the Generation Contract says <code>popover.scss</code> — pick one and make all three references agree.</span>
               </div>
               <div class="step-why">This is gap #1 — the core value. Anchoring is what makes dropdowns/tooltips sit at their trigger; the <code>@supports</code> split honors the anchor+fallback choice without breaking non-supporting browsers. Per-instance names are required or the anchor resolves to the nearest matching trigger, breaking multi-instance layouts.</div>
               <details class="step-verify-toggle">
@@ -1477,12 +1477,12 @@ img, video { max-width: 100%; height: auto; }
         <div class="test-card">
           <div class="test-card-header">
             <span class="test-badge test-badge-unit">Unit</span>
-            <span class="test-card-title">Golden parity guard — neutral source vs. fallback</span>
+            <span class="test-card-title">Parity guards — SCSS automated, TSX manual</span>
           </div>
           <div class="test-card-body">
-            <p><strong>File:</strong> <code>tests/validate_extracted_tsx.mjs</code> (existing).</p>
-            <p><strong>Targets:</strong> byte-identical parity between the <code>popover.component.md</code> react adapter and the <code>reference.md</code> templates after every edit.</p>
-            <p><strong>Key cases:</strong> TSX blocks match; SCSS blocks match; no drift introduced by the dual-file edits.</p>
+            <p><strong>SCSS (automated):</strong> <code>tests/run.sh</code> §2a diffs the extracted SCSS of both <code>popover.component.md</code> and <code>reference.md</code> against the golden fixture — this is the real byte-identical guard.</p>
+            <p><strong>TSX (manual):</strong> <code>tests/validate_extracted_tsx.mjs</code> only enumerates <code>reference.md</code> and syntax-checks the extracted TSX — it does <em>not</em> extract <code>popover.component.md</code> or diff the two, so it is <strong>not</strong> a parity guard. TSX parity is confirmed by a hand diff of the two files' adapter blocks until an automated TSX-parity check is added.</p>
+            <p><strong>Key cases:</strong> SCSS blocks byte-identical (fixture green); TSX adapter blocks match on manual diff; no drift from the dual-file edits.</p>
           </div>
         </div>
 

--- a/docs/plans/add-popover-anchor-positioning.html
+++ b/docs/plans/add-popover-anchor-positioning.html
@@ -11,7 +11,7 @@
 <meta name="plan-file" content="add-popover-anchor-positioning.html">
 <meta name="plan-path" content="docs/plans/add-popover-anchor-positioning.html">
 <meta name="plan-implement" content="Read and implement all steps in the plan at docs/plans/add-popover-anchor-positioning.html — Add CSS anchor positioning + dropdown/tooltip presets to component-popover">
-<meta name="plan-goal" content="Achieve this goal: Add CSS anchor positioning + tooltip/menu role presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome">
+<meta name="plan-goal" content="Achieve this goal: Add CSS anchor positioning + tooltip/disclosure-nav presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome">
 <title>Plan: Enhance component-popover with anchor positioning + dropdown/tooltip presets</title>
 <style>
   /* ── Design tokens ─────────────────────────────────────────────── */
@@ -1149,7 +1149,7 @@ img, video { max-width: 100%; height: auto; }
 
     <div class="objective-card" id="objective">
       <div class="section-label">Objective</div>
-      <p>Tether the popover to its trigger with CSS Anchor Positioning (plus a Firefox fallback) and ship <code>tooltip</code> and <code>menu</code> role presets — so <code>component-popover</code> works for dropdown nav and tooltips, not just centered cards — editing <code>popover.component.md</code> and <code>reference.md</code> in lockstep so the golden parity test stays green.</p>
+      <p>Tether the popover to its trigger with CSS Anchor Positioning (plus a Firefox fallback) and ship <code>tooltip</code> and disclosure-nav presets — so <code>component-popover</code> works for dropdown nav and tooltips, not just centered cards — editing <code>popover.component.md</code> and <code>reference.md</code> in lockstep so the golden parity test stays green.</p>
     </div>
 
     <div class="plan-implement">
@@ -1161,7 +1161,7 @@ img, video { max-width: 100%; height: auto; }
     <details class="plan-goal">
       <summary>Pursue as goal — optimize for the outcome</summary>
       <div class="plan-goal-inner">
-        <code id="goal-cmd" aria-label="Goal prompt">Achieve this goal: Add CSS anchor positioning + tooltip/menu role presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome</code>
+        <code id="goal-cmd" aria-label="Goal prompt">Achieve this goal: Add CSS anchor positioning + tooltip/disclosure-nav presets to component-popover. The plan at docs/plans/add-popover-anchor-positioning.html describes one approach — use it as reference, but optimize for the outcome</code>
         <button class="copy-goal-btn" type="button" onclick="copyGoal(this)" aria-label="Copy goal prompt to clipboard">Copy</button>
       </div>
     </details>
@@ -1255,7 +1255,7 @@ img, video { max-width: 100%; height: auto; }
           </tr>
           <tr>
             <td>No role semantics — reference punts <code>role</code> to the consumer</td>
-            <td><code>role="tooltip"</code> (+ <code>aria-describedby</code>) and <code>role="menu"</code> (+ <code>aria-haspopup</code> / <code>aria-expanded</code>) presets</td>
+            <td><code>role="tooltip"</code> (+ <code>aria-describedby</code>) and a <code>disclosure-nav</code> preset (trigger <code>aria-expanded</code> over a plain link list; no <code>role="menu"</code>)</td>
             <td>High</td>
           </tr>
           <tr>
@@ -1336,7 +1336,7 @@ img, video { max-width: 100%; height: auto; }
             <div class="step-body">
               <div class="step-action">
                 <span class="step-chip">todo</span>
-                <span class="step-chip-text">Sync <code>aria-expanded</code> on the trigger via the existing <code>toggle</code> listener (react adapter + neutral <code>init()</code> in <code>## Behavior</code>). Extend the handler already listening for <code>onToggle</code> to set <code>aria-expanded</code> on the trigger when <code>role="menu"</code>.</span>
+                <span class="step-chip-text">Sync <code>aria-expanded</code> on the trigger via the existing <code>toggle</code> listener (react adapter + neutral <code>init()</code> in <code>## Behavior</code>). Extend the handler already listening for <code>onToggle</code> to set <code>aria-expanded</code> on the trigger for the <code>disclosure-nav</code> preset.</span>
               </div>
               <div class="step-why">A dropdown-nav trigger with a stale/absent <code>aria-expanded</code> fails 4.1.2. Reuse the listener already there — no new effect, no new dependency.</div>
               <details class="step-verify-toggle">
@@ -1370,7 +1370,7 @@ img, video { max-width: 100%; height: auto; }
             <div class="step-body">
               <div class="step-action">
                 <span class="step-chip">todo</span>
-                <span class="step-chip-text">Add <code>## Examples</code> for dropdown-nav (<code>role="menu"</code>) and tooltip (<code>role="tooltip"</code>) to both files; drop the dead <code>--popover-z</code> reliance and note that <code>z-index</code> is inert in the top layer.</span>
+                <span class="step-chip-text">Add <code>## Examples</code> for dropdown-nav (disclosure pattern — trigger <code>aria-expanded</code> over a plain link list, no <code>role="menu"</code>) and tooltip (<code>role="tooltip"</code>) to both files; drop the dead <code>--popover-z</code> reliance and note that <code>z-index</code> is inert in the top layer.</span>
               </div>
               <div class="step-why">The examples are the acceptance surface for "reusable for dropdown nav and tooltips." The <code>--popover-z</code> note is a cleanup — the top layer ignores <code>z-index</code>, so the token is misleading.</div>
               <details class="step-verify-toggle">
@@ -1387,7 +1387,7 @@ img, video { max-width: 100%; height: auto; }
             <div class="step-body">
               <div class="step-action">
                 <span class="step-chip">todo</span>
-                <span class="step-chip-text">Update <code>SKILL.md</code> <code>description</code> + <code>hint</code> to name the new role presets (tooltip / disclosure-menu / dialog) and anchor positioning. This is unconditional — the current <code>hint</code> enumerates trigger/content/dismiss but has zero mention of the plan's new headline use cases.</span>
+                <span class="step-chip-text">Update <code>SKILL.md</code> <code>description</code> + <code>hint</code> to name the new presets (tooltip / disclosure-nav / dialog) and anchor positioning. This is unconditional — the current <code>hint</code> enumerates trigger/content/dismiss but has zero mention of the plan's new headline use cases.</span>
               </div>
               <div class="step-why">The <code>hint</code> tells users what to specify; without the new positioning/role surface the skill can't be invoked for the two use cases the objective names.</div>
               <details class="step-verify-toggle">
@@ -1616,7 +1616,7 @@ img, video { max-width: 100%; height: auto; }
           <summary>Fold the dropdown pattern into component-nav</summary>
           <div class="next-step-prompt">
             <p>Paste this prompt into Claude to execute this follow-up:</p>
-            <pre>Add a dropdown submenu pattern to component-nav (plugins/acss-kit/skills/component-nav/) that composes the enhanced Popover's role="menu" preset for expandable nav items, with roving-tabindex keyboard support (Arrow keys, Home/End) per the WAI-ARIA menu-button pattern. Keep it opt-in so the base Nav stays a plain landmark. Update both the neutral component.md source and the reference.md fallback in lockstep, and re-run the golden parity test.</pre>
+            <pre>Add a dropdown submenu pattern to component-nav (plugins/acss-kit/skills/component-nav/) that composes the enhanced Popover's disclosure-nav preset for expandable nav items (trigger aria-expanded + plain link list). Only upgrade to role="menu"/menuitem if you also implement the full menu keyboard model — roving tabindex, Arrow keys, Home/End per the WAI-ARIA menu-button pattern; otherwise keep the disclosure pattern. Keep it opt-in so the base Nav stays a plain landmark. Update both the neutral component.md source and the reference.md fallback in lockstep, and re-run the golden parity test.</pre>
             <button class="copy-prompt-btn" type="button" onclick="copyPrompt(this)" aria-label="Copy prompt to clipboard">Copy prompt</button>
           </div>
         </details>

--- a/docs/plans/add-popover-anchor-positioning.html
+++ b/docs/plans/add-popover-anchor-positioning.html
@@ -47,6 +47,7 @@
   /* ── Reset & base ──────────────────────────────────────────────── */
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
   body {
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     font-size: 15px;
@@ -1113,7 +1114,7 @@ img, video { max-width: 100%; height: auto; }
       <div class="plan-header-actions">
         <button class="save-pdf-btn" type="button" onclick="savePDF()" aria-label="Save this plan as PDF">Save as PDF</button>
         <span class="effort-badge" aria-label="Effort level">High</span>
-        <span class="status-badge">todo</span>
+        <span class="status-badge" aria-label="Plan status">todo</span>
       </div>
     </div>
     <div class="plan-meta">
@@ -1878,7 +1879,7 @@ function copyPrompt(btn) {
         navLinks.forEach(function (a) {
           var isActive = a.getAttribute('href') === '#' + id;
           a.classList.toggle('active', isActive);
-          if (isActive) a.setAttribute('aria-current', 'true');
+          if (isActive) a.setAttribute('aria-current', 'location');
           else          a.removeAttribute('aria-current');
         });
       });

--- a/docs/plans/artifacts/popover-dossier-2026-07-07.html
+++ b/docs/plans/artifacts/popover-dossier-2026-07-07.html
@@ -1,0 +1,444 @@
+<style>
+  :root {
+    /* neutrals — cool bias toward the blue accent, chosen not defaulted */
+    --ground:   #f6f7f9;
+    --surface:  #ffffff;
+    --surface-2:#f0f2f6;
+    --line:     #e3e6ec;
+    --line-2:   #d3d8e2;
+    --ink:      #14161c;
+    --body:     #363b47;
+    --muted:    #6a7180;
+    --faint:    #8a91a0;
+    /* one accent — a precise signal blue (the "anchor" hue) */
+    --accent:   #2f56d6;
+    --accent-2: #1f3fac;
+    --accent-wash:#eef1fd;
+    /* semantic severity — separate from the accent */
+    --crit:     #c1121f;   --crit-bg:#fdecee;
+    --high:     #b5560a;   --high-bg:#fdf0e5;
+    --med:      #8a6d00;   --med-bg:#fbf5e0;
+    --low:      #4b5563;   --low-bg:#eef0f4;
+    --good:     #10794f;   --good-bg:#e7f4ee;
+
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+    --maxw: 820px;
+    --rail: 116px;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:   #0d0f14;
+      --surface:  #14171e;
+      --surface-2:#1b1f28;
+      --line:     #262b36;
+      --line-2:   #333a48;
+      --ink:      #eceef3;
+      --body:     #c3c8d2;
+      --muted:    #8b93a2;
+      --faint:    #6b7280;
+      --accent:   #7d9bff;
+      --accent-2: #a9bdff;
+      --accent-wash:#191f33;
+      --crit:#ff8a8a; --crit-bg:#2a1417;
+      --high:#f0ad6b; --high-bg:#2a1d10;
+      --med: #ddc25a; --med-bg:#241f0f;
+      --low: #9aa3b2; --low-bg:#1b1f28;
+      --good:#57c99a; --good-bg:#0f2119;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:#0d0f14; --surface:#14171e; --surface-2:#1b1f28; --line:#262b36; --line-2:#333a48;
+    --ink:#eceef3; --body:#c3c8d2; --muted:#8b93a2; --faint:#6b7280;
+    --accent:#7d9bff; --accent-2:#a9bdff; --accent-wash:#191f33;
+    --crit:#ff8a8a; --crit-bg:#2a1417; --high:#f0ad6b; --high-bg:#2a1d10;
+    --med:#ddc25a; --med-bg:#241f0f; --low:#9aa3b2; --low-bg:#1b1f28; --good:#57c99a; --good-bg:#0f2119;
+  }
+  :root[data-theme="light"] {
+    --ground:#f6f7f9; --surface:#ffffff; --surface-2:#f0f2f6; --line:#e3e6ec; --line-2:#d3d8e2;
+    --ink:#14161c; --body:#363b47; --muted:#6a7180; --faint:#8a91a0;
+    --accent:#2f56d6; --accent-2:#1f3fac; --accent-wash:#eef1fd;
+    --crit:#c1121f; --crit-bg:#fdecee; --high:#b5560a; --high-bg:#fdf0e5;
+    --med:#8a6d00; --med-bg:#fbf5e0; --low:#4b5563; --low-bg:#eef0f4; --good:#10794f; --good-bg:#e7f4ee;
+  }
+
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+  .doc {
+    background: var(--ground);
+    color: var(--body);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+
+  /* ── coordinate-tick top band ─────────────────────────────── */
+  .band { height: 4px; background:
+    repeating-linear-gradient(90deg, var(--accent) 0 2px, transparent 2px 14px); }
+
+  /* ── masthead ─────────────────────────────────────────────── */
+  header.mast { padding: 52px 0 30px; border-bottom: 1px solid var(--line); }
+  .eyebrow {
+    font-family: var(--mono); font-size: 12px; letter-spacing: .16em;
+    text-transform: uppercase; color: var(--accent); font-weight: 600;
+    display:flex; gap:.6em; align-items:center; flex-wrap:wrap;
+  }
+  .eyebrow .dot { width:6px;height:6px;border-radius:50%;background:var(--accent);display:inline-block; }
+  h1 {
+    font-family: var(--sans); font-weight: 720; letter-spacing: -.021em;
+    font-size: clamp(30px, 5vw, 46px); line-height: 1.08; color: var(--ink);
+    margin: 18px 0 0; text-wrap: balance; max-width: 15ch;
+  }
+  .dek { font-size: 18px; color: var(--muted); margin: 16px 0 0; max-width: 60ch; }
+  .metagrid {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(140px,1fr));
+    gap: 1px; margin-top: 30px; background: var(--line);
+    border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+  }
+  .metagrid div { background: var(--surface); padding: 12px 14px; }
+  .metagrid dt {
+    font-family: var(--mono); font-size: 10.5px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--faint); margin-bottom: 3px;
+  }
+  .metagrid dd { margin: 0; font-family: var(--mono); font-size: 13px; color: var(--ink); font-weight: 600; }
+  .pill {
+    display:inline-block; font-family:var(--mono); font-size:11px; font-weight:700;
+    letter-spacing:.05em; padding:.2em .6em; border-radius:999px;
+    background: var(--low-bg); color: var(--low);
+  }
+  .pill.todo { background: var(--accent-wash); color: var(--accent); }
+
+  /* ── section scaffolding with mono rail ───────────────────── */
+  section.sec { padding: 40px 0; border-bottom: 1px solid var(--line); }
+  .sec-head { display: grid; grid-template-columns: var(--rail) 1fr; gap: 8px; align-items: baseline; }
+  .sec-label {
+    font-family: var(--mono); font-size: 11.5px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--faint); padding-top: 6px;
+  }
+  h2 { font-size: 25px; font-weight: 700; letter-spacing: -.015em; color: var(--ink); margin: 0; text-wrap: balance; }
+  .sec-body { display: grid; grid-template-columns: var(--rail) 1fr; gap: 8px; }
+  .sec-body > .spacer { grid-column: 1; }
+  .sec-body > .content { grid-column: 2; }
+  @media (max-width: 640px) {
+    .sec-head, .sec-body { grid-template-columns: 1fr; }
+    .sec-body > .content { grid-column: 1; }
+    .sec-label { padding-top: 0; }
+  }
+  .content > * + * { margin-top: 14px; }
+  p { margin: 0; }
+  strong { color: var(--ink); font-weight: 650; }
+  code {
+    font-family: var(--mono); font-size: .86em;
+    background: var(--surface-2); border: 1px solid var(--line);
+    padding: .08em .4em; border-radius: 4px; color: var(--ink);
+  }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid var(--line-2); }
+  a:hover { border-bottom-color: var(--accent); }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+
+  /* ── lede thesis card ─────────────────────────────────────── */
+  .thesis {
+    background: var(--surface); border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 10px; padding: 20px 22px;
+  }
+  .thesis p { font-size: 17px; color: var(--body); }
+  .thesis .lead { font-size: 18.5px; color: var(--ink); font-weight: 600; letter-spacing: -.01em; }
+
+  /* ── gap table ────────────────────────────────────────────── */
+  .tbl-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; min-width: 480px; }
+  caption { text-align: left; font-family: var(--mono); font-size: 11px; letter-spacing:.08em; text-transform:uppercase; color: var(--faint); padding: 0 0 8px; }
+  th, td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  thead th { font-family: var(--mono); font-size: 10.5px; letter-spacing: .1em; text-transform: uppercase; color: var(--faint); background: var(--surface-2); font-weight: 600; }
+  tbody tr:last-child td { border-bottom: none; }
+  td:first-child { color: var(--ink); font-weight: 550; width: 34%; }
+
+  /* ── code specimen ────────────────────────────────────────── */
+  figure.code { margin: 0; border: 1px solid var(--line-2); border-radius: 10px; overflow: hidden; background: var(--surface); }
+  figure.code figcaption {
+    font-family: var(--mono); font-size: 11.5px; color: var(--muted);
+    padding: 9px 14px; border-bottom: 1px solid var(--line); background: var(--surface-2);
+    display: flex; align-items: center; gap: 8px;
+  }
+  figure.code figcaption .fn { color: var(--accent); font-weight: 600; }
+  pre { margin: 0; padding: 16px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.7; color: var(--body); }
+  pre code { background: none; border: none; padding: 0; color: inherit; font-size: inherit; }
+  pre .c { color: var(--faint); font-style: italic; }
+  pre .k { color: var(--accent); }
+  pre .s { color: var(--good); }
+
+  /* ── review findings ──────────────────────────────────────── */
+  .findings { display: flex; flex-direction: column; gap: 10px; }
+  .finding {
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: 14px 16px; display: grid; grid-template-columns: auto 1fr; gap: 12px; align-items: start;
+  }
+  .sev {
+    font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: .06em;
+    text-transform: uppercase; padding: .3em .55em; border-radius: 5px; white-space: nowrap;
+    align-self: start; margin-top: 2px;
+  }
+  .sev-crit { background: var(--crit-bg); color: var(--crit); border: 1px solid var(--crit); }
+  .sev-high { background: var(--high-bg); color: var(--high); border: 1px solid var(--high); }
+  .sev-med  { background: var(--med-bg);  color: var(--med);  border: 1px solid var(--med); }
+  .f-title { color: var(--ink); font-weight: 650; font-size: 15px; }
+  .f-src { font-family: var(--mono); font-size: 11px; color: var(--faint); font-weight: 400; }
+  .f-body { font-size: 14px; color: var(--body); margin-top: 3px; }
+  .f-fix { font-size: 13px; color: var(--muted); margin-top: 6px; padding-top: 6px; border-top: 1px dashed var(--line-2); }
+  .f-fix b { color: var(--good); font-weight: 650; font-family: var(--mono); font-size: 10.5px; letter-spacing: .05em; text-transform: uppercase; }
+
+  /* ── decision + explore cards ─────────────────────────────── */
+  .cards { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+  @media (max-width: 560px) { .cards { grid-template-columns: 1fr; } }
+  .card { background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 16px 18px; }
+  .card h3 { margin: 0 0 6px; font-size: 15px; color: var(--ink); font-weight: 650; display:flex; gap:8px; align-items:baseline; }
+  .card h3 .tag { font-family: var(--mono); font-size: 10px; letter-spacing:.06em; text-transform:uppercase; color: var(--good); border:1px solid var(--good); border-radius:4px; padding:.1em .4em; }
+  .card p { font-size: 14px; color: var(--body); }
+  .card .alt { font-size: 12.5px; color: var(--muted); margin-top: 8px; }
+
+  .qlist { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+  .qlist li { display: grid; grid-template-columns: auto 1fr; gap: 11px; align-items: baseline; font-size: 14.5px; }
+  .qlist .q { font-family: var(--mono); color: var(--accent); font-weight: 700; }
+
+  .files { font-family: var(--mono); font-size: 13px; display:flex; flex-direction:column; gap:5px; }
+  .files .row { display:flex; gap:8px; align-items:baseline; flex-wrap:wrap; }
+  .fb { font-size:9.5px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:.15em .45em; border-radius:4px; }
+  .fb-mod { background: var(--med-bg); color: var(--med); }
+  .fb-new { background: var(--good-bg); color: var(--good); }
+  .fb-gen { background: var(--accent-wash); color: var(--accent); }
+
+  footer { padding: 30px 0 56px; }
+  .foot { font-family: var(--mono); font-size: 12px; color: var(--faint); display:flex; gap:16px; flex-wrap:wrap; justify-content:space-between; }
+
+  @media (prefers-reduced-motion: no-preference) {
+    a, .finding, .card { transition: border-color .15s ease, background .15s ease; }
+  }
+</style>
+
+<div class="doc">
+  <div class="band" aria-hidden="true"></div>
+
+  <div class="wrap">
+    <header class="mast">
+      <div class="eyebrow"><span class="dot"></span> Session Dossier · acss-kit · component-popover</div>
+      <h1>Anchoring the native popover to its trigger</h1>
+      <p class="dek">A working session that reviewed the existing native-Popover component, scoped an enhancement for dropdown nav and tooltips, and put the plan through a seven-reviewer critique before a line of it ships.</p>
+      <dl class="metagrid">
+        <div><dt>Component</dt><dd>component-popover</dd></div>
+        <div><dt>Approach</dt><dd>@supports CSS</dd></div>
+        <div><dt>Plan</dt><dd>10 steps · 11 AC</dd></div>
+        <div><dt>Reviewers</dt><dd>7</dd></div>
+        <div><dt>Status</dt><dd><span class="pill todo">todo</span></dd></div>
+        <div><dt>Commit</dt><dd>10dd358</dd></div>
+      </dl>
+    </header>
+
+    <!-- CONTEXT -->
+    <section class="sec">
+      <div class="sec-head"><div class="sec-label">Context</div><h2>What already exists — and the gap</h2></div>
+      <div class="sec-body">
+        <div class="spacer"></div>
+        <div class="content">
+          <div class="thesis">
+            <p class="lead">This was never a "build a popover" task. The repo already ships one.</p>
+            <p>The acss-kit <code>component-popover</code> skill generates a React popover built on the native HTML Popover API — <code>popover</code> + <code>popovertarget</code> + <code>showPopover()</code>/<code>hidePopover()</code>, auto/manual modes, light-dismiss, and top-layer rendering, with <em>zero</em> dependencies (no floating-ui, no radix). So the real work is closing the gap between "a centered card" and "a menu or tooltip that sits at its trigger."</p>
+          </div>
+          <div class="tbl-scroll">
+            <table>
+              <caption>Gap → fix, in priority order</caption>
+              <thead><tr><th>Gap today</th><th>Fix</th></tr></thead>
+              <tbody>
+                <tr><td>No real positioning — <code>data-placement</code> only draws an arrow; an <code>auto</code> popover lands viewport-center</td><td>CSS Anchor Positioning + <code>@supports not</code> fallback</td></tr>
+                <tr><td>No role semantics — the reference punts <code>role</code> to the consumer</td><td>Tooltip &amp; disclosure-menu presets with correct ARIA</td></tr>
+                <tr><td>Tooltips can't hover-open — native <code>popovertarget</code> is click-only</td><td>Hover/focus JS scoped to the tooltip preset</td></tr>
+                <tr><td>Arrow doesn't track <code>position-try</code> flips</td><td>Anchor the arrow to the same trigger</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p style="font-size:13.5px;color:var(--muted)">One hard constraint shapes everything: the generator has <strong>two source files</strong> — a neutral <code>popover.component.md</code> and a byte-identical <code>reference.md</code> fallback. A golden test diffs their extracted SCSS, so every change lands in both or CI goes red.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- APPROACH -->
+    <section class="sec">
+      <div class="sec-head"><div class="sec-label">Approach</div><h2>Progressive enhancement, inverted</h2></div>
+      <div class="sec-body">
+        <div class="spacer"></div>
+        <div class="content">
+          <p>CSS Anchor Positioning ships in <strong>Chrome/Edge 125+</strong> and <strong>Safari 26+</strong> — but not Firefox. So the base rule is the fallback that works everywhere, and the <code>@supports (anchor-name)</code> block layers the anchored version on top. Browsers that don't understand it never enter the block. No polyfill required, no JS branch.</p>
+          <figure class="code">
+            <figcaption><span class="fn">popover.scss</span> — the base rule is the everywhere-fallback; anchoring is additive</figcaption>
+<pre><code><span class="c">/* Base — works everywhere, unchanged behavior */</span>
+<span class="k">.popover</span> { inset: unset; <span class="c">/* border, bg, shadow… */</span> }
+
+<span class="c">/* Only Chrome/Edge 125+, Safari 26+ enter this block */</span>
+<span class="k">@supports</span> (anchor-name: --a) {
+  <span class="k">.popover</span> {
+    position-area: <span class="k">var</span>(--popover-area, block-end);
+    margin-block-start: <span class="k">var</span>(--popover-anchor-gap, 0.5rem);
+    position-try-fallbacks: flip-block, flip-inline;  <span class="c">/* auto edge-flip */</span>
+  }
+  <span class="k">.popover</span>[data-placement=<span class="s">"top"</span>] { --popover-area: block-start; }
+  <span class="k">.popover-arrow</span> { position-anchor: inherit; }   <span class="c">/* tracks the flip */</span>
+}</code></pre>
+          </figure>
+          <p><strong>The subtle part:</strong> a shared <code>anchor-name</code> would bind every popover to the nearest matching trigger — breaking the headline multi-instance case (a nav with several dropdowns). So the <code>anchor-name</code>/<code>position-anchor</code> pair rides in as an inline style keyed off the component's already-generated unique <code>id</code>. In a non-supporting browser it's just an unknown property — ignored, harmless.</p>
+          <figure class="code">
+            <figcaption><span class="fn">popover.tsx</span> — per-instance names, keyed off the generated id</figcaption>
+<pre><code><span class="c">// trigger</span>
+style={{ anchorName: <span class="s">`--pop-${popoverId}`</span> }}
+<span class="c">// popover element</span>
+style={{ positionAnchor: <span class="s">`--pop-${popoverId}`</span> }}</code></pre>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <!-- REVIEW -->
+    <section class="sec">
+      <div class="sec-head"><div class="sec-label">Review</div><h2>Seven reviewers, and what they caught</h2></div>
+      <div class="sec-body">
+        <div class="spacer"></div>
+        <div class="content">
+          <p>The draft plan went through an Agent Team — architecture, completeness, testability, risk, conventions, UX, accessibility. Several read the actual repo, so the findings are concrete, not generic. All of these were folded back into the plan before it was committed.</p>
+          <div class="findings">
+
+            <div class="finding">
+              <span class="sev sev-crit">critical</span>
+              <div>
+                <div class="f-title">Golden SCSS fixture never regenerated <span class="f-src">— completeness, risk, architecture</span></div>
+                <div class="f-body"><code>tests/run.sh</code> §2a diffs extracted SCSS against <code>tests/fixtures/golden/component-popover/popover.scss</code>. Any SCSS edit fails on golden DRIFT until that fixture is refreshed — the draft never listed it.</div>
+                <div class="f-fix"><b>Applied</b> New Step 9 regenerates the fixture; Files list + Context corrected.</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-crit">critical</span>
+              <div>
+                <div class="f-title"><code>role="menu"</code> on nav links is an ARIA anti-pattern <span class="f-src">— accessibility, ux</span></div>
+                <div class="f-body">A set of links dressed as <code>role="menu"</code> promises arrow-key roving-tabindex the plan doesn't build — assistive tech announces a contract the code breaks (WCAG 4.1.2).</div>
+                <div class="f-fix"><b>Applied</b> Switched to the WAI-ARIA Disclosure Navigation pattern (trigger <code>aria-expanded</code> + plain link list).</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-crit">critical</span>
+              <div>
+                <div class="f-title">E2E test wasn't a committed file; jsdom can't evaluate anchoring <span class="f-src">— testability</span></div>
+                <div class="f-body">The "E2E" was an ad-hoc MCP session, and jsdom has no layout engine — <code>anchor-name</code>/<code>position-try</code> are inert there. The anchored half of the objective had no repeatable guard.</div>
+                <div class="f-fix"><b>Applied</b> A committed Playwright spec (Chromium + Firefox); jsdom scoped to markup/ARIA only.</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-high">high</span>
+              <div>
+                <div class="f-title">Shared vs. per-instance <code>anchor-name</code> <span class="f-src">— architecture</span></div>
+                <div class="f-body">A class-level anchor name resolves to the nearest matching trigger, so multiple popovers on one page bind wrong — exactly the dropdown-nav use case.</div>
+                <div class="f-fix"><b>Applied</b> Per-instance names via inline style keyed off the generated id (Step 1 + AC8).</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-high">high</span>
+              <div>
+                <div class="f-title">Tooltip failed WCAG 1.4.13 <span class="f-src">— accessibility, ux</span></div>
+                <div class="f-body">A naive mouseenter/leave handler flickers, closes before you can read it, and excludes touch and keyboard. 1.4.13 requires hoverable + dismissible + persistent.</div>
+                <div class="f-fix"><b>Applied</b> Intent delay, listeners on the popover too, Escape dismiss, tap path (Step 5 + AC9).</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-high">high</span>
+              <div>
+                <div class="f-title">Breaking visual change with no version bump <span class="f-src">— risk</span></div>
+                <div class="f-body">Anchor CSS shifts where existing installs render on re-sync. The repo's pre-submit checklist requires a version bump + changelog for user-facing changes.</div>
+                <div class="f-fix"><b>Applied</b> New Step 10 bumps <code>plugin.json</code> + CHANGELOG (AC11).</div>
+              </div>
+            </div>
+
+            <div class="finding">
+              <span class="sev sev-high">high</span>
+              <div>
+                <div class="f-title">Parity mechanism misattributed; stale docs; filename mismatch <span class="f-src">— completeness, conventions</span></div>
+                <div class="f-body">The plan named the wrong parity guard, left the "user must add <code>role</code>" prose that the feature makes false, and never reconciled <code>popover.module.scss</code> vs <code>popover.scss</code>.</div>
+                <div class="f-fix"><b>Applied</b> New Step 8 (a11y prose + token tables); filename reconcile in Step 1; AC10.</div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- DECISIONS -->
+    <section class="sec">
+      <div class="sec-head"><div class="sec-label">Decisions</div><h2>Calls made this session</h2></div>
+      <div class="sec-body">
+        <div class="spacer"></div>
+        <div class="content">
+          <div class="cards">
+            <div class="card">
+              <h3><span class="tag">chosen</span> @supports fallback default</h3>
+              <p>CSS progressive enhancement, zero runtime. Firefox gets approximate placement until it ships anchoring natively.</p>
+              <p class="alt">Alt considered: JS positioning (getBoundingClientRect) — rejected, it reintroduces the library the native API replaced.</p>
+            </div>
+            <div class="card">
+              <h3><span class="tag">chosen</span> Disclosure over role="menu"</h3>
+              <p>A nav dropdown of links uses <code>aria-expanded</code> disclosure, not menu semantics. <code>role="menu"</code> waits for real keyboard support in a component-nav follow-up.</p>
+              <p class="alt">A role must not out-run the interaction it implies.</p>
+            </div>
+            <div class="card">
+              <h3><span class="tag">chosen</span> Polyfill = opt-in, not baked in</h3>
+              <p>OddBird's <code>@oddbird/css-anchor-positioning</code> is documented as a consumer-side feature-detected import — never a dependency of the generated component. Keeps <code>dependencies: []</code>.</p>
+              <p class="alt">Added to the plan's Next Steps for teams that need pixel-accurate Firefox anchoring.</p>
+            </div>
+            <div class="card">
+              <h3><span class="tag">chosen</span> Enhance, don't rebuild</h3>
+              <p>Everything lands in the two existing source docs, kept byte-identical. No new component, no parallel implementation.</p>
+              <p class="alt">The dual-source golden guard is the safety net for every edit.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- EXPLORE -->
+    <section class="sec">
+      <div class="sec-head"><div class="sec-label">Explore</div><h2>Open for the team</h2></div>
+      <div class="sec-body">
+        <div class="spacer"></div>
+        <div class="content">
+          <ul class="qlist">
+            <li><span class="q">?</span><span><strong>Ship or defer the <code>dialog</code> preset.</strong> It needs focus-into-on-open and focus-return-on-close, or it announces "dialog" while behaving like an unmanaged div. Ship with focus management, or cut it from v1?</span></li>
+            <li><span class="q">?</span><span><strong>Safari verification path.</strong> Anchoring is asserted in Chromium + Firefox by Playwright; Safari relies on a one-time manual check. Is a WebKit runner worth wiring up?</span></li>
+            <li><span class="q">?</span><span><strong>component-nav follow-up.</strong> The full menu-button pattern (roving tabindex, Arrow/Home/End) is queued as a separate plan. Does the disclosure pattern cover enough near-term?</span></li>
+            <li><span class="q">?</span><span><strong>interestfor invokers.</strong> The declarative hover API would delete the tooltip JS entirely once it ships broadly — parked on the Wish List. Worth tracking?</span></li>
+          </ul>
+          <div class="card" style="margin-top:18px">
+            <h3>Artifacts to review</h3>
+            <div class="files">
+              <div class="row"><span class="fb fb-mod">plan</span> <code>docs/plans/add-popover-anchor-positioning.html</code></div>
+              <div class="row"><span class="fb fb-mod">modified</span> <code>skills/component-popover/popover.component.md</code></div>
+              <div class="row"><span class="fb fb-mod">modified</span> <code>skills/component-popover/reference.md</code></div>
+              <div class="row"><span class="fb fb-gen">generated</span> <code>tests/fixtures/golden/component-popover/popover.scss</code></div>
+              <div class="row"><span class="fb fb-new">new</span> <code>tests/e2e/popover-anchor.spec.ts</code></div>
+            </div>
+            <p class="alt" style="margin-top:12px">The committed plan HTML carries the full 10 steps, 11 acceptance criteria, Tier-1 test matrix, and the appended Team Review — it's the source of truth for implementation.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <div class="foot">
+        <span>acss-kit · component-popover enhancement</span>
+        <span>branch claude/html-popover-component-fbf3f0 · plan status: todo</span>
+      </div>
+    </footer>
+  </div>
+</div>

--- a/docs/plans/index.html
+++ b/docs/plans/index.html
@@ -158,6 +158,11 @@
     .filter-chip[data-type="refactor"].active  { background: #7c3aed; border-color: #7c3aed; color: #fff; }
     .filter-chip[data-type="docs"].active      { background: #ea580c; border-color: #ea580c; color: #fff; }
     .filter-chip[data-type="chore"].active     { background: #0d9488; border-color: #0d9488; color: #fff; }
+    .filter-chip[data-type="artifact"].active  { background: #4f46e5; border-color: #4f46e5; color: #fff; }
+    .filter-chip[data-effort="all"].active     { background: var(--text); border-color: var(--text); color: #fff; }
+    .filter-chip[data-effort="low"].active     { background: #16a34a; border-color: #16a34a; color: #fff; }
+    .filter-chip[data-effort="medium"].active  { background: #d97706; border-color: #d97706; color: #fff; }
+    .filter-chip[data-effort="high"].active    { background: #dc2626; border-color: #dc2626; color: #fff; }
 
     /* ── Visible count ───────────────────────────────────────────── */
     .visible-count {
@@ -201,7 +206,7 @@
       gap: 5px;
     }
 
-    .status-chip, .type-chip {
+    .status-chip, .type-chip, .effort-chip {
       display: inline-block;
       font-size: 10px;
       font-weight: 700;
@@ -224,6 +229,13 @@
     .type-docs     { background: #fff7ed; color: #ea580c; border: 1px solid #fed7aa; }
     .type-chore    { background: #f0fdfa; color: #0d9488; border: 1px solid #99f6e4; }
     .type-untyped  { background: #f3f4f6; color: #6b7280; border: 1px solid #d1d5db; }
+    .type-artifact { background: #eef2ff; color: #4f46e5; border: 1px solid #c7d2fe; }
+
+    /* Effort colours — mirror the plan template's effort badge */
+    .effort-low    { background: #f0fdf4; color: #16a34a; border: 1px solid #bbf7d0; }
+    .effort-medium { background: #fffbeb; color: #d97706; border: 1px solid #fde68a; }
+    .effort-high   { background: #fef2f2; color: #dc2626; border: 1px solid #fecaca; }
+    .effort-chip::before { content: "\2022\00a0"; opacity: .6; }
 
     .card-title {
       font-size: 14px;
@@ -301,7 +313,7 @@
 
   <div class="gallery-header">
     <h1>Plans Library</h1>
-    <p>5 plans &mdash; click any card to open it</p>
+    <p>7 items &mdash; click any card to open it</p>
   </div>
 
   <div class="toolbar">
@@ -332,65 +344,39 @@
       <button class="filter-chip" data-type="refactor" aria-pressed="false">Refactor</button>
       <button class="filter-chip" data-type="docs" aria-pressed="false">Docs</button>
       <button class="filter-chip" data-type="chore" aria-pressed="false">Chore</button>
+      <button class="filter-chip" data-type="artifact" aria-pressed="false">Artifact</button>
+    </div>
+  </div>
+
+  <div class="filter-row" id="effortRow">
+    <span class="filter-row-label">Effort</span>
+    <div class="filter-chips" id="effortChips">
+      <button class="filter-chip active" data-effort="all" aria-pressed="true">All</button>
+      <button class="filter-chip" data-effort="low" aria-pressed="false">Low</button>
+      <button class="filter-chip" data-effort="medium" aria-pressed="false">Medium</button>
+      <button class="filter-chip" data-effort="high" aria-pressed="false">High</button>
     </div>
   </div>
 
   <div class="visible-count" id="visibleCount"></div>
 
   <div class="gallery-grid" id="galleryGrid">
-    <a class="gallery-card" href="realize-web-component-target.html"
-   data-status="todo" data-type="feature" data-title="realize the web-component projection target">
+    <a class="gallery-card" href="add-popover-anchor-positioning.html"
+   data-status="todo" data-type="feature" data-effort="high" data-title="enhance component-popover with anchor positioning + dropdown/tooltip presets">
   <div class="card-badges">
-    <span class="status-chip status-todo">todo</span>
-    <span class="type-chip type-feature">feature</span>
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-feature">feature</span>
+    <span class="effort-chip effort-high">high</span>
   </div>
-  <div class="card-title">Realize the web-component projection target</div>
+  <div class="card-title">Enhance component-popover with anchor positioning + dropdown/tooltip presets</div>
   <div class="card-meta">
-    <span class="card-date">2026-06-15</span>
-    <span class="card-file">realize-web-component-target.html</span>
-  </div>
-</a>
-<a class="gallery-card" href="generate-component-catalog.html"
-   data-status="todo" data-type="feature" data-title="generate a self-documenting component catalog from component.md">
-  <div class="card-badges">
-    <span class="status-chip status-todo">todo</span>
-    <span class="type-chip type-feature">feature</span>
-  </div>
-  <div class="card-title">Generate a self-documenting component catalog from COMPONENT.md</div>
-  <div class="card-meta">
-    <span class="card-date">2026-06-15</span>
-    <span class="card-file">generate-component-catalog.html</span>
-  </div>
-</a>
-<a class="gallery-card" href="evaluate-css-scope-encapsulation.html"
-   data-status="todo" data-type="chore" data-title="evaluate css @scope for component style encapsulation (spike)">
-  <div class="card-badges">
-    <span class="status-chip status-todo">todo</span>
-    <span class="type-chip type-chore">chore</span>
-  </div>
-  <div class="card-title">Evaluate CSS @scope for component style encapsulation (spike)</div>
-  <div class="card-meta">
-    <span class="card-date">2026-06-15</span>
-    <span class="card-file">evaluate-css-scope-encapsulation.html</span>
-  </div>
-</a>
-<a class="gallery-card" href="emit-custom-elements-manifest.html"
-   data-status="todo" data-type="feature" data-title="emit a custom elements manifest from component.md">
-  <div class="card-badges">
-    <span class="status-chip status-todo">todo</span>
-    <span class="type-chip type-feature">feature</span>
-  </div>
-  <div class="card-title">Emit a Custom Elements Manifest from COMPONENT.md</div>
-  <div class="card-meta">
-    <span class="card-date">2026-06-15</span>
-    <span class="card-file">emit-custom-elements-manifest.html</span>
+    <span class="card-date">2026-07-07</span>
+    <span class="card-file">add-popover-anchor-positioning.html</span>
   </div>
 </a>
 <a class="gallery-card" href="document-primitive-composite-boundary.html"
-   data-status="todo" data-type="docs" data-title="document the primitive vs composite boundary in the component.md spec">
+   data-status="todo" data-type="docs" data-effort="" data-title="document the primitive vs composite boundary in the component.md spec">
   <div class="card-badges">
-    <span class="status-chip status-todo">todo</span>
-    <span class="type-chip type-docs">docs</span>
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-docs">docs</span>
   </div>
   <div class="card-title">Document the primitive vs composite boundary in the COMPONENT.md spec</div>
   <div class="card-meta">
@@ -398,18 +384,74 @@
     <span class="card-file">document-primitive-composite-boundary.html</span>
   </div>
 </a>
+<a class="gallery-card" href="emit-custom-elements-manifest.html"
+   data-status="todo" data-type="feature" data-effort="" data-title="emit a custom elements manifest from component.md">
+  <div class="card-badges">
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-feature">feature</span>
+  </div>
+  <div class="card-title">Emit a Custom Elements Manifest from COMPONENT.md</div>
+  <div class="card-meta">
+    <span class="card-date">2026-06-15</span>
+    <span class="card-file">emit-custom-elements-manifest.html</span>
+  </div>
+</a>
+<a class="gallery-card" href="evaluate-css-scope-encapsulation.html"
+   data-status="todo" data-type="chore" data-effort="" data-title="evaluate css @scope for component style encapsulation (spike)">
+  <div class="card-badges">
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-chore">chore</span>
+  </div>
+  <div class="card-title">Evaluate CSS @scope for component style encapsulation (spike)</div>
+  <div class="card-meta">
+    <span class="card-date">2026-06-15</span>
+    <span class="card-file">evaluate-css-scope-encapsulation.html</span>
+  </div>
+</a>
+<a class="gallery-card" href="generate-component-catalog.html"
+   data-status="todo" data-type="feature" data-effort="" data-title="generate a self-documenting component catalog from component.md">
+  <div class="card-badges">
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-feature">feature</span>
+  </div>
+  <div class="card-title">Generate a self-documenting component catalog from COMPONENT.md</div>
+  <div class="card-meta">
+    <span class="card-date">2026-06-15</span>
+    <span class="card-file">generate-component-catalog.html</span>
+  </div>
+</a>
+<a class="gallery-card" href="realize-web-component-target.html"
+   data-status="todo" data-type="feature" data-effort="" data-title="realize the web-component projection target">
+  <div class="card-badges">
+    <span class="status-chip status-todo">todo</span><span class="type-chip type-feature">feature</span>
+  </div>
+  <div class="card-title">Realize the web-component projection target</div>
+  <div class="card-meta">
+    <span class="card-date">2026-06-15</span>
+    <span class="card-file">realize-web-component-target.html</span>
+  </div>
+</a>
+<a class="gallery-card" href="artifacts/popover-dossier-2026-07-07.html"
+   data-status="" data-type="artifact" data-effort="" data-title="popover-dossier-2026-07-07.html">
+  <div class="card-badges">
+    <span class="type-chip type-artifact">artifact</span>
+  </div>
+  <div class="card-title">popover-dossier-2026-07-07.html</div>
+  <div class="card-meta">
+    <span class="card-date">2026-07-07</span>
+    <span class="card-file">artifacts/popover-dossier-2026-07-07.html</span>
+  </div>
+</a>
   </div>
 
-  <div class="no-results" id="noResults">No plans match your search.</div>
+  <div class="no-results" id="noResults">No items match your search.</div>
 
   <div class="gallery-footer">
-    <span>5 plans</span>
-    <span>Generated 2026-06-19 13:24</span>
+    <span>7 items</span>
+    <span>Generated 2026-07-07 22:25</span>
   </div>
 
   <script>
     var activeStatus = 'all';
     var activeType   = 'all';
+    var activeEffort = 'all';
     var searchText   = '';
     var grid         = document.getElementById('galleryGrid');
     var cards        = grid.querySelectorAll('.gallery-card');
@@ -422,11 +464,14 @@
         var card   = cards[i];
         var status = card.getAttribute('data-status') || '';
         var type   = card.getAttribute('data-type')   || '';
+        var effort = card.getAttribute('data-effort') || '';
         var title  = card.getAttribute('data-title')  || '';
         var matchStatus = activeStatus === 'all' || status === activeStatus;
         var matchType   = activeType   === 'all' || type   === activeType;
+        // Plans with no effort tag pass every effort filter.
+        var matchEffort = activeEffort === 'all' || effort === '' || effort === activeEffort;
         var matchSearch = !searchText  || title.indexOf(searchText) !== -1;
-        if (matchStatus && matchType && matchSearch) {
+        if (matchStatus && matchType && matchEffort && matchSearch) {
           card.style.display = '';
           shown++;
         } else {
@@ -436,7 +481,7 @@
       noResults.style.display = shown === 0 ? 'block' : 'none';
       visibleCount.textContent = shown === cards.length
         ? ''
-        : 'Showing ' + shown + ' of ' + cards.length + ' plans';
+        : 'Showing ' + shown + ' of ' + cards.length + ' items';
     }
 
     function wireChips(containerId, prop) {
@@ -450,8 +495,10 @@
           }
           this.classList.add('active');
           this.setAttribute('aria-pressed', 'true');
-          if (prop === 'status') activeStatus = this.getAttribute('data-status');
-          else                   activeType   = this.getAttribute('data-type');
+          var val = this.getAttribute('data-' + prop);
+          if      (prop === 'status') activeStatus = val;
+          else if (prop === 'type')   activeType   = val;
+          else                        activeEffort = val;
           applyFilters();
         });
       }
@@ -459,6 +506,7 @@
 
     wireChips('statusChips', 'status');
     wireChips('typeChips',   'type');
+    wireChips('effortChips', 'effort');
 
     document.getElementById('searchBox').addEventListener('input', function () {
       searchText = this.value.trim().toLowerCase();


### PR DESCRIPTION
## What

Adds a self-contained HTML implementation plan for enhancing the acss-kit `component-popover` skill with **CSS Anchor Positioning** and **dropdown-nav / tooltip role presets**.

Plan file: `docs/plans/add-popover-anchor-positioning.html`

## Why

`component-popover` already ships a native HTML Popover (auto/manual, light-dismiss, top-layer, zero deps), but it fakes placement with a `data-placement` arrow and never tethers the popover to its trigger — so it can't serve dropdown nav or tooltips. This plan closes that gap using the native `@supports (anchor-name)` progressive-enhancement path with a CSS `@supports not` fallback (Firefox), keeping `dependencies: []`.

## What's in the plan

- **10 steps** editing the two byte-identical source docs (`popover.component.md` + `reference.md`) in lockstep, plus golden-fixture regeneration, a committed Playwright E2E spec, and a version bump/CHANGELOG.
- **11 acceptance criteria**, Tier-1 test matrix (objective + unit/integration/E2E).
- An appended **Team Review** section — the plan was run through a 7-reviewer critique (architecture, completeness, testability, risk, conventions, UX, accessibility) and hardened before commit. Key corrections baked in: per-instance `anchor-name`, disclosure pattern over `role="menu"`, WCAG 1.4.13 tooltip behavior, committed E2E, golden-fixture regen, version bump.

## Reviewer notes

- **This is a plan document only — no component source changes.** Implementation is a separate, follow-up task.
- Two commits: the reviewed plan, then a Next-Steps addition documenting the OddBird anchor-positioning polyfill as an opt-in (not a baked-in dependency).
- Open questions for discussion are captured in the plan's Next Steps / Team Review (ship-or-defer `dialog` preset, Safari verification, component-nav follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new planning page for enhancing `component-popover` with CSS Anchor Positioning, including a Firefox fallback via feature detection.
  * Introduced new `tooltip` and `disclosure-nav` role preset guidance within the plan.
  * Includes interactive “Save as PDF,” implement-prompt generation, one-click copy tools, live progress/status updates, scroll progress indication, and improved sidebar section highlighting.
  * Provides a structured checklist, acceptance-criteria tracking, and test plan coverage (unit, integration, e2e).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->