### PR TITLE
chore: set up GitHub Pages publishing for docs/

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Pages artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Assert .nojekyll exists
+        run: test -f docs/.nojekyll || { echo "::error::docs/.nojekyll is missing — Jekyll will mangle the site"; exit 1; }
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: docs
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agentic ACSS Plugins</title>
+  <style>
+    :root {
+      --bg:         #ffffff;
+      --surface:    #f9fafb;
+      --border:     #e5e7eb;
+      --border-mid: #d1d5db;
+      --text:       #111827;
+      --muted:      #6b7280;
+      --subtle:     #9ca3af;
+      --accent:     #2563eb;
+      --accent-bg:  #eff6ff;
+      --radius:     4px;
+      --shadow:     0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font-size: 15px;
+      min-height: 100vh;
+      padding: 32px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+    }
+
+    /* ── Skip link ──────────────────────────────────────────────── */
+    .skip-link {
+      position: absolute;
+      left: -9999px; top: auto;
+      width: 1px; height: 1px;
+      overflow: hidden;
+    }
+    .skip-link:focus {
+      position: fixed;
+      left: 1rem; top: 1rem;
+      width: auto; height: auto;
+      overflow: visible;
+      background: var(--accent);
+      color: #fff;
+      padding: .5rem 1rem;
+      border-radius: var(--radius);
+      font-weight: 700;
+      z-index: 9999;
+      text-decoration: none;
+    }
+
+    /* ── Header ──────────────────────────────────────────────────── */
+    .gallery-header {
+      max-width: 1200px;
+      margin: 0 auto 32px;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 16px;
+    }
+    .gallery-header::before {
+      content: "";
+      display: block;
+      height: 3px;
+      background: var(--accent);
+      margin-bottom: 20px;
+      border-radius: 2px;
+    }
+    .gallery-header h1 {
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: -.02em;
+      margin-bottom: 4px;
+    }
+    .gallery-header p {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    /* ── Card grid ───────────────────────────────────────────────── */
+    .gallery-grid {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+
+    @media (max-width: 640px) {
+      .gallery-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    /* ── Cards ───────────────────────────────────────────────────── */
+    .gallery-card {
+      display: block;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
+      text-decoration: none;
+      color: var(--text);
+      box-shadow: var(--shadow);
+      transition: border-color .15s, box-shadow .15s;
+    }
+    .gallery-card:hover {
+      border-color: var(--accent);
+      box-shadow: 0 4px 12px rgba(0,0,0,.08);
+    }
+    .gallery-card:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .gallery-card { transition: none; }
+    }
+
+    .gallery-card .card-title {
+      font-size: 17px;
+      font-weight: 700;
+      margin-bottom: 6px;
+      letter-spacing: -.01em;
+    }
+    .gallery-card .card-description {
+      font-size: 13px;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    /* ── Footer ──────────────────────────────────────────────────── */
+    .gallery-footer {
+      max-width: 1200px;
+      margin: 48px auto 0;
+      padding-top: 16px;
+      border-top: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--subtle);
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+<a href="#main" class="skip-link">Skip to content</a>
+
+<header class="gallery-header">
+  <h1>Agentic ACSS Plugins</h1>
+  <p>Browse generated plans and social cards.</p>
+</header>
+
+<main id="main">
+  <div class="gallery-grid">
+
+    <!-- CARD:plans -->
+    <a class="gallery-card" href="plans/index.html">
+      <div class="card-title">Plans</div>
+      <div class="card-description">Browse implementation plans for features, fixes, and infrastructure changes.</div>
+    </a>
+    <!-- /CARD:plans -->
+
+    <!-- CARD:social -->
+    <a class="gallery-card" href="media/social/index.html">
+      <div class="card-title">Social Media</div>
+      <div class="card-description">View social media cards and posts generated from code changes, releases, and project highlights.</div>
+    </a>
+    <!-- /CARD:social -->
+
+  </div>
+</main>
+
+<footer class="gallery-footer">
+  Agentic ACSS Plugins
+</footer>
+
+</body>
+</html>

--- a/docs/media/social/index.html
+++ b/docs/media/social/index.html
@@ -1,0 +1,576 @@
+<!DOCTYPE html>
+<!--
+  gallery.html — Media library for saved social media cards.
+
+  Static variables (substituted by the media-library skill):
+    GALLERY_ENTRIES  — Repeated <a> blocks, one per saved card
+    CARD_COUNT       — Total number of cards displayed
+    GENERATED_AT     — ISO timestamp of gallery generation
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Media Library</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --muted: #8b949e;
+      --accent: #388bfd;
+      --accent-hover: #58a6ff;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      padding: 32px;
+    }
+
+    .gallery-header {
+      max-width: 1200px;
+      margin: 0 auto 24px;
+    }
+
+    .gallery-header h1 {
+      font-size: 24px;
+      font-weight: 600;
+      margin-bottom: 6px;
+    }
+
+    .gallery-header p {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .toolbar {
+      max-width: 1200px;
+      margin: 0 auto 24px;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .search-box {
+      flex: 1;
+      min-width: 200px;
+      max-width: 360px;
+      padding: 8px 12px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    .search-box:focus {
+      border-color: var(--accent);
+    }
+
+    .search-box::placeholder {
+      color: var(--muted);
+    }
+
+    .filter-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .filter-chip {
+      padding: 4px 12px;
+      border-radius: 16px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      cursor: pointer;
+      transition: all 0.15s;
+      white-space: nowrap;
+    }
+
+    .filter-chip:hover {
+      border-color: var(--accent);
+      color: var(--text);
+    }
+
+    .filter-chip.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+
+    .view-toggle {
+      margin-left: auto;
+      display: flex;
+      gap: 4px;
+    }
+
+    .view-btn {
+      padding: 6px 10px;
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 14px;
+      transition: all 0.15s;
+    }
+
+    .view-btn:first-child { border-radius: 6px 0 0 6px; }
+    .view-btn:last-child { border-radius: 0 6px 6px 0; }
+
+    .view-btn.active {
+      background: var(--surface);
+      border-color: var(--accent);
+      color: var(--text);
+    }
+
+    .visible-count {
+      font-size: 12px;
+      color: var(--muted);
+      max-width: 1200px;
+      margin: 0 auto 16px;
+    }
+
+    /* Grid view */
+    .gallery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 20px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .gallery-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.15s, box-shadow 0.15s;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .gallery-card:hover {
+      border-color: var(--accent);
+      box-shadow: 0 4px 16px rgba(56, 139, 253, 0.15);
+    }
+
+    .thumb-container {
+      width: 100%;
+      aspect-ratio: 16 / 10;
+      background: var(--bg);
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .thumb-container img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .thumb-fallback {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--border);
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+
+    .card-info {
+      padding: 14px 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      flex: 1;
+    }
+
+    .card-info-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .type-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      white-space: nowrap;
+    }
+
+    .type-diff     { background: #f8514933; color: #f85149; }
+    .type-feature  { background: #3fb95033; color: #3fb950; }
+    .type-quote    { background: #d2a8ff33; color: #d2a8ff; }
+    .type-blog     { background: #388bfd33; color: #388bfd; }
+    .type-snippet  { background: #79c0ff33; color: #79c0ff; }
+    .type-video    { background: #ff7b7233; color: #ff7b72; }
+    .type-project  { background: #ffa65733; color: #ffa657; }
+    .type-session  { background: #7ee78733; color: #7ee787; }
+
+    .card-date {
+      font-size: 12px;
+      color: var(--muted);
+      font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+    }
+
+    .card-topic {
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--text);
+      line-height: 1.4;
+    }
+
+    .card-file {
+      font-size: 11px;
+      color: var(--muted);
+      font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+      word-break: break-all;
+    }
+
+    /* List view */
+    .gallery-grid.list-view {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .list-view .gallery-card {
+      flex-direction: row;
+      align-items: center;
+      border-radius: 6px;
+    }
+
+    .list-view .thumb-container {
+      width: 120px;
+      min-width: 120px;
+      aspect-ratio: 16 / 10;
+      border-bottom: none;
+      border-right: 1px solid var(--border);
+    }
+
+    .list-view .card-info {
+      flex-direction: row;
+      align-items: center;
+      gap: 16px;
+      padding: 12px 16px;
+      flex: 1;
+      min-width: 0;
+    }
+
+    .list-view .card-info-top {
+      gap: 12px;
+      flex-shrink: 0;
+    }
+
+    .list-view .card-topic {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .list-view .card-file {
+      flex-shrink: 0;
+    }
+
+    .gallery-card-wrap {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .open-img-link {
+      display: block;
+      font-size: 12px;
+      color: var(--accent);
+      text-align: center;
+      padding: 4px 0 8px;
+      text-decoration: none;
+      transition: color 0.15s;
+      background: none;
+      border: 0;
+      cursor: pointer;
+      font-family: inherit;
+      width: 100%;
+    }
+
+    .open-img-link:hover {
+      color: var(--accent-hover);
+      text-decoration: underline;
+    }
+
+    #imgDialog {
+      border: none;
+      background: transparent;
+      padding: 0;
+      max-width: 90vw;
+      max-height: 90vh;
+    }
+
+    #imgDialog::backdrop {
+      background: rgba(0, 0, 0, 0.8);
+    }
+
+    #imgDialog .dialog-content {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    #imgDialog img {
+      max-width: 90vw;
+      max-height: 85vh;
+      object-fit: contain;
+      border-radius: 6px;
+    }
+
+    #imgDialog .dialog-close {
+      position: absolute;
+      top: -12px;
+      right: -12px;
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: none;
+      background: var(--surface);
+      color: var(--text);
+      font-size: 18px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.15s;
+    }
+
+    #imgDialog .dialog-close:hover {
+      background: var(--border);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #imgDialog, #imgDialog::backdrop {
+        transition: none;
+        animation: none;
+      }
+    }
+
+    .no-results {
+      max-width: 1200px;
+      margin: 64px auto;
+      text-align: center;
+      color: var(--muted);
+      font-size: 14px;
+      display: none;
+    }
+
+    .gallery-footer {
+      max-width: 1200px;
+      margin: 32px auto 0;
+      padding-top: 16px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .gallery-footer span {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 640px) {
+      body { padding: 16px; }
+      .toolbar { gap: 8px; }
+      .search-box { max-width: none; }
+      .list-view .thumb-container { display: none; }
+      .list-view .card-info { flex-wrap: wrap; gap: 8px; }
+      .list-view .card-topic { white-space: normal; }
+    }
+  </style>
+</head>
+<body>
+  <div class="gallery-header">
+    <h1>Media Library</h1>
+    <p>1 saved cards &mdash; click any card to view it</p>
+  </div>
+
+  <div class="toolbar">
+    <input type="text" class="search-box" placeholder="Search by topic or type..." id="searchBox" aria-label="Search cards by topic or type">
+    <div class="filter-chips" id="filterChips">
+      <button class="filter-chip active" data-type="all" aria-pressed="true">All</button>
+      <button class="filter-chip" data-type="diff" aria-pressed="false">Diff</button>
+      <button class="filter-chip" data-type="feature" aria-pressed="false">Feature</button>
+      <button class="filter-chip" data-type="quote" aria-pressed="false">Quote</button>
+      <button class="filter-chip" data-type="blog" aria-pressed="false">Blog</button>
+      <button class="filter-chip" data-type="snippet" aria-pressed="false">Snippet</button>
+      <button class="filter-chip" data-type="video" aria-pressed="false">Video</button>
+      <button class="filter-chip" data-type="project" aria-pressed="false">Project</button>
+      <button class="filter-chip" data-type="session" aria-pressed="false">Session</button>
+    </div>
+    <div class="view-toggle">
+      <button class="view-btn active" id="gridBtn" title="Grid view" aria-label="Grid view" aria-pressed="true">&#9638;</button>
+      <button class="view-btn" id="listBtn" title="List view" aria-label="List view" aria-pressed="false">&#9776;</button>
+    </div>
+  </div>
+
+  <div class="visible-count" id="visibleCount"></div>
+
+  <div class="gallery-grid" id="galleryGrid">
+    <div class="gallery-card-wrap">
+    <a class="gallery-card" href="diff-sessionstart-worktree-origin-reset-2026-06-18.html" data-type="diff" data-topic="Sessionstart Worktree Origin Reset">
+      <div class="thumb-container">
+        <img src="diff-sessionstart-worktree-origin-reset-2026-06-18.png" alt="Sessionstart Worktree Origin Reset" onerror="showFallback(this)">
+        <span class="thumb-fallback" style="display:none">diff</span>
+      </div>
+      <div class="card-info">
+        <div class="card-info-top">
+          <span class="type-badge type-diff">diff</span>
+          <span class="card-date">2026-06-18</span>
+        </div>
+        <span class="card-topic">Sessionstart Worktree Origin Reset</span>
+        <span class="card-file">diff-sessionstart-worktree-origin-reset-2026-06-18.html</span>
+      </div>
+    </a>
+    <button type="button" class="open-img-link" data-img="diff-sessionstart-worktree-origin-reset-2026-06-18.png" data-topic="Sessionstart Worktree Origin Reset" aria-label="View image: Sessionstart Worktree Origin Reset">View image</button>
+    </div>
+  </div>
+
+  <div class="no-results" id="noResults">No cards match your search.</div>
+
+  <div class="gallery-footer">
+    <span>1 cards</span>
+    <span>Generated 2026-07-07</span>
+  </div>
+
+  <dialog id="imgDialog">
+    <div class="dialog-content">
+      <img id="imgDialogImg" src="" alt="">
+      <button class="dialog-close" aria-label="Close">&times;</button>
+    </div>
+  </dialog>
+
+  <script>
+    function showFallback(img) {
+      var container = img.parentElement;
+      img.style.display = 'none';
+      var fb = container.querySelector('.thumb-fallback');
+      if (fb) fb.style.display = 'block';
+    }
+
+    var imgDialog = document.getElementById('imgDialog');
+    var imgDialogImg = document.getElementById('imgDialogImg');
+    var dialogCloseBtn = imgDialog.querySelector('.dialog-close');
+
+    document.getElementById('galleryGrid').addEventListener('click', function(e) {
+      var btn = e.target.closest('.open-img-link');
+      if (!btn) return;
+      var imgSrc = btn.getAttribute('data-img');
+      if (!imgSrc || !/^[a-zA-Z0-9._-]+\.png$/i.test(imgSrc)) return;
+      imgDialogImg.src = encodeURI(imgSrc);
+      imgDialogImg.alt = btn.getAttribute('data-topic') || 'Social card image';
+      imgDialog.showModal();
+    });
+
+    dialogCloseBtn.addEventListener('click', function() {
+      imgDialog.close();
+    });
+
+    imgDialog.addEventListener('click', function(e) {
+      if (e.target === imgDialog) imgDialog.close();
+    });
+
+    var activeType = 'all';
+    var searchText = '';
+    var grid = document.getElementById('galleryGrid');
+    var cards = grid.querySelectorAll('.gallery-card-wrap');
+    var chips = document.querySelectorAll('.filter-chip');
+    var searchBox = document.getElementById('searchBox');
+    var noResults = document.getElementById('noResults');
+    var visibleCount = document.getElementById('visibleCount');
+
+    function applyFilters() {
+      var shown = 0;
+      for (var i = 0; i < cards.length; i++) {
+        var wrap = cards[i];
+        var inner = wrap.querySelector('.gallery-card');
+        var type = inner ? inner.getAttribute('data-type') || '' : '';
+        var topic = inner ? inner.getAttribute('data-topic') || '' : '';
+        var matchType = activeType === 'all' || type === activeType;
+        var matchSearch = !searchText ||
+          topic.toLowerCase().indexOf(searchText) !== -1 ||
+          type.toLowerCase().indexOf(searchText) !== -1;
+        if (matchType && matchSearch) {
+          wrap.style.display = '';
+          shown++;
+        } else {
+          wrap.style.display = 'none';
+        }
+      }
+      noResults.style.display = shown === 0 ? 'block' : 'none';
+      visibleCount.textContent = shown === cards.length
+        ? ''
+        : 'Showing ' + shown + ' of ' + cards.length + ' cards';
+    }
+
+    for (var i = 0; i < chips.length; i++) {
+      chips[i].addEventListener('click', function() {
+        for (var j = 0; j < chips.length; j++) {
+          chips[j].classList.remove('active');
+          chips[j].setAttribute('aria-pressed', 'false');
+        }
+        this.classList.add('active');
+        this.setAttribute('aria-pressed', 'true');
+        activeType = this.getAttribute('data-type');
+        applyFilters();
+      });
+    }
+
+    searchBox.addEventListener('input', function() {
+      searchText = this.value.trim().toLowerCase();
+      applyFilters();
+    });
+
+    var gridBtn = document.getElementById('gridBtn');
+    var listBtn = document.getElementById('listBtn');
+
+    gridBtn.addEventListener('click', function() {
+      grid.classList.remove('list-view');
+      gridBtn.classList.add('active');
+      gridBtn.setAttribute('aria-pressed', 'true');
+      listBtn.classList.remove('active');
+      listBtn.setAttribute('aria-pressed', 'false');
+    });
+
+    listBtn.addEventListener('click', function() {
+      grid.classList.add('list-view');
+      listBtn.classList.add('active');
+      listBtn.setAttribute('aria-pressed', 'true');
+      gridBtn.classList.remove('active');
+      gridBtn.setAttribute('aria-pressed', 'false');
+    });
+  </script>
+</body>
+</html>

--- a/scripts/serve-docs.sh
+++ b/scripts/serve-docs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local preview for the docs/ tree before it ships to GitHub Pages.
+# Serves docs/ over http://127.0.0.1 on an auto-selected free port (or pass
+# a port as $1). Mirrors what the deploy-pages.yml workflow uploads, so what
+# you see here is what Pages will publish.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOCS_DIR="$REPO_ROOT/docs"
+PORT="${1:-0}"
+
+if [ ! -d "$DOCS_DIR" ]; then
+  echo "Error: docs/ directory not found at $DOCS_DIR" >&2
+  exit 1
+fi
+
+if [ "$PORT" = "0" ]; then
+  PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+fi
+
+echo ""
+echo "Serving docs at http://localhost:$PORT/"
+[ -f "$DOCS_DIR/plans/index.html" ]        && echo "  Plans gallery:  http://localhost:$PORT/plans/"
+[ -f "$DOCS_DIR/media/social/index.html" ] && echo "  Media library:  http://localhost:$PORT/media/social/"
+echo ""
+echo "Press Ctrl+C to stop."
+echo ""
+
+cd "$DOCS_DIR"
+python3 -m http.server "$PORT" --bind 127.0.0.1


### PR DESCRIPTION
## What

Scaffolds the GitHub Pages deploy pipeline so anything generated under `docs/` (plan galleries, social cards, static HTML) publishes to a public URL.

**Live URL:** https://shawn-sandy.github.io/agentic-acss-plugins/ (project site, served under the `/agentic-acss-plugins/` path prefix)

## Files added

- `.github/workflows/deploy-pages.yml` — path-filtered Actions workflow; a push to `main` touching `docs/**` uploads `docs/` and deploys to Pages. Actions are SHA-pinned.
- `docs/.nojekyll` — stops Jekyll from mangling underscore filenames (build job asserts on this).
- `docs/index.html` — landing hub linking the Plans and Social galleries. Relative links only (required under the path prefix).
- `scripts/serve-docs.sh` — local preview server.

## Why

Generated `docs/` output (from `plan-agent`, `social-media-tools`) had no publish path. This installs the one-push-to-deploy pipeline.

## Reviewer notes

- Pages source is already set to **GitHub Actions** via `gh` (one-time repo setting).
- Only a push to `main` touching `docs/**` triggers a deploy — this feature branch never publishes; the deploy fires on merge.
- Preview locally: `bash scripts/serve-docs.sh`.
- Verified: `.nojekyll` present, workflow installed, actions SHA-pinned, hub uses relative links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)