### PR TITLE
docs: consumer usage guides for components, styles, and utilities

### DIFF
--- a/plugins/acss-kit/docs/README.md
+++ b/plugins/acss-kit/docs/README.md
@@ -8,6 +8,9 @@ Developers using the plugin to generate fpkit-style components into their own pr
 
 | Guide | What it covers |
 |-------|---------------|
+| [components/](components/README.md) | Per-component usage guides — add-command, import, props, examples, theming, and a11y for all 15 components |
+| [styles.md](styles.md) | Consuming the theming system: theme commands, how generated `light.css`/`dark.css` are imported, and theme roles |
+| [utilities.md](utilities.md) | Consuming the atomic-CSS utilities: `/utility-add`, class usage, breakpoints, and the token bridge |
 | [visual-guide.md](visual-guide.md) | A diagrams-first portal: system overview, `/kit-add` lifecycle, component anatomy, composition, theming flow, and a gated maintainer track |
 | [tutorial.md](tutorial.md) | A guided walkthrough: generate, import, and customize your first component |
 | [concepts.md](concepts.md) | The mental model: UI base component, data-\* variants, CSS-var fallbacks, aria-disabled, generation flow, and the `.acss-target.json` config |

--- a/plugins/acss-kit/docs/components/README.md
+++ b/plugins/acss-kit/docs/components/README.md
@@ -1,0 +1,40 @@
+# Component Usage Guides
+
+Consumer-facing guides for using each `acss-kit` component in your own React project. Each guide covers: how to add the component, how to import it, its props, copy-paste examples, theming variables, and accessibility notes.
+
+> These are **consumer** guides. The canonical, verified-against-fpkit source for each component lives in `skills/component-<name>/reference.md`.
+
+## First time here?
+
+1. Run `/setup` once — installs `sass`, creates the `ui.tsx` foundation, writes `.acss-target.json`, and seeds a starter theme.
+2. Add a component with `/kit-add <Name>`, or install everything at once with `/kit-sync`.
+3. Import the generated `.tsx` + `.scss` pair and use it.
+
+See the [tutorial](../tutorial.md) for a full walkthrough and [concepts](../concepts.md) for the mental model.
+
+## Components
+
+| Component | What it is |
+|-----------|-----------|
+| [Alert](alert.md) | Status/feedback message banner. |
+| [Button](button.md) | Primary interactive element with size/style/color variants. |
+| [Card](card.md) | Content container with header/body/footer regions. |
+| [Checkbox](checkbox.md) | Accessible checkbox input. |
+| [Dialog](dialog.md) | Modal dialog / `<dialog>` wrapper. |
+| [Field](field.md) | Label + control + help/error wrapper for forms. |
+| [Icon](icon.md) | Inline SVG icon. |
+| [Icon Button](icon-button.md) | Icon-only button. |
+| [Img](img.md) | Responsive image with aspect-ratio control. |
+| [Input](input.md) | Text input control. |
+| [Link](link.md) | Styled anchor / router-agnostic link. |
+| [List](list.md) | Ordered/unordered list wrapper. |
+| [Nav](nav.md) | Navigation landmark with links. |
+| [Popover](popover.md) | Anchored popover / tooltip. |
+| [Table](table.md) | Data table with accessible structure. |
+
+## Styles and utilities
+
+| Guide | What it covers |
+|-------|---------------|
+| [Styles (theming)](../styles.md) | OKLCH light/dark themes, brand presets, theme-role edits, token extraction. |
+| [Utilities (atomic CSS)](../utilities.md) | Tailwind-style utility classes, breakpoints, the token bridge. |

--- a/plugins/acss-kit/docs/components/README.md
+++ b/plugins/acss-kit/docs/components/README.md
@@ -26,7 +26,7 @@ See the [tutorial](../tutorial.md) for a full walkthrough and [concepts](../conc
 | [Icon Button](icon-button.md) | Icon-only button. |
 | [Img](img.md) | Responsive image with aspect-ratio control. |
 | [Input](input.md) | Text input control. |
-| [Link](link.md) | Styled anchor / router-agnostic link. |
+| [Link component](link.md) | Styled anchor / router-agnostic link. |
 | [List](list.md) | Ordered/unordered list wrapper. |
 | [Nav](nav.md) | Navigation landmark with links. |
 | [Popover](popover.md) | Anchored popover / tooltip. |

--- a/plugins/acss-kit/docs/components/alert.md
+++ b/plugins/acss-kit/docs/components/alert.md
@@ -1,0 +1,123 @@
+# Alert — Usage Guide
+
+A severity-aware notification for status messages. Supports info/success/warning/error levels with matching icons, optional dismissal, optional auto-hide, and three visual variants. Uses `role="alert"` / `role="status"` live regions so screen readers announce it correctly.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Alert` — copies `alert.tsx` + `alert.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required. Alert inlines its severity icon SVGs, so it has no Icon dependency.
+
+## Import
+
+```tsx
+import Alert from './fpkit/alert/alert'
+import './fpkit/alert/alert.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | — (required) | Whether the alert is visible. |
+| `children` | `React.ReactNode` | — (required) | Alert content. |
+| `severity` | `'default' \| 'info' \| 'success' \| 'warning' \| 'error'` | `default` | Determines color, icon, and live-region role. |
+| `title` | `string` | — | Optional title. |
+| `dismissible` | `boolean` | `false` | Renders a close button; enables Escape-to-dismiss. |
+| `onDismiss` | `() => void` | — | Callback when dismissed. |
+| `variant` | `'outlined' \| 'filled' \| 'soft'` | `outlined` | Visual variant. |
+| `autoHideDuration` | `number` | — | ms before auto-dismiss; omit to never auto-dismiss. |
+| `pauseOnHover` | `boolean` | `true` | Pause the auto-hide timer on hover/focus. |
+| `hideIcon` | `boolean` | `false` | Hide the severity icon. |
+| `titleLevel` | `2 \| 3 \| 4 \| 5 \| 6` | — | Render the title as `<h2>`–`<h6>`; omit for `<strong>`. |
+| `actions` | `React.ReactNode` | — | Action buttons rendered after the message. |
+
+Plus any native `<div>` attribute except `title` / `children`.
+
+## Examples
+
+```tsx
+// Basic
+<Alert open={true} severity="info">
+  Your session will expire in 5 minutes.
+</Alert>
+
+// With title and dismiss
+<Alert
+  open={isOpen}
+  severity="error"
+  title="Payment failed"
+  dismissible
+  onDismiss={() => setIsOpen(false)}
+>
+  Please check your card details and try again.
+</Alert>
+
+// Auto-dismiss after 5s
+<Alert
+  open={showSuccess}
+  severity="success"
+  autoHideDuration={5000}
+  onDismiss={() => setShowSuccess(false)}
+>
+  Your changes have been saved.
+</Alert>
+
+// With actions
+<Alert
+  open={true}
+  severity="warning"
+  title="Unsaved changes"
+  actions={
+    <>
+      <button onClick={saveChanges}>Save</button>
+      <button onClick={discard}>Discard</button>
+    </>
+  }
+>
+  You have unsaved changes.
+</Alert>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every alert. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--alert-padding` / `--alert-gap` | Inner padding and icon/content spacing. |
+| `--alert-radius` | Corner radius. |
+| `--alert-info-bg` / `--alert-info-color` | Info severity background/text (border via `--alert-info-border`). |
+| `--alert-success-bg` / `--alert-success-color` | Success severity background/text. |
+| `--alert-warning-bg` / `--alert-warning-color` | Warning severity background/text. |
+| `--alert-error-bg` / `--alert-error-color` | Error severity background/text. |
+| `--alert-icon-size` | Severity icon size. |
+| `--alert-transition` | Show/hide opacity transition. |
+
+```css
+:root {
+  --alert-radius: 0.5rem;
+  --alert-info-bg: #e0f2fe;
+  --alert-info-color: #075985;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `error` severity renders `role="alert"` + `aria-live="assertive"` (interrupts the screen reader); `info` / `success` / `warning` render `role="status"` + `aria-live="polite"` (announced when the current speech finishes).
+- The severity word ("error:", "success:") is rendered in a visually-hidden span before the content, so screen readers get the severity plus the message. The icon carries `aria-hidden="true"`.
+- Dismissible alerts render an explicit `<button aria-label="Dismiss alert">` and respond to Escape.
+- `autoHideDuration` pairs with `pauseOnHover` (default on) so the timer pauses on hover/focus — satisfying WCAG 2.2.1 Timing Adjustable. For critical messages, prefer `dismissible` without auto-hide.
+- Each severity's default color pair meets 4.5:1 contrast. Verify custom overrides stay above AA.
+
+## Related
+
+- [Component index](README.md)
+- [Dialog](dialog.md) — for modal, blocking messages that require a decision
+- Full maintainer reference: [`skills/component-alert/reference.md`](../../skills/component-alert/reference.md)

--- a/plugins/acss-kit/docs/components/button.md
+++ b/plugins/acss-kit/docs/components/button.md
@@ -1,0 +1,91 @@
+# Button — Usage Guide
+
+The primary interactive element. Size, style, and color variants are applied via HTML `data-*` attributes. Uses `aria-disabled` instead of the native `disabled` attribute so a disabled button stays in the tab order and reachable by keyboard (WCAG 2.1.1).
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Button` — copies `button.tsx` + `button.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Button from './fpkit/button/button'
+import './fpkit/button/button.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `'button' \| 'submit' \| 'reset'` | — (required) | Prevents implicit form submit. |
+| `children` | `React.ReactNode` | — | Button content. |
+| `disabled` | `boolean` | `false` | Accessible disabled — keeps the element focusable (WCAG 2.1.1). |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| '2xl'` | `md` | Maps to `data-btn`. |
+| `variant` | `'text' \| 'pill' \| 'icon' \| 'outline'` | — | Maps to `data-style`. |
+| `color` | `'primary' \| 'secondary' \| 'danger' \| 'success' \| 'warning'` | — | Maps to `data-color`. |
+| `block` | `boolean` | `false` | Stretches to 100% width. |
+| `classes` | `string` | — | CSS class(es); takes precedence over `className`. |
+
+Plus any native `<button>` attribute (`onClick`, `aria-*`, etc.).
+
+## Examples
+
+```tsx
+// Basic
+<Button type="button" onClick={() => {}}>Click me</Button>
+
+// Color + size
+<Button type="button" color="primary" size="lg">Save</Button>
+<Button type="button" color="danger">Delete</Button>
+
+// Full-width primary
+<Button type="button" color="primary" block>Continue</Button>
+
+// Accessible disabled (still focusable)
+<Button type="button" color="primary" disabled>Cannot click</Button>
+
+// Style variants
+<Button type="button" variant="outline">Outlined</Button>
+<Button type="button" variant="pill" color="primary">Pill</Button>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every button. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--btn-size-md` | Default font size (other sizes: `--btn-size-xs`…`--btn-size-xl`). |
+| `--btn-radius` | Corner radius. |
+| `--btn-padding-block` / `--btn-padding-inline` | Padding. |
+| `--btn-primary-bg` / `--btn-primary-color` | Primary color-variant background/text. |
+| `--btn-danger-bg` | Danger-variant background. |
+| `--btn-focus-outline` / `--btn-focus-outline-offset` | Focus ring. |
+| `--btn-disabled-opacity` | Disabled appearance. |
+
+```css
+:root {
+  --btn-radius: 0.5rem;
+  --btn-primary-bg: #6d28d9;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Disabled state uses `aria-disabled="true"` — the button stays keyboard-focusable so users understand it exists (native `disabled` removes it from the tab order).
+- Ships a visible focus ring (`--btn-focus-outline`).
+- Always pass an explicit `type` to avoid accidental form submits.
+
+## Related
+
+- [Component index](README.md)
+- [Icon Button](icon-button.md) — icon-only variant
+- Full maintainer reference: [`skills/component-button/reference.md`](../../skills/component-button/reference.md)

--- a/plugins/acss-kit/docs/components/card.md
+++ b/plugins/acss-kit/docs/components/card.md
@@ -1,0 +1,113 @@
+# Card — Usage Guide
+
+A flexible container for grouping related content, built as a compound component: `Card`, `Card.Title`, `Card.Content`, and `Card.Footer`. Supports an interactive (whole-card clickable) variant with keyboard support.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Card` — copies `card.tsx` + `card.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required. All four sub-components ship in a single `card.tsx`.
+
+## Import
+
+```tsx
+import Card from './fpkit/card/card'
+import './fpkit/card/card.scss'
+```
+
+`Card.Title`, `Card.Content`, and `Card.Footer` are attached to the default export — no extra imports. Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+`Card` (root):
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `as` | `React.ElementType` | `div` | Element to render as (e.g. `article`, `section`). |
+| `children` | `React.ReactNode` | — | Card content, typically the sub-components. |
+| `interactive` | `boolean` | `false` | Makes the whole card clickable + keyboard-navigable. |
+| `onClick` | `() => void` | — | Click handler (required when `interactive`). |
+| `classes` | `string` | — | CSS class names. |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+
+Sub-components — `Card.Title` (`as` default `h3`, plus `id`, `className`), `Card.Content` (`as` default `article`), `Card.Footer` (`as` default `div`). Each also accepts `children` and native attributes for its element.
+
+## Examples
+
+```tsx
+// Basic card
+<Card>
+  <Card.Title>Product Name</Card.Title>
+  <Card.Content>
+    <p>Product description here...</p>
+  </Card.Content>
+  <Card.Footer>
+    <button>Buy Now — $29.99</button>
+  </Card.Footer>
+</Card>
+
+// Accessible card with linked title
+<Card as="article" aria-labelledby="product-1">
+  <Card.Title id="product-1">Featured Widget</Card.Title>
+  <Card.Content>
+    <p>Best widget on the market.</p>
+  </Card.Content>
+</Card>
+
+// Interactive card (entire card is clickable)
+<Card
+  interactive
+  aria-label="View article: 5 Tips for Better Code"
+  onClick={() => navigate('/articles/1')}
+>
+  <Card.Title>5 Tips for Better Code</Card.Title>
+  <Card.Content>
+    <p>Learn how to write cleaner code...</p>
+  </Card.Content>
+</Card>
+
+// Custom heading level for document outline
+<Card as="section">
+  <Card.Title as="h2">Section Title</Card.Title>
+  <Card.Content>Content here...</Card.Content>
+</Card>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every card. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--card-bg` / `--card-color` | Card background/text. |
+| `--card-radius` | Corner radius. |
+| `--card-border` / `--card-shadow` | Border and drop shadow. |
+| `--card-title-fs` / `--card-title-padding` | Title size and padding. |
+| `--card-content-padding` | Content region padding. |
+| `--card-footer-bg` / `--card-footer-padding` | Footer background and padding. |
+| `--card-interactive-hover-shadow` / `--card-interactive-hover-transform` | Hover feedback on interactive cards. |
+| `--card-focus-outline` | Focus ring on interactive cards. |
+
+```css
+:root {
+  --card-radius: 0.75rem;
+  --card-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Non-interactive cards carry no interactive semantics. For a semantic association with the title, use `as="article"` and link it with `aria-labelledby` pointing at `Card.Title`'s `id`.
+- Interactive cards get `role="button"`, `tabIndex={0}`, and Enter/Space activation. Always pass an `aria-label` describing what activating the card does — the text content is not always a complete accessible name.
+- Avoid nesting other interactive elements (links, buttons) inside an interactive card; prefer a non-interactive card with an explicit action instead.
+- `Card.Title` defaults to `<h3>`. Set `as="h2"` etc. to keep the document outline correct — never skip heading levels.
+- Interactive cards show a `:focus-visible` outline and easily exceed the 44 px target-size minimum.
+
+## Related
+
+- [Component index](README.md)
+- Full maintainer reference: [`skills/component-card/reference.md`](../../skills/component-card/reference.md)

--- a/plugins/acss-kit/docs/components/checkbox.md
+++ b/plugins/acss-kit/docs/components/checkbox.md
@@ -1,0 +1,120 @@
+# Checkbox — Usage Guide
+
+A checkbox with simplified ergonomics: a boolean `onChange` (not the native `ChangeEvent`), a bundled visible label, size presets, and full validation passthrough. It wraps the kit's `Input`, so it inherits all validation, disabled, and ARIA logic.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Checkbox` — copies `checkbox.tsx` + `checkbox.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+Checkbox depends on `Input` — `/kit-add Checkbox` pulls in `input.tsx` + `input.scss` too. No `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Checkbox from './fpkit/checkbox/checkbox'
+import './fpkit/input/input.scss'
+import './fpkit/checkbox/checkbox.scss'
+```
+
+Import `input.scss` as well as `checkbox.scss` — the checkbox reuses Input's validation styling. Adjust the paths to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — (required) | Required for label association. |
+| `label` | `React.ReactNode` | — (required) | Visible label text. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `md` | Size preset (sets `data-checkbox-size`). |
+| `checked` | `boolean` | — | Controlled checked state. |
+| `defaultChecked` | `boolean` | — | Uncontrolled initial state. |
+| `value` | `string` | `'on'` | Form-submission value when checked. |
+| `onChange` | `(checked: boolean) => void` | — | Receives `true`/`false`, not a `ChangeEvent`. |
+| `required` | `boolean` | `false` | Sets `aria-required` and renders a `*` after the label. |
+| `disabled` | `boolean` | `false` | Accessible disabled (via `aria-disabled`, inherited from Input). |
+| `validationState` | `'none' \| 'invalid'` (from Input) | — | Cascades `aria-invalid`. |
+| `errorMessage` / `hintText` | `string` | — | Passed through to Input for `aria-describedby`. |
+| `classes` | `string` | — | Wrapper `<div>` CSS classes. |
+| `inputClasses` | `string` | `'checkbox-input'` | Input element CSS classes. |
+| `styles` | `React.CSSProperties` | — | CSS custom properties for theming / custom sizing. |
+
+Plus the remaining `Input` props except `type`, `value`, `onChange`, `defaultValue`, and `placeholder`.
+
+## Examples
+
+```tsx
+// Basic
+<Checkbox id="terms" label="I accept the terms and conditions" />
+
+// Controlled
+const [agreed, setAgreed] = useState(false)
+<Checkbox
+  id="terms"
+  label="I accept the terms"
+  checked={agreed}
+  onChange={setAgreed}
+  required
+/>
+
+// Validation + error
+<Checkbox
+  id="confirm"
+  label="I understand this action is permanent"
+  checked={confirmed}
+  onChange={setConfirmed}
+  validationState={!confirmed ? 'invalid' : 'none'}
+  errorMessage={!confirmed ? 'Confirmation required' : undefined}
+  required
+/>
+
+// Size variants
+<Checkbox id="opt-sm" label="Small" size="sm" />
+<Checkbox id="opt-lg" label="Large" size="lg" />
+
+// Custom sizing via CSS variables
+<Checkbox
+  id="opt-custom"
+  label="Custom 2rem"
+  styles={{ '--checkbox-size': '2rem', '--checkbox-gap': '1rem' } as React.CSSProperties}
+/>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every checkbox. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--checkbox-size` | Box size (or set per-size `--checkbox-size-xs`…`--checkbox-size-lg`). |
+| `--checkbox-radius` | Corner radius. |
+| `--checkbox-border-color` / `--checkbox-bg` | Unchecked border and background. |
+| `--checkbox-checked-bg` / `--checkbox-check-color` | Checked fill and checkmark color. |
+| `--checkbox-gap` | Space between box and label. |
+| `--checkbox-label-fs` / `--checkbox-label-color` | Label size and color. |
+| `--checkbox-focus-ring` | Focus ring box-shadow. |
+| `--checkbox-required-color` | Color of the required `*`. |
+
+```css
+:root {
+  --checkbox-checked-bg: #6d28d9;
+  --checkbox-radius: 0.375rem;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `id` and `label` are both required. The component renders `<label htmlFor={id}>`, so clicking the label toggles the box and screen readers announce the label on focus.
+- Renders a native `<input type="checkbox">` — Space toggles, Tab navigates. The visual appearance is custom (`appearance: none` + `::after` checkmark) but the semantics stay native.
+- `disabled` uses `aria-disabled` (not native `disabled`), inherited from Input, so the control stays discoverable in the tab order (WCAG 2.1.1).
+- `required` renders `aria-required="true"` plus a visible `*` labeled `aria-label="required"`; `validationState="invalid"` cascades `aria-invalid`.
+- `xs` and `sm` presets fall below the 44 px target-size minimum on their own — the label row usually compensates, but reserve them for dense forms. `md` and `lg` meet the minimum.
+
+## Related
+
+- [Component index](README.md)
+- [Field](field.md) — pair with Field for label + layout around any control
+- [Input](input.md) — the underlying control Checkbox wraps
+- Full maintainer reference: [`skills/component-checkbox/reference.md`](../../skills/component-checkbox/reference.md)

--- a/plugins/acss-kit/docs/components/dialog.md
+++ b/plugins/acss-kit/docs/components/dialog.md
@@ -106,7 +106,8 @@ Generate a full matching theme with `/theme-create` (see [styles.md](../styles.m
 
 - Opening with `showModal()` traps focus inside the dialog, and closing returns focus to the trigger — both native browser behaviors. Never use modeless `show()`; it does not enforce the trap.
 - `Escape` fires the native `cancel` event and closes the dialog. No keybinding code needed.
-- The native `<dialog>` supplies `role="dialog"` and `aria-modal="true"` automatically — don't add them. `aria-labelledby` references the generated title id; set `description` to add `aria-describedby` context.
+- The native `<dialog>` supplies `role="dialog"` and `aria-modal="true"` automatically — don't add them. `aria-labelledby` references the generated title id so the dialog is announced by its title.
+- The `description` prop renders a visible paragraph inside the header. Note: the generated component does **not** wire it to `aria-describedby`, so it is not announced as the dialog's programmatic description — treat it as visible supporting text.
 - The close button carries `aria-label="Close dialog"` since the `×` glyph is not an accessible name.
 - The browser focuses the first focusable element on open — often the close button. To land focus on a safer footer action, pass `autoFocus` to that button.
 - Dialog title renders as `<h2>`; keep the surrounding heading outline in mind if the page already uses `<h2>` nearby.

--- a/plugins/acss-kit/docs/components/dialog.md
+++ b/plugins/acss-kit/docs/components/dialog.md
@@ -1,0 +1,119 @@
+# Dialog — Usage Guide
+
+A modal dialog built on the native HTML `<dialog>` element, so focus trapping, the backdrop scrim, and Escape-to-close come for free — no npm packages. It is a compound component (`Dialog`, `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`) and you drive open/close through a ref.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Dialog` — copies `dialog.tsx` + `dialog.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+Dialog depends on `Button` (for the close button and footer actions) — `/kit-add Dialog` pulls in `button.tsx` + `button.scss` too. No `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import { useRef } from 'react'
+import Dialog from './fpkit/dialog/dialog'
+import Button from './fpkit/button/button'
+import './fpkit/dialog/dialog.scss'
+import './fpkit/button/button.scss'
+```
+
+`Dialog.Header`, `Dialog.Body`, and `Dialog.Footer` are attached to the default export. Adjust the paths to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+`Dialog` (root):
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `dialogRef` | `React.RefObject<HTMLDialogElement>` | — (required) | Ref used to call `showModal()` / `close()`. |
+| `openOnMount` | `boolean` | `false` | Whether to open on mount. |
+| `onClose` | `() => void` | — | Callback when the dialog closes. |
+| `title` | `string` | — | Renders a header title, wired to `aria-labelledby`. |
+| `description` | `string` | — | Renders a description paragraph under the title. |
+| `showCloseButton` | `boolean` | `true` | Show the header close button. |
+| `children` | `React.ReactNode` | — | Dialog body content. |
+| `footer` | `React.ReactNode` | — | Footer action buttons. |
+| `classes` | `string` | — | CSS class name. |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+
+Plus any native `<dialog>` attribute except `open`. Sub-components — `Dialog.Header` (`children`, `onClose`, `showCloseButton`, `classes`), `Dialog.Body` (`children`, `classes`), `Dialog.Footer` (`children`, `classes`).
+
+## Examples
+
+```tsx
+function App() {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  return (
+    <>
+      <Button type="button" onClick={() => dialogRef.current?.showModal()}>
+        Open Dialog
+      </Button>
+
+      <Dialog
+        dialogRef={dialogRef}
+        title="Confirm Action"
+        description="This action cannot be undone."
+        onClose={() => console.log('closed')}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={() => dialogRef.current?.close()}>
+              Cancel
+            </Button>
+            <Button type="button" color="primary" onClick={() => {}}>
+              Confirm
+            </Button>
+          </>
+        }
+      >
+        <p>Are you sure you want to proceed?</p>
+      </Dialog>
+    </>
+  )
+}
+```
+
+Open with `dialogRef.current?.showModal()` and close with `dialogRef.current?.close()`. Backdrop clicks and the Escape key also close the dialog.
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every dialog. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--dialog-bg` / `--dialog-color` | Dialog background/text. |
+| `--dialog-radius` | Corner radius. |
+| `--dialog-width` / `--dialog-max-width` / `--dialog-max-height` | Sizing constraints. |
+| `--dialog-shadow` | Drop shadow. |
+| `--dialog-header-padding` / `--dialog-body-padding` | Header and body padding. |
+| `--dialog-footer-bg` / `--dialog-footer-justify` | Footer background and action alignment. |
+| `--dialog-backdrop-bg` | `::backdrop` scrim color. |
+
+```css
+:root {
+  --dialog-width: 28rem;
+  --dialog-radius: 0.75rem;
+  --dialog-backdrop-bg: rgba(0, 0, 0, 0.6);
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Opening with `showModal()` traps focus inside the dialog, and closing returns focus to the trigger — both native browser behaviors. Never use modeless `show()`; it does not enforce the trap.
+- `Escape` fires the native `cancel` event and closes the dialog. No keybinding code needed.
+- The native `<dialog>` supplies `role="dialog"` and `aria-modal="true"` automatically — don't add them. `aria-labelledby` references the generated title id; set `description` to add `aria-describedby` context.
+- The close button carries `aria-label="Close dialog"` since the `×` glyph is not an accessible name.
+- The browser focuses the first focusable element on open — often the close button. To land focus on a safer footer action, pass `autoFocus` to that button.
+- Dialog title renders as `<h2>`; keep the surrounding heading outline in mind if the page already uses `<h2>` nearby.
+
+## Related
+
+- [Component index](README.md)
+- [Button](button.md) — used for the close button and footer actions
+- [Alert](alert.md) — for inline, non-blocking status messages
+- Full maintainer reference: [`skills/component-dialog/reference.md`](../../skills/component-dialog/reference.md)

--- a/plugins/acss-kit/docs/components/field.md
+++ b/plugins/acss-kit/docs/components/field.md
@@ -1,0 +1,94 @@
+# Field — Usage Guide
+
+A minimal wrapper that pairs a `<label>` with a single form control and guarantees the label is associated via `htmlFor`. Field owns the layout and label association only — error and hint text live in the control (Input handles `errorMessage` / `hintText` and their `aria-describedby` ids).
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Field` — copies `field.tsx` + `field.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required. Layer a control (Input, Select, Textarea) inside it.
+
+## Import
+
+```tsx
+import Field from './fpkit/field/field'
+import Input from './fpkit/input/input'
+import './fpkit/field/field.scss'
+```
+
+Adjust the paths to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `React.ReactNode` | — (required) | Label content — text or a React node. |
+| `labelFor` | `string` | — (required) | Must match the `id` of the wrapped control (compile-time enforced). |
+| `children` | `React.ReactNode` | — (required) | The form control rendered inside. |
+| `id` | `string` | — | Optional id on the wrapper `<div>`. |
+| `classes` | `string` | — | Wrapper CSS classes. |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+
+Plus any native `<label>` attribute except `htmlFor` (Field owns that via `labelFor`).
+
+## Examples
+
+```tsx
+// Field + Input
+<Field labelFor="email" label="Email address">
+  <Input id="email" type="email" required />
+</Field>
+
+// Field + Select
+<Field labelFor="country" label="Country">
+  <select id="country" name="country">
+    <option value="">Select a country</option>
+    <option value="us">United States</option>
+  </select>
+</Field>
+
+// Custom label content
+<Field labelFor="card" label={<>Card number <small>(no spaces)</small></>}>
+  <Input id="card" inputMode="numeric" pattern="\d*" required />
+</Field>
+```
+
+The `labelFor` value must equal the wrapped control's `id` — that pairing is what associates the label with the control.
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every field. Each has a fallback, so overriding is optional. Field styles hang off the `[data-style="fields"]` hook the component sets.
+
+| Variable | Purpose |
+|----------|---------|
+| `--field-display` / `--field-direction` | Layout mode and stacking direction. |
+| `--field-gap` | Space between label and control. |
+| `--field-margin-block-end` | Spacing below each field. |
+| `--field-label-fs` | Label font size. |
+| `--field-label-fw` | Label font weight. |
+| `--field-label-color` | Label color. |
+| `--field-label-margin-block-end` | Space below the label. |
+
+```css
+:root {
+  --field-gap: 0.5rem;
+  --field-label-fw: 600;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `labelFor` is required by the type, so a missing label is impossible at the Field level. The remaining discipline is making the wrapped control's `id` match (WCAG 1.3.1, 4.1.2).
+- Always pass a visible `label`. Field does not support visually-hidden labels — if you truly need one, use the bare control with `aria-label` / `aria-labelledby` instead.
+- Field does not render `*`, required text, or error/hint paragraphs — the wrapped control owns those. Don't add `<p class="error">` siblings inside Field; the control won't pick them up in `aria-describedby`.
+
+## Related
+
+- [Component index](README.md)
+- [Input](input.md) — the control most often wrapped by Field
+- [Checkbox](checkbox.md) — bundles its own label; use instead of Field for checkboxes
+- Full maintainer reference: [`skills/component-field/reference.md`](../../skills/component-field/reference.md)

--- a/plugins/acss-kit/docs/components/icon-button.md
+++ b/plugins/acss-kit/docs/components/icon-button.md
@@ -14,10 +14,11 @@ The generated component is self-contained — no `@fpkit/acss` install required.
 
 ```tsx
 import IconButton from './fpkit/icon-button/icon-button'
+import './fpkit/button/button.scss' // base .btn styles + focus-visible ring
 import './fpkit/icon-button/icon-button.scss'
 ```
 
-Adjust the path to match the `componentsDir` in your `.acss-target.json`. IconButton imports `Button` from `../button/button`, so both must be present.
+Adjust the path to match the `componentsDir` in your `.acss-target.json`. IconButton renders `Button` from `../button/button`, so both the `.tsx` and `button.scss` must be present — the icon button inherits its variant styling, disabled appearance, and focus ring from `button.scss`.
 
 ## Props
 

--- a/plugins/acss-kit/docs/components/icon-button.md
+++ b/plugins/acss-kit/docs/components/icon-button.md
@@ -1,0 +1,91 @@
+# Icon Button — Usage Guide
+
+An accessible icon-only (or icon + label) button built on top of [Button](button.md). A TypeScript XOR type requires exactly one of `aria-label` or `aria-labelledby` at compile time, so the icon always has a programmatic accessible name (WCAG 1.1.1 / 4.1.2).
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add IconButton` — copies `icon-button.tsx` + `icon-button.scss` into your components directory (default `src/components/fpkit/`). It depends on `Button`, so add that too (or run `/kit-sync`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import IconButton from './fpkit/icon-button/icon-button'
+import './fpkit/icon-button/icon-button.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`. IconButton imports `Button` from `../button/button`, so both must be present.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `icon` | `React.ReactNode` | — (required) | The icon element rendered inside the button. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `button` | Prevents implicit form submit. |
+| `aria-label` | `string` | — | Accessible name. Required unless `aria-labelledby` is passed. |
+| `aria-labelledby` | `string` | — | Accessible name by reference. Required unless `aria-label` is passed. |
+| `label` | `string` | — | Optional text shown beside the icon at desktop widths; always in the a11y tree. |
+| `variant` | `'text' \| 'pill' \| 'icon' \| 'outline'` | `icon` | Inherited from Button; `outline` restores padding for label layout. |
+
+The XOR type means passing **both** `aria-label` and `aria-labelledby` — or **neither** — is a TypeScript compile-time error. Plus any other `ButtonProps` (`size`, `color`, `disabled`, `onClick`, etc.) except `children`.
+
+## Examples
+
+```tsx
+// Icon-only — compile-time accessible-name requirement enforced
+<IconButton type="button" aria-label="Close menu" icon={<CloseIcon />} />
+
+// Icon + responsive label (label hidden below 48rem; always in a11y tree)
+<IconButton
+  type="button"
+  aria-label="Settings"
+  icon={<SettingsIcon />}
+  label="Settings"
+  variant="outline"   // restores padding for label layout
+/>
+
+// Labelled by external element
+<>
+  <span id="del-label">Delete item</span>
+  <IconButton type="button" aria-labelledby="del-label" icon={<TrashIcon />} />
+</>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme. Each has a fallback, so overriding is optional. IconButton also inherits color and focus tokens from [Button](button.md).
+
+| Variable | Purpose |
+|----------|---------|
+| `--icon-btn-size` | Tap-target size (default `3rem` / 48 px). |
+| `--icon-btn-padding` | Inner padding (default `0`). |
+| `--icon-btn-radius` | Corner radius (default `50%` — circular). |
+| `--icon-btn-gap` | Gap between icon and label. |
+| `--icon-label-bp` | Breakpoint above which the label appears (default `48rem`). |
+| `--icon-label-fs` | Label font size. |
+
+```css
+:root {
+  --icon-btn-radius: 0.5rem;
+  --icon-btn-size: 2.75rem;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- The XOR type makes the accessible name a build-time guarantee — you cannot ship an icon button without `aria-label` or `aria-labelledby`.
+- Default `--icon-btn-size: 3rem` (48 px) exceeds WCAG 2.5.5 Target Size (AAA); keep it at or above 44 px if you shrink it.
+- Inherits Button's keyboard behavior (Enter/Space activation), `:focus-visible` ring, and `aria-disabled` disabled pattern that keeps the button in the tab order.
+- The optional `label` is visually hidden below the breakpoint with `clip` (not `display: none`), so screen readers announce it at every viewport.
+
+## Related
+
+- [Component index](README.md)
+- [Button](button.md) — the base component IconButton is built on
+- [Icon](icon.md) — supplies the glyph you pass to `icon`
+- Full maintainer reference: [`skills/component-icon-button/reference.md`](../../skills/component-icon-button/reference.md)

--- a/plugins/acss-kit/docs/components/icon.md
+++ b/plugins/acss-kit/docs/components/icon.md
@@ -1,0 +1,84 @@
+# Icon — Usage Guide
+
+A lightweight inline-SVG icon component with a small built-in icon set. Each icon renders as an `<svg>` sized via the `size` prop, colored via `color` (default `currentColor`), and named for assistive tech via `aria-hidden` (decorative) or `aria-label` (standalone).
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Icon` — copies `icon.tsx` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+Icon has no SCSS file — it styles entirely through props and `currentColor`. The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Icon from './fpkit/icon/icon'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`. Icon ships no stylesheet, so there is nothing to import for CSS.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `'info' \| 'success' \| 'warning' \| 'error' \| 'close' \| 'chevron-down' \| 'chevron-right' \| 'check' \| 'external-link'` | — (required) | Icon from the built-in set. |
+| `size` | `number` | `16` | SVG width/height in pixels. |
+| `color` | `string` | `currentColor` | Stroke / fill color. |
+| `aria-hidden` | `boolean` | `true` | Decorative — screen readers skip it. |
+| `aria-label` | `string` | — | Accessible name for standalone icons; swaps in `role="img"` and drops `aria-hidden`. |
+
+Plus any native `<svg>` attribute except `aria-hidden` / `aria-label` (handled above).
+
+## Examples
+
+```tsx
+// Decorative — screen readers skip
+<Icon name="info" aria-hidden size={16} />
+
+// Inside a label that already carries meaning
+<button type="button">
+  <Icon name="check" aria-hidden /> Save
+</button>
+
+// Standalone — needs accessible name
+<button type="button" aria-label="Close dialog">
+  <Icon name="close" aria-hidden size={20} />
+</button>
+
+// Or label the icon directly when there's no surrounding interactive element
+<Icon name="warning" aria-label="Warning" size={24} color="var(--color-warning)" />
+
+// Inline with custom color
+<Icon name="external-link" aria-hidden size={12} color="var(--color-primary)" />
+```
+
+## Theming
+
+Icon has no dedicated SCSS file, so there are no `--icon-*` custom properties to override. Control appearance directly through props:
+
+| Lever | How |
+|-------|-----|
+| Color | `color` prop, or let it inherit the parent's text color via the default `currentColor`. |
+| Size | `size` prop, in pixels. |
+| Theme-driven color | Pass a theme token, e.g. `color="var(--color-primary)"`. |
+
+```tsx
+// Inherit surrounding text color (recommended)
+<span style={{ color: 'var(--color-danger)' }}>
+  <Icon name="error" aria-hidden /> Something went wrong
+</span>
+```
+
+## Accessibility
+
+- Decorative by default (`aria-hidden="true"`) — use for icons that sit next to text that already conveys the meaning.
+- Pass `aria-label` for standalone icons that carry meaning alone; the component swaps `aria-hidden` for `role="img"` automatically. Never pass both.
+- Color must not be the only indicator of state (WCAG 1.4.1) — pair state icons with text or shape.
+- A 16 px icon is not a touch target. When the icon is the only clickable area, wrap it in [Icon Button](icon-button.md) or [Button](button.md) to meet the 44 px minimum (WCAG 2.5.8).
+
+## Related
+
+- [Component index](README.md)
+- [Icon Button](icon-button.md) — accessible icon-only button that hosts an Icon
+- Full maintainer reference: [`skills/component-icon/reference.md`](../../skills/component-icon/reference.md)

--- a/plugins/acss-kit/docs/components/img.md
+++ b/plugins/acss-kit/docs/components/img.md
@@ -1,0 +1,117 @@
+# Img — Usage Guide
+
+A semantic image component with accessibility and performance defaults. Wraps the native `<img>` with lazy loading, an automatic SVG-gradient placeholder on load error, `srcSet` / `sizes` responsive support, and `fetchpriority` / `decoding` performance hints. The `alt` prop is required by the type.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Img` — copies `img.tsx` + `img.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Img from './fpkit/img/img'
+import './fpkit/img/img.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `alt` | `string` | — (required) | Alt text; empty string for decorative images. |
+| `src` | `string` | `'//'` | Image source URL. |
+| `width` | `number \| string` | `480` | Image width (number = px). |
+| `height` | `number \| string` | `'auto'` | Image height (number = px). |
+| `loading` | `'lazy' \| 'eager'` | `lazy` | Loading strategy for below/above-the-fold images. |
+| `placeholder` | `string` | generated SVG | Custom fallback URL when `src` fails to load. |
+| `fetchpriority` | `'high' \| 'low' \| 'auto'` | `low` | Fetch priority hint. |
+| `decoding` | `'sync' \| 'async' \| 'auto'` | `auto` | Decoding strategy. |
+| `srcSet` | `string` | — | Responsive image candidates. |
+| `sizes` | `string` | — | Responsive sizes hint. |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `onError` | `(e) => void` | — | Runs before the placeholder swap; call `e.preventDefault()` to skip it. |
+| `onLoad` | `(e) => void` | — | Native load handler. |
+
+Plus any native `<img>` attribute except the overridden `src`, `alt`, `onError`, `onLoad`.
+
+## Examples
+
+```tsx
+// Decorative
+<Img src="/decorative-border.svg" alt="" />
+
+// Informative
+<Img
+  src="/sales-chart.png"
+  alt="Sales chart showing 30% revenue growth in Q4 2024"
+  width={800}
+  height={400}
+/>
+
+// Hero (above the fold)
+<Img
+  src="/hero.jpg"
+  alt="Two engineers reviewing code on a laptop"
+  width={1200}
+  height={600}
+  loading="eager"
+  fetchpriority="high"
+/>
+
+// Responsive
+<Img
+  src="/photo.jpg"
+  srcSet="/photo-320w.jpg 320w, /photo-640w.jpg 640w, /photo-1024w.jpg 1024w"
+  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 800px"
+  alt="Mountain range at sunset"
+  width={1024}
+  height={768}
+/>
+
+// Custom fallback + error logging
+<Img
+  src="/avatar.jpg"
+  placeholder="/default-avatar.svg"
+  alt="User profile photo"
+  onError={(e) => analytics('image_error', { src: e.currentTarget.src })}
+/>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every image. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--img-display` | Display mode (default `block`). |
+| `--img-max-width` | Max width (default `100%`). |
+| `--img-height` | Height (default `auto`). |
+| `--img-object-fit` | Object-fit behavior (default `cover`). |
+| `--img-radius` | Corner radius (default `var(--radius-none, 0)`). |
+
+```css
+:root {
+  --img-radius: 0.75rem;
+  --img-object-fit: contain;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `alt` is required by the type — pass `alt=""` for purely decorative images, or a descriptive `alt` that conveys purpose and content for informative ones.
+- Always pass explicit `width` and `height` so the browser reserves layout space and avoids Cumulative Layout Shift.
+- Pair `loading="eager"` with `fetchpriority="high"` for the LCP (hero) image; defaults are `lazy` + `low` for off-screen images.
+- On load error the component swaps in a generated SVG-gradient data-URI placeholder (no network request), guarding against an infinite error loop.
+- `max-width: 100%` via SCSS prevents horizontal scroll on small viewports (WCAG 1.4.10 Reflow).
+
+## Related
+
+- [Component index](README.md)
+- Full maintainer reference: [`skills/component-img/reference.md`](../../skills/component-img/reference.md)

--- a/plugins/acss-kit/docs/components/input.md
+++ b/plugins/acss-kit/docs/components/input.md
@@ -1,0 +1,125 @@
+# Input — Usage Guide
+
+A text-based form control with first-class validation states, error/hint association, and the kit-builder accessible-disabled pattern. Emits `aria-required`, `aria-invalid`, `aria-readonly`, and a generated `aria-describedby` linking to error and hint text. Pair it with [Field](field.md) for label association.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Input` — copies `input.tsx` + `input.scss` into your components directory (default `src/components/fpkit/`). Add `Field` too (or run `/kit-sync`) for label association.
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Field from './fpkit/field/field'
+import Input from './fpkit/input/input'
+import './fpkit/field/field.scss'
+import './fpkit/input/input.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — (required) | Label association and `aria-describedby` id generation. |
+| `type` | `React.HTMLInputTypeAttribute` | `'text'` | HTML input type. |
+| `name` | `string` | — | Form field name. |
+| `value` | `string \| number \| readonly string[]` | — | Controlled value. |
+| `defaultValue` | `string \| number \| readonly string[]` | — | Uncontrolled initial value. |
+| `placeholder` | `string` | — | Placeholder text (not a substitute for a label). |
+| `disabled` | `boolean` | `false` | Accessible disabled — renders `aria-disabled`, keeps the element focusable. |
+| `isDisabled` | `boolean` | — | Legacy alias for `disabled`; `disabled` takes precedence. |
+| `readOnly` | `boolean` | `false` | Read-only state. |
+| `required` | `boolean` | `false` | Renders `aria-required` + native `required`. |
+| `validationState` | `'none' \| 'valid' \| 'invalid'` | `'none'` | Drives `aria-invalid` and the `data-validation` attribute. |
+| `errorMessage` | `string` | — | Links a `{id}-error` reference via `aria-describedby`. |
+| `hintText` | `string` | — | Links a `{id}-hint` reference via `aria-describedby`. |
+| `onEnter` | `React.KeyboardEventHandler` | — | Convenience handler for Enter; fires after `onKeyDown`. |
+| `classes` | `string` | — | Custom CSS classes. |
+
+Plus `onChange`, `onBlur`, `onFocus`, `onKeyDown`, `maxLength`, `minLength`, `pattern`, `autoComplete`, `autoFocus`, `inputMode`, and other native `<input>` attributes.
+
+## Examples
+
+```tsx
+// Basic Field + Input
+<Field labelFor="email" label="Email">
+  <Input id="email" type="email" required />
+</Field>
+
+// With validation + error message
+const [email, setEmail] = useState('')
+const [emailErr, setEmailErr] = useState<string | undefined>()
+
+<Field labelFor="email" label="Email">
+  <Input
+    id="email"
+    type="email"
+    value={email}
+    onChange={(e) => setEmail(e.target.value)}
+    validationState={emailErr ? 'invalid' : 'none'}
+    errorMessage={emailErr}
+    required
+  />
+  {emailErr && <p id="email-error" role="alert">{emailErr}</p>}
+</Field>
+
+// With hint text
+<Field labelFor="password" label="Password">
+  <Input
+    id="password"
+    type="password"
+    hintText="At least 8 characters with one number"
+    minLength={8}
+    required
+  />
+  <p id="password-hint">At least 8 characters with one number</p>
+</Field>
+
+// Submit on Enter
+<Input id="search" type="search" onEnter={(e) => runSearch(e.currentTarget.value)} />
+
+// Read-only
+<Input id="invoice" defaultValue="INV-12345" readOnly />
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every input. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--input-bg` / `--input-color` | Background and text color. |
+| `--input-border` | Border (the primary editable-area indicator). |
+| `--input-radius` | Corner radius. |
+| `--input-focus-border` / `--input-focus-ring` | Focus border and ring. |
+| `--input-invalid-border` / `--input-invalid-ring` | Invalid-state styling. |
+| `--input-valid-border` | Valid-state border. |
+| `--input-disabled-bg` / `--input-disabled-opacity` | Disabled appearance. |
+
+```css
+:root {
+  --input-radius: 0.5rem;
+  --input-focus-border: #6d28d9;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Input does not render its own `<label>`. Wrap it with [Field](field.md) (or a `<label htmlFor={id}>`) so the control has an accessible name; the `id` prop is required.
+- Disabled state uses `aria-disabled="true"` instead of the native `disabled` attribute, keeping the input in the tab order (WCAG 2.1.1). `onChange`/`onBlur`/`onKeyDown` no-op while disabled; `onFocus` is intentionally not gated.
+- `validationState="invalid"` sets `aria-invalid="true"` and `data-validation="invalid"`. Pass `errorMessage` and render the error yourself with id `{id}-error`.
+- `hintText` links helper text via id `{id}-hint`; both hint and error are combined into one `aria-describedby`.
+- Never rely on `placeholder` as the only label — it disappears on focus and has low contrast.
+
+## Related
+
+- [Component index](README.md)
+- [Field](field.md) — provides the label association Input needs
+- Full maintainer reference: [`skills/component-input/reference.md`](../../skills/component-input/reference.md)

--- a/plugins/acss-kit/docs/components/link.md
+++ b/plugins/acss-kit/docs/components/link.md
@@ -1,0 +1,109 @@
+# Link — Usage Guide
+
+A semantic anchor wrapper with automatic security defaults for external links. When `target="_blank"` is set, the component merges `rel="noopener noreferrer"` with any user-provided rel tokens, blocking `window.opener` exploitation and referrer leakage. Supports an optional `prefetch` hint and button-style rendering.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Link` — copies `link.tsx` + `link.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+```tsx
+import Link from './fpkit/link/link'
+import './fpkit/link/link.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `href` | `string` | — (required) | Link destination. |
+| `target` | `string` | — | Link target (e.g. `"_blank"`). |
+| `rel` | `string` | — | rel tokens; merged with security defaults when `target="_blank"`. |
+| `prefetch` | `boolean` | `false` | Adds a prefetch hint. |
+| `btnStyle` | `string` | — | Maps to `data-btn` for button-style links. |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `children` | `React.ReactNode` | — | Link content. |
+
+Plus any native `<a>` attribute except the overridden `href`, `target`, `rel`.
+
+## Examples
+
+```tsx
+// Internal
+<Link href="/about">About us</Link>
+
+// External — automatic security defaults
+<Link href="https://example.com" target="_blank">
+  Visit example.com
+</Link>
+
+// External + user-provided rel (merged with security defaults)
+<Link href="https://partner.com" target="_blank" rel="sponsored">
+  Sponsored: partner site
+</Link>
+
+// Icon-only link (accessible name required)
+<Link href="/settings" aria-label="Settings">
+  <Icon name="info" aria-hidden size={20} />
+</Link>
+
+// Skip-link pattern (combined with CSS visually-hidden-until-focus)
+<Link href="#main" className="skip-link">Skip to main content</Link>
+
+// Button-style link (visually a button; semantically still an anchor)
+<Link href="/signup" btnStyle="block">
+  Get started
+</Link>
+
+// Analytics tracking — works for keyboard activation too
+<Link
+  href="/products"
+  onClick={() => trackEvent('link_click', { href: '/products' })}
+>
+  Browse products
+</Link>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every link. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--link-color` | Default link color. |
+| `--link-hover-color` | Hover color. |
+| `--link-visited-color` | Visited color (default `#551a8b`). |
+| `--link-text-decoration` / `--link-hover-text-decoration` | Underline default and on hover. |
+| `--link-focus-outline` / `--link-focus-outline-offset` | Focus ring. |
+| `--link-subtle-color` | Subtle-link variant color. |
+
+```css
+:root {
+  --link-color: #6d28d9;
+  --link-hover-color: #5b21b6;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Use descriptive link text ("Read installation guide", not "Click here"); for icon-only links pass `aria-label` (WCAG 2.4.4).
+- `target="_blank"` automatically adds `rel="noopener noreferrer"` — `noopener` blocks tabnabbing, `noreferrer` strips the `Referer` header. User rel tokens are merged and deduplicated.
+- Native `<a>` gives full keyboard support (Tab + Enter); don't intercept clicks unless a SPA router handles the route, and still allow Cmd/Ctrl-click.
+- `:focus-visible` renders a 2 px outline at `currentColor` that adapts to light/dark themes; verify 3:1 contrast in dark themes.
+- The default underline is the non-color link indicator (WCAG 1.4.1). Button-style links (`btnStyle`) are still anchors — Enter activates, not Space; use [Button](button.md) if you need true button behavior.
+
+## Related
+
+- [Component index](README.md)
+- [Icon](icon.md) — pair with an external-link glyph to mark links that leave the site
+- [Button](button.md) — use instead of `btnStyle` when you need real button semantics
+- Full maintainer reference: [`skills/component-link/reference.md`](../../skills/component-link/reference.md)

--- a/plugins/acss-kit/docs/components/link.md
+++ b/plugins/acss-kit/docs/components/link.md
@@ -57,7 +57,9 @@ Plus any native `<a>` attribute except the overridden `href`, `target`, `rel`.
 // Skip-link pattern (combined with CSS visually-hidden-until-focus)
 <Link href="#main" className="skip-link">Skip to main content</Link>
 
-// Button-style link (visually a button; semantically still an anchor)
+// Button-style link — requires button.scss imported for the button appearance
+// (link.scss only removes the underline; the .btn styling comes from button.scss).
+// Semantically still an anchor: activates with Enter, not Space.
 <Link href="/signup" btnStyle="block">
   Get started
 </Link>

--- a/plugins/acss-kit/docs/components/list.md
+++ b/plugins/acss-kit/docs/components/list.md
@@ -1,0 +1,130 @@
+# List — Usage Guide
+
+A semantic list wrapper for unordered (`ul`), ordered (`ol`), and definition (`dl`) lists. It uses the compound API `List` + `List.ListItem`, keeping the parent-child relationship explicit at the call site, and supports the `role="list"` override that restores list semantics for Safari/VoiceOver when `list-style: none` would otherwise strip them.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add List` — copies `list.tsx` + `list.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+`List` is a compound component — the parent and its `List.ListItem` sub-part ship in one file.
+
+```tsx
+import List from './fpkit/list/list'
+import './fpkit/list/list.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+**`List`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `'ul' \| 'ol' \| 'dl'` | `ul` | List variant. |
+| `variant` | `'inline' \| 'numbered' \| 'none' \| string` | — | Visual variant; drives `data-variant` for SCSS targeting. |
+| `role` | `string` | — | Explicit role override. Pass `role="list"` with `variant="none"`/`"inline"` to restore semantics for VoiceOver/Safari. |
+| `classes` | `string` | — | CSS class(es). |
+| `styles` | `React.CSSProperties` | — | Inline styles / CSS variables. |
+| `children` | `React.ReactNode` | — | `List.ListItem` children. |
+
+Plus any native `<ul>` attribute (except `type`).
+
+**`List.ListItem`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `type` | `'li' \| 'dt' \| 'dd'` | `li` | Item element — match the parent list type. |
+| `id` | `string` | — | Element id. |
+| `classes` | `string` | — | CSS class(es). |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `children` | `React.ReactNode` | — | Item content. |
+
+Plus any native `<li>` attribute (except `type`).
+
+## Examples
+
+```tsx
+// Basic unordered list
+<List>
+  <List.ListItem>Apples</List.ListItem>
+  <List.ListItem>Bananas</List.ListItem>
+  <List.ListItem>Cherries</List.ListItem>
+</List>
+
+// Ordered list with custom marker color
+<List
+  type="ol"
+  styles={{ '--list-marker-color': '#0066cc' } as React.CSSProperties}
+>
+  <List.ListItem>Step one</List.ListItem>
+  <List.ListItem>Step two</List.ListItem>
+</List>
+
+// Unstyled list with role restoration (Safari/VoiceOver fix)
+<List variant="none" role="list">
+  <List.ListItem><a href="/about">About</a></List.ListItem>
+  <List.ListItem><a href="/contact">Contact</a></List.ListItem>
+</List>
+
+// Inline list — navigation menu
+<nav aria-label="Primary">
+  <List variant="inline" role="list">
+    <List.ListItem><a href="/home">Home</a></List.ListItem>
+    <List.ListItem><a href="/products">Products</a></List.ListItem>
+    <List.ListItem><a href="/contact">Contact</a></List.ListItem>
+  </List>
+</nav>
+
+// Definition list (glossary)
+<List type="dl">
+  <List.ListItem type="dt">React</List.ListItem>
+  <List.ListItem type="dd">A JavaScript library for building user interfaces.</List.ListItem>
+  <List.ListItem type="dt">TypeScript</List.ListItem>
+  <List.ListItem type="dd">JavaScript with syntactic types.</List.ListItem>
+</List>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every list. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--list-padding-inline-start` | Indent of the list from its container. |
+| `--list-gap` | Space between items. |
+| `--list-item-padding-block` | Vertical padding on each item. |
+| `--list-marker-color` | Bullet/number (`::marker`) color. |
+| `--list-inline-gap` | Gap between items in `variant="inline"`. |
+| `--dl-term-fw` | Font weight of definition terms (`<dt>`). |
+| `--dl-term-margin-block-start` | Space above each term. |
+| `--dl-desc-margin-block-end` | Space below each description (`<dd>`). |
+
+```css
+:root {
+  --list-gap: 0.75rem;
+  --list-marker-color: #6d28d9;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Renders native `<ul>`, `<ol>`, or `<dl>` — screen readers announce "list of N items" and definition-list term/description pairs automatically.
+- Safari + VoiceOver drop the implicit `role="list"` when `list-style: none` is applied. The `variant="none"` and `variant="inline"` variants trigger this, so pass `role="list"` explicitly on those.
+- Pass `type="dt"` / `type="dd"` on `List.ListItem` when `type="dl"` so term/description semantics are preserved.
+- Custom `::marker` colors used as the only indicator must meet 3:1 against the page background (WCAG 1.4.11) — verify in dark themes.
+- For inline lists used as navigation, wrap them in a `<nav aria-label="…">` landmark and keep adequate `--list-inline-gap` for target size (WCAG 2.5.8).
+
+## Related
+
+- [Component index](README.md)
+- [Nav](nav.md) — navigation landmark for inline link lists
+- Full maintainer reference: [`skills/component-list/reference.md`](../../skills/component-list/reference.md)

--- a/plugins/acss-kit/docs/components/nav.md
+++ b/plugins/acss-kit/docs/components/nav.md
@@ -141,6 +141,6 @@ Generate a full matching theme with `/theme-create` (see [styles.md](../styles.m
 ## Related
 
 - [Component index](README.md)
-- [Link](link.md) — the anchor styling used inside `Nav.Item`
+- [Link component](link.md) — the anchor styling used inside `Nav.Item`
 - [List](list.md) — for inline link lists outside a nav landmark
 - Full maintainer reference: [`skills/component-nav/reference.md`](../../skills/component-nav/reference.md)

--- a/plugins/acss-kit/docs/components/nav.md
+++ b/plugins/acss-kit/docs/components/nav.md
@@ -1,0 +1,146 @@
+# Nav — Usage Guide
+
+A semantic navigation landmark using the compound pattern `Nav`, `Nav.List`, `Nav.Item`. It renders a `<nav>` wrapping a `<ul>` of `<li>` items, supports horizontal (default) and vertical layouts, and styles the links you place inside each item.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Nav` — copies `nav.tsx` + `nav.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+`Nav` is a compound component — `Nav`, `Nav.List`, and `Nav.Item` all ship in one file.
+
+```tsx
+import Nav from './fpkit/nav/nav'
+import './fpkit/nav/nav.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+**`Nav`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `aria-label` | `string` | — | Accessible label; required when more than one `<nav>` exists on the page (WCAG 2.4.8). |
+| `classes` | `string` | — | CSS class(es). |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `children` | `React.ReactNode` | — | Typically `Nav.List` (and an optional logo/link). |
+
+Plus any native `<nav>` attribute (except `className`).
+
+**`Nav.List`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isBlock` | `boolean` | `false` | Vertical (block/column) layout instead of horizontal. |
+| `aria-label` | `string` | — | Accessible label for this list. |
+| `children` | `React.ReactNode` | — | `Nav.Item` children. |
+
+Plus any native `<ul>` attribute (except `className`).
+
+**`Nav.Item`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `id` | `string` | — | Element id. |
+| `classes` | `string` | — | CSS class(es). |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `children` | `React.ReactNode` | — | Item content — usually an `<a>`. |
+
+Plus any native `<li>` attribute (except `className`).
+
+## Examples
+
+```tsx
+// Basic horizontal nav
+<Nav aria-label="Main navigation">
+  <Nav.List>
+    <Nav.Item><a href="/" aria-current="page">Home</a></Nav.Item>
+    <Nav.Item><a href="/about">About</a></Nav.Item>
+    <Nav.Item><a href="/contact">Contact</a></Nav.Item>
+  </Nav.List>
+</Nav>
+
+// Multiple nav regions (aria-label required — WCAG 2.4.8)
+<Nav aria-label="Main navigation">
+  <Nav.List>
+    <Nav.Item><a href="/">Home</a></Nav.Item>
+    <Nav.Item><a href="/products">Products</a></Nav.Item>
+  </Nav.List>
+</Nav>
+
+<Nav aria-label="Footer navigation">
+  <Nav.List>
+    <Nav.Item><a href="/privacy">Privacy</a></Nav.Item>
+    <Nav.Item><a href="/terms">Terms</a></Nav.Item>
+  </Nav.List>
+</Nav>
+
+// Vertical sidebar navigation
+<Nav aria-label="Sidebar navigation">
+  <Nav.List isBlock>
+    <Nav.Item><a href="/dashboard">Dashboard</a></Nav.Item>
+    <Nav.Item><a href="/settings">Settings</a></Nav.Item>
+    <Nav.Item><a href="/profile">Profile</a></Nav.Item>
+  </Nav.List>
+</Nav>
+
+// Nav with logo and menu
+<Nav aria-label="Site navigation">
+  <a href="/" aria-label="Go to homepage">
+    <img src="/logo.svg" alt="Company Logo" />
+  </a>
+  <Nav.List>
+    <Nav.Item><a href="/products">Products</a></Nav.Item>
+    <Nav.Item><a href="/pricing">Pricing</a></Nav.Item>
+  </Nav.List>
+  <Nav.List aria-label="User actions">
+    <Nav.Item><a href="/login">Sign in</a></Nav.Item>
+  </Nav.List>
+</Nav>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every nav. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--nav-justify` | Alignment of nav contents (default `space-between`). |
+| `--nav-gap` | Gap between top-level nav children. |
+| `--nav-list-gap` | Gap between items in a horizontal list. |
+| `--nav-list-block-gap` | Gap between items in a vertical (`isBlock`) list. |
+| `--nav-link-color` / `--nav-link-hover-color` | Link text color and hover color. |
+| `--nav-link-current-color` / `--nav-link-current-fw` | Color and weight of the `aria-current="page"` link. |
+| `--nav-link-radius` | Corner radius on link hit areas. |
+| `--nav-link-focus-outline` | Focus ring on links. |
+
+```css
+:root {
+  --nav-link-hover-color: #6d28d9;
+  --nav-link-current-color: #6d28d9;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `<nav>` is a landmark — screen reader users can jump directly to it.
+- `aria-label` is required when multiple `<nav>` elements exist on the page (WCAG 2.4.8).
+- `aria-current="page"` on the active link announces "current page" to screen readers.
+- The `<ul>` + `<li>` structure lets screen readers announce "list of N items".
+- Links carry visible `:focus-visible` outlines meeting WCAG 2.4.7.
+
+## Related
+
+- [Component index](README.md)
+- [Link](link.md) — the anchor styling used inside `Nav.Item`
+- [List](list.md) — for inline link lists outside a nav landmark
+- Full maintainer reference: [`skills/component-nav/reference.md`](../../skills/component-nav/reference.md)

--- a/plugins/acss-kit/docs/components/popover.md
+++ b/plugins/acss-kit/docs/components/popover.md
@@ -1,0 +1,124 @@
+# Popover — Usage Guide
+
+A popover anchored to a trigger button, built on the native HTML Popover API (`popover` attribute + `popovertarget`). It supports auto mode (light dismiss on outside click or Escape) and manual mode (explicit close button), an optional positioning arrow, and controlled or uncontrolled open state — no `floating-ui` or `@radix-ui` dependency. Browser support: Chrome/Edge 125+, Safari 17.4+, Firefox 125+.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Popover` — copies `popover.tsx` + `popover.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+The trigger, popover panel, arrow, and close button are all rendered by the single `Popover` component.
+
+```tsx
+import Popover from './fpkit/popover/popover'
+import './fpkit/popover/popover.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `React.ReactNode` | — (required) | Content rendered inside the popover. |
+| `id` | `string` | generated | Unique id; required for `popovertarget` linking (auto-generated via `useId`). |
+| `trigger` | `React.ReactNode` | — | Custom trigger element; cloned with the required `popovertarget` attributes. Defaults to a `<button>`. |
+| `triggerLabel` | `string` | `'Open'` | `aria-label` and text for the default trigger button. |
+| `mode` | `'auto' \| 'manual'` | `auto` | `auto` = light dismiss; `manual` = explicit close required. |
+| `placement` | `'top' \| 'bottom' \| 'left' \| 'right'` | `bottom` | Visual placement hint relative to the trigger. |
+| `isOpen` | `boolean` | — | Controlled open state. |
+| `onToggle` | `(open: boolean) => void` | — | Toggle callback (fires on the native ToggleEvent). |
+| `showCloseButton` | `boolean` | `true` for `manual`, `false` for `auto` | Show the close button. |
+| `closeButtonLabel` | `string` | `'Close'` | `aria-label` for the close button. |
+| `showArrow` | `boolean` | `true` | Show the positioning arrow. |
+| `className` | `string` | `''` | Custom CSS class on the popover element. |
+| `styles` | `React.CSSProperties` | — | Inline CSS variables / styles. |
+
+## Examples
+
+```tsx
+// Default — auto mode (light dismiss)
+<Popover id="info" triggerLabel="More info">
+  <p>Additional context shown in a popover.</p>
+</Popover>
+
+// Manual mode — explicit close required
+<Popover
+  id="confirm"
+  mode="manual"
+  triggerLabel="Confirm"
+  closeButtonLabel="Cancel confirmation"
+>
+  <h3>Are you sure?</h3>
+  <p>This action cannot be undone.</p>
+  <button type="button" onClick={handleConfirm}>Yes, proceed</button>
+</Popover>
+
+// Custom trigger
+<Popover
+  id="user-menu"
+  trigger={<button type="button" aria-label="User menu">@alice</button>}
+  placement="bottom"
+>
+  <ul>
+    <li><a href="/profile">Profile</a></li>
+    <li><a href="/logout">Log out</a></li>
+  </ul>
+</Popover>
+
+// Controlled
+const [open, setOpen] = useState(false)
+<Popover
+  id="controlled"
+  isOpen={open}
+  onToggle={setOpen}
+  triggerLabel="Toggle externally"
+>
+  <p>State driven from parent.</p>
+</Popover>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every popover. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--popover-bg` | Panel background. |
+| `--popover-color` | Panel text color. |
+| `--popover-border` | Panel border. |
+| `--popover-radius` | Corner radius. |
+| `--popover-padding` | Content padding. |
+| `--popover-shadow` | Drop shadow. |
+| `--popover-max-width` | Maximum panel width. |
+| `--popover-arrow-size` | Size of the positioning arrow. |
+
+```css
+:root {
+  --popover-radius: 0.5rem;
+  --popover-max-width: 24rem;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- `popover="auto"` gives native light-dismiss: outside click or Escape closes it, handled by the browser with no JS listeners. Use `popover="manual"` for content (like forms) where accidental dismissal would lose input.
+- The trigger toggles via `popovertargetaction="toggle"` — Enter or Space works natively. Focus is not trapped (unlike a modal dialog) by design.
+- The default trigger has an `aria-label` (via `triggerLabel`); pass a custom `trigger` only if it has its own accessible name. The close button has an explicit `aria-label` since the `×` glyph is not a name.
+- The container gets no `role="dialog"`/`role="tooltip"` automatically — add `role="tooltip"` + `aria-describedby`, or a menu pattern, if the popover serves that role.
+- On close, focus returns to the trigger (native behavior). Popover text/background must meet 4.5:1 (WCAG 1.4.3); a border-only design must meet 3:1 (WCAG 1.4.11).
+- In browsers without Popover API support the panel renders inline as a normal `<div>` — plan for graceful degradation or feature-detect `'showPopover' in HTMLElement.prototype`.
+
+## Related
+
+- [Component index](README.md)
+- [Button](button.md) — pass a kit Button as the `trigger`
+- [Dialog](dialog.md) — for modal content that should trap focus
+- Full maintainer reference: [`skills/component-popover/reference.md`](../../skills/component-popover/reference.md)

--- a/plugins/acss-kit/docs/components/table.md
+++ b/plugins/acss-kit/docs/components/table.md
@@ -1,0 +1,137 @@
+# Table — Usage Guide
+
+A semantic HTML table wrapper with compound sub-components: `Table`, `Table.Caption`, `Table.Head`, `Table.Body`, `Table.Row`, `Table.HeaderCell`, and `Table.Cell`. It renders native `<table>`/`<caption>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>` elements and carries no opinion on sorting, filtering, or pagination — those are application concerns you layer on top.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, and creates the `ui.tsx` foundation every component imports.
+2. **Add this component:** `/kit-add Table` — copies `table.tsx` + `table.scss` into your components directory (default `src/components/fpkit/`).
+   - Or run `/kit-sync` once to install **all** components, the foundation, and a starter theme together.
+
+The generated component is self-contained — no `@fpkit/acss` install required.
+
+## Import
+
+`Table` is a compound component — the root and all six sub-parts ship in one file.
+
+```tsx
+import Table from './fpkit/table/table'
+import './fpkit/table/table.scss'
+```
+
+Adjust the path to match the `componentsDir` in your `.acss-target.json`.
+
+## Props
+
+**`Table`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `aria-label` | `string` | — | Accessible name — alternative to `<Table.Caption>`. |
+| `aria-labelledby` | `string` | — | Accessible name reference — alternative to `<Table.Caption>`. |
+| `classes` | `string` | — | CSS class(es). |
+| `styles` | `React.CSSProperties` | — | Inline styles. |
+| `children` | `React.ReactNode` | — | Caption, head, and body sub-components. |
+
+Plus any native `<table>` attribute.
+
+**`Table.HeaderCell`**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `scope` | `'col' \| 'row' \| 'colgroup' \| 'rowgroup'` | `col` | Header scope; set `row` for row headers, spans for complex tables. |
+
+Plus any native `<th>` attribute.
+
+**`Table.Caption` / `.Head` / `.Body` / `.Row` / `.Cell`** each accept the native props of their element (`<caption>`, `<thead>`, `<tbody>`, `<tr>`, `<td>` respectively).
+
+## Examples
+
+```tsx
+// Basic data table with caption
+<Table>
+  <Table.Caption>Quarterly revenue, 2024</Table.Caption>
+  <Table.Head>
+    <Table.Row>
+      <Table.HeaderCell>Quarter</Table.HeaderCell>
+      <Table.HeaderCell>Revenue</Table.HeaderCell>
+      <Table.HeaderCell>YoY change</Table.HeaderCell>
+    </Table.Row>
+  </Table.Head>
+  <Table.Body>
+    <Table.Row>
+      <Table.HeaderCell scope="row">Q1</Table.HeaderCell>
+      <Table.Cell>$1.2M</Table.Cell>
+      <Table.Cell>+5%</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <Table.HeaderCell scope="row">Q2</Table.HeaderCell>
+      <Table.Cell>$1.4M</Table.Cell>
+      <Table.Cell>+18%</Table.Cell>
+    </Table.Row>
+  </Table.Body>
+</Table>
+
+// Accessible name via aria-labelledby (when caption duplicates a nearby heading)
+<>
+  <h2 id="users-heading">Active users</h2>
+  <Table aria-labelledby="users-heading">
+    <Table.Head>
+      <Table.Row>
+        <Table.HeaderCell>Name</Table.HeaderCell>
+        <Table.HeaderCell>Email</Table.HeaderCell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>Alice</Table.Cell>
+        <Table.Cell>alice@example.com</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
+</>
+
+// Wide table, scrollable wrapper
+<div style={{ overflowX: 'auto' }}>
+  <Table>
+    {/* ...many columns... */}
+  </Table>
+</div>
+```
+
+## Theming
+
+Override these CSS custom properties in your theme to restyle every table. Each has a fallback, so overriding is optional.
+
+| Variable | Purpose |
+|----------|---------|
+| `--table-width` | Table width (default `100%`). |
+| `--table-caption-fw` | Caption font weight. |
+| `--table-th-bg` | Header-cell background. |
+| `--table-th-padding` / `--table-td-padding` | Header / body cell padding. |
+| `--table-th-border-bottom` | Header separator border. |
+| `--table-td-border-bottom` | Row separator border. |
+| `--table-row-hover-bg` | Row hover background. |
+
+```css
+:root {
+  --table-th-bg: #f0f0f5;
+  --table-row-hover-bg: #f5f3ff;
+}
+```
+
+Generate a full matching theme with `/theme-create` (see [styles.md](../styles.md)).
+
+## Accessibility
+
+- Always give a data table an accessible name — a `<Table.Caption>` first child (richest, visible to all), `aria-label`, or `aria-labelledby` pointing at a nearby heading.
+- `<Table.HeaderCell>` defaults `scope="col"`; pass `scope="row"` for row headers, and `colgroup`/`rowgroup` (or `headers="…"` on cells) for spanning headers in complex tables.
+- Keep native table semantics — don't add `role="grid"` unless building a fully interactive grid, and never `role="presentation"` for layout (use CSS Grid/Flexbox instead).
+- For wide tables on narrow viewports, prefer a horizontal-scroll wrapper (`overflow-x: auto`) over collapsing rows — scrolling preserves the row-column relationship AT users rely on.
+- Header text on `--table-th-bg`, body text, and `--table-row-hover-bg` must all keep text contrast at 4.5:1; row-separator borders used as the sole divider must meet 3:1 (WCAG 1.4.11).
+
+## Related
+
+- [Component index](README.md)
+- [List](list.md) — for non-tabular, single-dimension data
+- Full maintainer reference: [`skills/component-table/reference.md`](../../skills/component-table/reference.md)

--- a/plugins/acss-kit/docs/styles.md
+++ b/plugins/acss-kit/docs/styles.md
@@ -1,0 +1,78 @@
+# Styles — Usage Guide
+
+The theming system for fpkit/acss projects. It generates OKLCH light/dark themes as plain CSS custom properties — a fixed set of semantic **role** tokens (`--color-primary`, `--color-surface`, `--color-text`, …) that every component reads. You seed a theme from a single hex color and the palette math derives the rest, validating each theme against WCAG 2.2 AA contrast before it lands.
+
+You never author JSON. Themes are CSS files you own, edit, and commit.
+
+## Add it to your project
+
+1. **One-time setup** (run once per project): `/setup` — installs `sass`, writes `.acss-target.json`, copies the `ui.tsx` foundation, and (unless you pass `--no-theme`) seeds `src/styles/theme/light.css` + `dark.css` from a seed hex color. It also appends the `@import` lines to your CSS entry.
+2. **Generate or refine themes** with the commands below. `/theme-create` is the usual starting point if you skipped the seed step, or when you want to regenerate from a new color.
+
+Themes are committed artifacts — keep `src/styles/theme/` in version control, not `.gitignore`.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/theme-create <hex> [--mode=light\|dark\|both]` | Generate `light.css` / `dark.css` from a seed color using OKLCH palette math. |
+| `/theme-brand <name> [--from=<hex>]` | Scaffold `brand-<name>.css` with primary/accent overrides that layer over light/dark. |
+| `/theme-update <file> <--color-role=#hex> [...]` | Edit specific role values in a theme file and re-validate (reverts changes that fail AA). |
+| `/theme-extract <image\|figma-url>` | Extract brand colors from an image or Figma design, then generate theme CSS. |
+| `/theme-from-design <DESIGN.md>` | Generate a full theme — colors plus spacing/rounded/typography — from a DESIGN.md file. |
+| `/theme-from-figma <figma-url\|fileKey>` | Generate a theme from a Figma file's variables via the Figma MCP server. |
+| `/color-scale <color> [--name=<name>] [--format=css\|json\|both]` | Generate a 10-step OKLCH scale (50–900) from a hex, CSS named color, or theme role. |
+| `/design-export [--format=design-md\|dtcg\|tailwind]` | Export the project's theme back out as a DESIGN.md (or DTCG/Tailwind via the upstream CLI). |
+
+Every write-bearing command runs the WCAG contrast validator automatically before finishing.
+
+## How themes are consumed
+
+Generated theme files live under `src/styles/theme/`:
+
+- `light.css` — semantic role tokens under `:root`
+- `dark.css` — the same roles under `[data-theme="dark"]`
+- `brand-<name>.css` — optional primary/accent overrides layered on top
+
+Import them into your app's CSS entry **after** `foundation.css` so theme values win the cascade:
+
+```css
+/* src/styles/index.css */
+@import "./foundation.css";
+@import "./theme/light.css";
+@import "./theme/dark.css";
+@import "./theme/brand-forest.css"; /* optional — after light + dark */
+```
+
+Toggle dark mode by setting `data-theme="dark"` on the `<html>` element.
+
+Components never hardcode colors — they read the role tokens with a fallback, so they render correctly with or without a theme present:
+
+```scss
+.btn[data-color="primary"] {
+  background: var(--btn-primary-bg, var(--color-primary, #0066cc));
+  color: var(--btn-primary-color, var(--color-text-inverse, #fff));
+}
+```
+
+Override a role in your theme file and every component that reads it restyles at once — that CSS-custom-property layer is the whole contract between styles and components.
+
+## Theme roles
+
+A theme defines 18 `--color-*` roles (15 required + 3 optional), grouped by purpose. Below are the categories with a couple of examples each; the full list with contrast pairings is in [`role-catalogue.md`](../skills/styles/references/role-catalogue.md).
+
+| Category | Examples | Purpose |
+|----------|----------|---------|
+| Backgrounds | `--color-background`, `--color-surface`, `--color-surface-raised` | Page, cards/panels, elevated surfaces (modals, popovers). |
+| Text | `--color-text`, `--color-text-muted`, `--color-text-inverse` | Body copy, secondary text, text on a primary background. |
+| Borders | `--color-border`, `--color-border-strong` | Default and emphasized (form-focus) borders. |
+| Brand & semantic | `--color-primary`, `--color-primary-hover`, `--color-success`, `--color-warning`, `--color-danger`, `--color-info` | Brand action color and state colors. |
+| Focus | `--color-focus-ring` | Keyboard focus indicator; usually equals `--color-primary`. |
+| Optional | `--color-surface-subtle`, `--color-text-subtle`, `--color-brand-accent` | Tertiary surfaces/text and secondary brand accent. |
+
+Beyond colors, a theme can also carry **mode-independent** dimension tokens — `space-radius.css` (`--space-*`, `--radius-*`) and `typography.css` (`--font-<role>-*`) — emitted when the source (a DESIGN.md, for example) provides them.
+
+## Related
+
+- [Component index](components/README.md) — components that consume these roles.
+- Styles skill (maintainer reference): [`skills/styles/SKILL.md`](../skills/styles/SKILL.md).

--- a/plugins/acss-kit/docs/utilities.md
+++ b/plugins/acss-kit/docs/utilities.md
@@ -1,0 +1,71 @@
+# Utilities — Usage Guide
+
+Tailwind-style atomic CSS utility classes for fpkit/acss projects. A single prebuilt `utilities.css` bundle ships the full atomic suite — spacing, flexbox, grid, color, type, radius, shadow, display, position, and z-index families — plus a `token-bridge.css` alias layer that wires the utilities' color classes up to your acss-kit theme roles.
+
+No build step, no JIT purge — the bundle is complete and you drop it in.
+
+## Add it to your project
+
+Run `/utility-add` to copy the bundle into your project:
+
+```text
+/utility-add
+/utility-add --target=src/styles
+/utility-add --families=spacing,flex,color-bg
+/utility-add --no-bridge
+```
+
+It detects your utilities directory (default `src/styles/`), copies `utilities.css`, and — unless you pass `--no-bridge` — copies `token-bridge.css` too. If `acss-kit` is installed alongside, it also verifies your CSS entry imports the files it wrote.
+
+If you have already run `/setup` for components and themes, `/utility-add` reuses the same project config (`.acss-target.json`). Utilities work standalone too — without an acss-kit theme, the bridge's hex fallbacks resolve to sensible fpkit-default colors.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/utility-add [--target=<dir>] [--families=<list>] [--no-bridge]` | Copy `utilities.css` (and `token-bridge.css`) into your project. |
+| `/utility-list [family]` | Read-only catalogue printer — list families, or every class in one family. |
+| `/utility-tune <natural-language>` | Adjust the spacing baseline, breakpoints, or which families are enabled. |
+| `/utility-bridge [--theme=<file>]` | Regenerate `token-bridge.css` aliases against your active theme. |
+
+## Using the classes
+
+Import the bridge **before** the utilities so the color aliases are defined when the utility classes resolve them:
+
+```ts
+import "./styles/token-bridge.css";   // first
+import "./styles/utilities.css";       // then
+```
+
+Then compose classes directly in your markup:
+
+```tsx
+// Flex row: spaced children, centered vertically, padded
+<div className="flex items-center justify-between p-4 gap-3">…</div>
+
+// Surface card with muted border and rounded corners
+<article className="bg-surface border-border rounded-lg shadow p-6">…</article>
+
+// Primary-colored heading text
+<h2 className="text-primary font-semibold text-2xl mb-2">Plan</h2>
+```
+
+Spacing uses a `0.25rem` baseline (`.m-4` = `1rem`, `.p-8` = `2rem`) and emits CSS logical properties, so `mt`/`mb`/`ml`/`mr` follow the document's writing mode.
+
+**Responsive variants** use a plain hyphen prefix — no escaping needed. Prefixes are `sm` (30rem), `md` (48rem), `lg` (62rem), `xl` (80rem), plus `print`:
+
+```tsx
+<div className="hide sm-show">Mobile-only header</div>
+<button className="bg-primary p-4 md-p-6 lg-p-8">Padded button</button>
+```
+
+Run `/utility-list` to see the enabled families and the spacing/breakpoint scales, or `/utility-list spacing` for every class in a family. The full catalogue is in [`utility-catalogue.md`](../skills/utilities/references/utility-catalogue.md); breakpoint details are in [`breakpoints.md`](../skills/utilities/references/breakpoints.md).
+
+## The token bridge
+
+`utilities.css` references fpkit-style token names (`--color-error`, `--color-error-bg`, `--color-secondary`, `--color-primary-light`) that don't all exist in acss-kit's role catalogue. `token-bridge.css` is the alias layer that maps them onto acss-kit's roles — `--color-error` aliases to `--color-danger`, `-bg` and `-light` variants are synthesized with `color-mix(in oklch, …)`, and every alias is defined for both `:root` and `[data-theme="dark"]`. Regenerate it with `/utility-bridge` whenever your theme changes (a new `/theme-create`, a `/theme-update` edit, or a custom palette) so the utility color classes track your current colors. See [`token-bridge.md`](../skills/utilities/references/token-bridge.md) for the full mapping.
+
+## Related
+
+- [Component index](components/README.md) — components you can style alongside these utilities.
+- Utilities skill (maintainer reference): [`skills/utilities/SKILL.md`](../skills/utilities/SKILL.md).

--- a/plugins/style-agent/docs/README.md
+++ b/plugins/style-agent/docs/README.md
@@ -19,6 +19,8 @@
 | `/inline-style-to-class [name]` | Convert an inline style attribute, JSX style object, or `<style>` block into a named CSS class and append it to the project stylesheet, replacing hard-coded values with CSS variables (reuse-or-create) |
 | `/create-utilities [description]` | Generate a utility class string from a plain-language visual description |
 
+For per-command usage guides (when to use, how to run, before/after examples), see [`docs/commands/`](commands/README.md).
+
 ## Skills
 
 The plugin ships three skills. Command logic delegates to each skill file.

--- a/plugins/style-agent/docs/commands/README.md
+++ b/plugins/style-agent/docs/commands/README.md
@@ -1,0 +1,11 @@
+# style-agent commands — Usage Guides
+
+Consumer usage guides for the three CSS commands shipped by `style-agent`. Each guide covers when to reach for the command, how to run it, a copy-paste before/after example, and important behavior.
+
+| Command | What it does | Guide |
+|---|---|---|
+| `/css-to-class [name]` | Collapse a utility class list (or HTML element) into one named CSS class, resolving declarations from your project's `.css` files. | [css-to-class.md](css-to-class.md) |
+| `/inline-style-to-class [name]` | Convert an inline style attribute, JSX style object, or `<style>` block into a named class appended to your stylesheet, tokenizing values into CSS variables. | [inline-style-to-class.md](inline-style-to-class.md) |
+| `/create-utilities [description]` | Generate a utility class string from a plain-language visual description, matched to your project's framework. | [create-utilities.md](create-utilities.md) |
+
+See the [style-agent developer guide](../README.md) for plugin internals and skill layout.

--- a/plugins/style-agent/docs/commands/create-utilities.md
+++ b/plugins/style-agent/docs/commands/create-utilities.md
@@ -1,0 +1,58 @@
+# /create-utilities — Usage Guide
+
+Turn a plain-language description of visual intent into a ready-to-use utility class string. The command detects which utility library your project uses (acss-kit, Tailwind, Bootstrap, or a Tailwind-compatible fallback) and maps your description to the matching class names, then prints the class string and a one-line HTML example.
+
+## When to use it
+
+- You know what you want visually ("centered flex row, 1rem gap, primary background") but not the exact class names.
+- You want class names that match the framework already in your project, without looking them up.
+- You are scaffolding an element and want a sensible starting class list, focus styling included for interactive elements.
+- You plan to consolidate the result into a named class afterward with `/css-to-class`.
+
+## How to run it
+
+```text
+/create-utilities [description]
+```
+
+Then supply the intent as input:
+
+| Input form | Example |
+|---|---|
+| Plain description | `"a card with white background, 1rem padding, subtle shadow, and rounded corners"` |
+| Component phrase | `"primary submit button with hover state"` |
+| HTML element with intent | `<div> <!-- make this a centered hero section -->` |
+
+- If the description is too vague ("make it look nice"), the command asks a focused follow-up before generating.
+
+## Example
+
+Input:
+
+```text
+a centered flex row with 1rem gap and a primary background
+```
+
+Output — a class string plus a one-line HTML example (Tailwind / fallback vocabulary shown; `focus-visible:ring` is added automatically for interactive elements):
+
+```text
+flex items-center gap-4 bg-primary focus-visible:ring
+```
+
+```html
+<button class="flex items-center gap-4 bg-primary focus-visible:ring">Label</button>
+```
+
+## Notes
+
+- Framework detection drives the vocabulary: acss-kit (`utilities.css` with `.bg-primary`), Tailwind (`tailwind.config.*` or `@tailwind base`), Bootstrap (`bootstrap*.css` or `d-flex`/`btn`), else a Tailwind-compatible fallback. If more than one framework is detected, you are asked which to use.
+- Classes are ordered layout → spacing → color → typography → border/radius → shadow → state.
+- Focus styling for interactive elements (button/link/input): `focus-visible:ring` for Tailwind/fallback, `focus-ring` for Bootstrap. For acss-kit the bundle ships no focus utility, so the summary warns and suggests adding `:focus-visible` CSS or using an acss-kit component class.
+- Emits classes only — it does not write to your stylesheet.
+- Chains naturally into `/css-to-class [name]` to consolidate the string into a single named class.
+
+## Related
+
+- [/css-to-class](css-to-class.md) — consolidate the generated class string into one named class
+- [/inline-style-to-class](inline-style-to-class.md) — convert inline styles or a JSX style object into a named class
+- [Command index](README.md) · [Developer guide](../README.md)

--- a/plugins/style-agent/docs/commands/css-to-class.md
+++ b/plugins/style-agent/docs/commands/css-to-class.md
@@ -1,0 +1,66 @@
+# /css-to-class — Usage Guide
+
+Collapse a multi-class HTML element (or a bare class string) into a single, semantically named CSS class. Each utility token is resolved to its real property/value declarations by grepping the `.css` files already in your project, so the output works with plain CSS, compiled SCSS, Tailwind, or any utility-first setup.
+
+## When to use it
+
+- An element has grown a long "utility soup" `class="..."` list and you want one semantic selector instead.
+- You need a reusable named class (e.g. `.testimonial-grid`) that inlines the declarations those utilities produced.
+- You are consolidating the output of `/create-utilities` into a committed class.
+- You want to see which tokens are project-defined vs. undefined (unresolved tokens are flagged for manual follow-up).
+
+## How to run it
+
+```text
+/css-to-class [name]
+```
+
+Then paste one of these as input:
+
+| Input form | Example |
+|---|---|
+| HTML element | `<div class="testimonial flex-grid py-8 items-center" data-flex-grid>` |
+| Plain class list | `testimonial flex-grid py-8 items-center` |
+| Quoted string | `"flex py-4 items-center justify-between"` |
+
+- `name` is optional. Provide it to set the class name; omit it to auto-generate from the most semantic tokens.
+- Name rules: max 20 characters, kebab-case (`[a-z][a-z0-9-]*`). Non-conforming names are coerced and you are warned.
+
+## Example
+
+Input:
+
+```html
+<div class="testimonial flex-grid py-8 items-center" data-flex-grid>
+```
+
+Output — a named class with declarations resolved from your project CSS (`py-8` and `items-center` matched; `testimonial` and `flex-grid` are defined elsewhere, so they become manual placeholders), plus the refactored HTML:
+
+```css
+/* extracted: testimonial flex-grid py-8 items-center */
+.testimonial-grid {
+  /* testimonial: add declarations manually */
+  /* flex-grid: add declarations manually */
+  padding-block: 2rem;
+  align-items: center;
+}
+```
+
+```html
+<div class="testimonial-grid" data-flex-grid>
+```
+
+## Notes
+
+- Framework-agnostic — resolves tokens by grepping `.css` files in your project (`node_modules`, `.git`, `dist`, `build` excluded); SCSS is supported via its compiled output.
+- Read-only lookup: it does not write to your stylesheet. Copy the emitted class block into your CSS yourself.
+- Declarations found inside an at-rule (`@media`, `@supports`, `@layer`) keep their wrapper as a nested block so they still apply at the intended breakpoint or query.
+- Unresolved tokens (custom/semantic classes not in any `.css` file) are preserved in place as `/* <token>: add declarations manually */` comments.
+- Other attributes on the element (`data-*`, `id`, `aria-*`) are preserved untouched; only the `class` value is rewritten.
+- The inverse operation is `/inline-style-to-class`.
+
+## Related
+
+- [/inline-style-to-class](inline-style-to-class.md) — convert inline styles or a JSX style object into a named class
+- [/create-utilities](create-utilities.md) — generate a utility class string from a plain-language description
+- [Command index](README.md) · [Developer guide](../README.md)

--- a/plugins/style-agent/docs/commands/css-to-class.md
+++ b/plugins/style-agent/docs/commands/css-to-class.md
@@ -34,7 +34,7 @@ Input:
 <div class="testimonial flex-grid py-8 items-center" data-flex-grid>
 ```
 
-Output — a named class with declarations resolved from your project CSS (`py-8` and `items-center` matched; `testimonial` and `flex-grid` are defined elsewhere, so they become manual placeholders), plus the refactored HTML:
+Output — a named class with declarations resolved from your project CSS (`py-8` and `items-center` matched; `testimonial` and `flex-grid` were not found in any project CSS file, so they remain manual placeholders), plus the refactored HTML:
 
 ```css
 /* extracted: testimonial flex-grid py-8 items-center */

--- a/plugins/style-agent/docs/commands/inline-style-to-class.md
+++ b/plugins/style-agent/docs/commands/inline-style-to-class.md
@@ -1,0 +1,65 @@
+# /inline-style-to-class — Usage Guide
+
+Convert an inline `style` attribute, a JSX `style={{ ... }}` object, or a `<style>` block into a single, semantically named CSS class and append it to your project stylesheet. Hard-coded colors, units, and values are replaced with CSS variables — reusing an existing variable when one already holds that value, and creating a new one when none does. The inverse of `/css-to-class`.
+
+## When to use it
+
+- You have inline styles or a JSX style object and want a reusable, tokenized CSS class instead.
+- You want hard-coded literals (`#2563eb`, `1rem`) swapped for `var(...)` references that reuse your existing design tokens.
+- You are migrating a `<style>` block's rule into your main stylesheet.
+- You selected an element in your IDE and want the style lifted out and the class wired in-place.
+
+## How to run it
+
+```text
+/inline-style-to-class [name]
+```
+
+Then provide one of these as input:
+
+| Input form | Example |
+|---|---|
+| IDE selection | Select an element/style block in your editor, then run the command |
+| HTML inline attribute | `<div style="background: #2563eb; padding: 1rem">` |
+| JSX style object | `<Button style={{ backgroundColor: theme.primary, padding: 8 }}>` |
+| `<style>` block | `<style>.hero { color: red; padding: 2rem; }</style>` |
+
+- `name` is optional. Provide it to set the class name; omit it to auto-generate from the element tag and first declared property (e.g. `div-bg`, `btn-pad`).
+- Name rules: max 20 characters, kebab-case (`[a-z][a-z0-9-]*`). Non-conforming names are coerced and you are warned.
+
+## Example
+
+Input:
+
+```html
+<div style="background: #2563eb; padding: 1rem">
+```
+
+Output — a tokenized class appended to your stylesheet (here `#2563eb` matched an existing `--color-primary`; `1rem` had no match, so `--space-1rem` was created), plus the refactored HTML:
+
+```css
+/* from: style attr on <div> */
+.div-bg {
+  background: var(--color-primary, #2563eb);
+  padding: var(--space-1rem, 1rem);
+}
+```
+
+```html
+<div class="div-bg">
+```
+
+## Notes
+
+- Appends the class to a stylesheet detected from your project's own conventions — plain CSS, SCSS, or Sass-indented syntax. If no stylesheet is found, the class is emitted to chat only.
+- Reuse-or-create tokens: an existing custom property is referenced when its value matches; otherwise a new variable is declared in your tokens/variables file, an existing `:root` block, or a new `:root` block. Matching is exact on the normalised value — no color-format or unit conversion (`16px` never matches `1rem`).
+- The original literal is always kept as the `var()` fallback, so the class still renders if the variable is absent.
+- Values already written as `var(...)` pass through untouched; unresolved JSX expressions become `/* unresolved */` placeholders.
+- IDE selection enables in-place editing — the `style` attribute is removed and the `class` added directly in your source file (falls back to emitting refactored source in chat when the edit would be ambiguous).
+- Other attributes (`data-*`, `id`, `aria-*`) are preserved; the new class is appended to any existing `class`/`className`.
+
+## Related
+
+- [/css-to-class](css-to-class.md) — collapse a utility class list into one named class (the inverse)
+- [/create-utilities](create-utilities.md) — generate a utility class string from a plain-language description
+- [Command index](README.md) · [Developer guide](../README.md)

--- a/plugins/style-agent/docs/commands/inline-style-to-class.md
+++ b/plugins/style-agent/docs/commands/inline-style-to-class.md
@@ -54,7 +54,7 @@ Output — a tokenized class appended to your stylesheet (here `#2563eb` matched
 - Appends the class to a stylesheet detected from your project's own conventions — plain CSS, SCSS, or Sass-indented syntax. If no stylesheet is found, the class is emitted to chat only.
 - Reuse-or-create tokens: an existing custom property is referenced when its value matches; otherwise a new variable is declared in your tokens/variables file, an existing `:root` block, or a new `:root` block. Matching is exact on the normalised value — no color-format or unit conversion (`16px` never matches `1rem`).
 - The original literal is always kept as the `var()` fallback, so the class still renders if the variable is absent.
-- Values already written as `var(...)` pass through untouched; unresolved JSX expressions become `/* unresolved */` placeholders.
+- Values already written as `var(...)` pass through untouched; unresolved JSX expressions become `/* <property>: unresolved — was JS expression */` placeholders.
 - IDE selection enables in-place editing — the `style` attribute is removed and the `class` added directly in your source file (falls back to emitting refactored source in chat when the edit would be ambiguous).
 - Other attributes (`data-*`, `id`, `aria-*`) are preserved; the new class is appended to any existing `class`/`className`.
 


### PR DESCRIPTION
## What

Adds **consumer-facing usage guides** for both plugins — documentation aimed at developers who want to consume the plugins in their own projects (distinct from the maintainer-facing `reference.md` files).

**acss-kit** (`plugins/acss-kit/docs/`)
- `components/` — 15 per-component usage guides + an index. Each guide covers: add-command flow (`/setup` → `/kit-add` / `/kit-sync`), import, props table, copy-paste examples, theming variables, and accessibility notes. Compound components (Card, Dialog, Nav, Table, List) document their sub-parts.
- `styles.md` — theming commands, how generated `light.css`/`dark.css` are imported and consumed, and theme roles.
- `utilities.md` — `/utility-add`, class usage, breakpoints, and the token bridge.

**style-agent** (`plugins/style-agent/docs/commands/`)
- Usage guides for `/css-to-class`, `/inline-style-to-class`, `/create-utilities` + an index (when-to-use, how-to-run, before/after examples).

Both existing docs READMEs now link to the new guides.

## Why

The per-component `reference.md` files are maintainer-oriented (generation contracts, fpkit verification, TSX templates). Consumers needed a thinner, task-focused artifact answering "how do I get this into my project and use it." These guides distill that from the existing references.

## Reviewer notes

- Pure documentation change — no SKILL.md, `plugin.json`, command, or script was touched, so `tests/run.sh` validates nothing that changed and was not run.
- All props, examples, and CSS variables were extracted from the canonical `reference.md` / `SKILL.md` sources — nothing invented.
- All internal cross-links were verified to resolve; no emojis (per repo docs convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded ACSS Kit consumer guides with new entries for per-component usage, theming/styles consumption, and atomic utilities consumption.
  * Added a consumer-facing components index plus comprehensive usage guides for components including Alert, Button, Card, Checkbox, Dialog, Field, Icon, IconButton, Img, Input, Link, List, Nav, Popover, and Table.
  * Enhanced style-agent documentation with a commands overview and new usage guides for converting CSS and inline styles into reusable class names, including `/create-utilities`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->